### PR TITLE
tests: allow adding extra local RPMs to the updates.img

### DIFF
--- a/test/README.rst
+++ b/test/README.rst
@@ -21,9 +21,14 @@ Then download test dependencies::
     cd ui/webui
     make prepare-test-deps
 
-Prepare an updates.img containing the anaconda RPMs and the cockpit dependencies::
+Prepare an updates.img containing the anaconda-webui RPM and its dependencies::
 
     make create-updates.img
+
+You can optionally add extra RPMs to the updates.img by setting the ``TEST_RPMS`` variable,
+with a comma-seperated list of RPMs to add. For example::
+
+    make TEST_RPMS="/tmp/anaconda-core-123.rpm, /tmp/anaconda-core-debuginfo-123.rpm" create-updates.img
 
 Then download the ISO file that the test VMs will use::
 

--- a/test/prepare-updates-img
+++ b/test/prepare-updates-img
@@ -2,9 +2,17 @@
 
 set -eu
 
+TEST_RPMS="${TEST_RPMS:-""}"
+
 # build the anaconda-webui rpm && download anaconda-webui missing dependencies
 make srpm
 test/build-rpms -v anaconda-webui*.src.rpm
+
+# Copy the extra RPMs to the /tmp/rpms directory
+for i in ${TEST_RPMS//,/ }; do
+    echo "Copying $i to tmp/rpms"
+    cp $i tmp/rpms
+done
 
 # makeupdates must be run from the top level of the anaconda source tree
 # shellcheck disable=SC2086,SC2046


### PR DESCRIPTION
This enables us to test against locally built anaconda-core RPM to validate features that touch front end and backend.

Resolves: INSTALLER-3794