### PR TITLE
storage: show toast notification when disks selection changed

### DIFF
--- a/test/check-storage
+++ b/test/check-storage
@@ -61,6 +61,9 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         dev = dev.split("/")[-1]
         s.rescan_disks()
 
+        # Check the newly added disk generated a notification
+        s.wait_disk_added(dev)
+
         # Check that the disk selection persists when moving next and back
         s.check_disk_selected("vda", True)
         i.next()

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -94,6 +94,9 @@ class StorageDestination():
     def wait_no_disks_detected_not_present(self):
         self.browser.wait_not_present("#no-disks-detected-alert")
 
+    def wait_disk_added(self, disk):
+        self.browser.wait_in_text("#disks-changed-alert", f"The following disk was detected: {disk}")
+
     @log_step(snapshots=True)
     def rescan_disks(self):
         self.browser.click(f"#{self._step}-rescan-disks")


### PR DESCRIPTION
* [x] Add tests

Also change the notification type to toast for the 'no changes detected', in order to avoid moving UI elements when the notification appears.

This also fixes a bug, where the 'not additional disks detected' notification appears while re-scan is in progress.

Resolves: INSTALLER-3727
Resolves: INSTALLER-3742

![Screen Shot 2023-11-17 at 16 10 55](https://github.com/rhinstaller/anaconda-webui/assets/14921356/9e221f08-11dd-4965-9b3d-07bca346354a)
![Screen Shot 2023-11-17 at 16 10 35](https://github.com/rhinstaller/anaconda-webui/assets/14921356/0c7195ec-c970-491e-925c-b1b2e8851ed4)