### PR TITLE
tests: temporarily ignore in pixel tests the logo

### DIFF
--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -29,6 +29,8 @@ from testlib import MachineCase  # pylint: disable=import-error
 
 from storage import Storage
 
+pixel_tests_ignore = [".logo", "#betanag-icon"]
+
 
 class VirtInstallMachineCase(MachineCase):
     efi = False

--- a/test/check-language
+++ b/test/check-language
@@ -95,7 +95,7 @@ class TestLanguage(anacondalib.VirtInstallMachineCase):
             "language-step-basic",
             # HACK pf-v5-c-menu__item-text is ignored because some of our CI infrastructure is
             # missing CJK and Cyrillic fonts..
-            ignore=["#betanag-icon", ".pf-v5-c-menu__item-text"],
+            ignore=anacondalib.pixel_tests_ignore + [".pf-v5-c-menu__item-text"],
         )
 
         b.wait_in_text("h2 + h3", "Wählen Sie eine Sprache aus")

--- a/test/check-review
+++ b/test/check-review
@@ -64,7 +64,7 @@ class TestReview(anacondalib.VirtInstallMachineCase):
         b.assert_pixels(
             "#app",
             "review-step-basic",
-            ignore=["#betanag-icon"],
+            ignore=anacondalib.pixel_tests_ignore,
         )
 
     def testNoConfirmation(self):

--- a/test/check-storage
+++ b/test/check-storage
@@ -50,7 +50,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         b.assert_pixels(
             "#app",
             "storage-step-basic",
-            ignore=["#betanag-icon"],
+            ignore=anacondalib.pixel_tests_ignore,
         )
 
         # This attaches a disk to the running VM
@@ -100,7 +100,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         b.assert_pixels(
             "#app",
             "storage-step-basic-live",
-            ignore=["#betanag-icon"],
+            ignore=anacondalib.pixel_tests_ignore,
         )
 
         s.modify_storage()
@@ -151,7 +151,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         b.assert_pixels(
             "#app",
             "storage-step-encrypt",
-            ignore=["#betanag-icon"],
+            ignore=anacondalib.pixel_tests_ignore,
         )
 
         s.check_encryption_selected(False)
@@ -162,7 +162,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         b.assert_pixels(
             "#app",
             "storage-step-password",
-            ignore=["#betanag-icon"],
+            ignore=anacondalib.pixel_tests_ignore,
         )
 
         # No password set
@@ -411,6 +411,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         b.assert_pixels(
             "#app",
             "mount-point-mapping-table",
+            ignore=anacondalib.pixel_tests_ignore,
         )
 
         self.addCleanup(lambda: dbus_reset_users(self.machine))
@@ -554,6 +555,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         b.assert_pixels(
             "#app",
             "review-multiple-disks",
+            ignore=anacondalib.pixel_tests_ignore,
         )
 
     @nondestructive

--- a/test/check-users
+++ b/test/check-users
@@ -38,7 +38,7 @@ class TestUsers(anacondalib.VirtInstallMachineCase):
         b.assert_pixels(
             "#app",
             "users-step-basic",
-            ignore=["#betanag-icon"],
+            ignore=anacondalib.pixel_tests_ignore,
         )
         i.reach(i.steps.REVIEW)
 

--- a/test/helpers/installer.py
+++ b/test/helpers/installer.py
@@ -142,8 +142,6 @@ class Installer():
             step = self.steps._steps_jump[step][0]
         self.browser.open(f"/cockpit/@localhost/anaconda-webui/index.html#/{step}")
         self.wait_current_page(step)
-        # Ensure that the logo is visible before proceeding as pixel tests get racy otherwise
-        self.browser.wait_js_cond("document.querySelector('.logo').complete && document.querySelector('.logo').naturalHeight !== 0")
 
     def click_step_on_sidebar(self, step=None):
         step = step or self.get_current_page()


### PR DESCRIPTION
This is not being always loaded.
https://issues.redhat.com/browse/INSTALLER-3792

Leave a single test in test/check-progress to check that icon till we figure out the issue.