### PR TITLE
packit: Build COPR for main commits

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -21,18 +21,12 @@ jobs:
     targets:
     - fedora-development
 
+  # for cross-project testing
   - job: copr_build
-    trigger: release
+    trigger: commit
     owner: "@rhinstaller"
     project: "Anaconda-webui"
     preserve_project: True
-    actions:
-      post-upstream-clone: make anaconda-webui.spec
-      # HACK: tarball for releases (copr_build, koji, etc.), copying spec's Source0; this
-      # really should be the default, see https://github.com/packit/packit-service/issues/1505
-      create-archive:
-        - sh -exc "curl -L -O https://github.com/rhinstaller/anaconda-webui/releases/download/${PACKIT_PROJECT_VERSION}/${PACKIT_PROJECT_NAME_VERSION}.tar.xz"
-        - sh -exc "ls ${PACKIT_PROJECT_NAME_VERSION}.tar.xz"
 
   - job: propose_downstream
     trigger: release


### PR DESCRIPTION
Build every commit into main into
https://copr.fedorainfracloud.org/coprs/g/rhinstaller/Anaconda-webui/

We will use that for cross-project testing (e.g. building ISOs from the main anaconda repo containing the anaconda-webui RPM with latest merged commit)

This now reuses the COPR project with the build after releases, but the latter are not used anywhere to this point, so no need for a new project.