### PR TITLE
packit: add koji_build and bodhi_update targets

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -38,3 +38,13 @@ jobs:
     trigger: release
     dist_git_branches:
       - fedora-development
+
+  - job: koji_build
+    trigger: commit
+    dist_git_branches:
+      - fedora-development
+
+#  - job: bodhi_update
+#    trigger: commit
+#    dist_git_branches:
+#      # rawhide updates are created automatically


### PR DESCRIPTION
Trigger the build in Fedora Koji build system as a reaction to a new dist-git commit.
Create a new update in Fedora Bodhi for successful Koji build.