### PR TITLE
tests: address pixel tests flakiness with unloaded logo image

### DIFF
--- a/test/helpers/installer.py
+++ b/test/helpers/installer.py
@@ -132,7 +132,7 @@ class Installer():
         self.browser.open(f"/cockpit/@localhost/anaconda-webui/index.html#/{step}")
         self.wait_current_page(step)
         # Ensure that the logo is visible before proceeding as pixel tests get racy otherwise
-        self.browser.wait_js_cond("document.querySelector('.logo').complete")
+        self.browser.wait_js_cond("document.querySelector('.logo').complete && document.querySelector('.logo').naturalHeight !== 0")
 
     def click_step_on_sidebar(self, step=None):
         step = step or self.get_current_page()


### PR DESCRIPTION
Resolves: INSTALLER-3792

In my local tests the flakes disappeared, but some tests timeouted on the condition.