### PR TITLE
storage: Add new integration layer between anaconda and cockpit storage

### DIFF
--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -13,7 +13,7 @@ BuildRequires:  gettext
 
 %global anacondacorever 40.20
 %global cockpitver 275
-%global cockpitstorver 310
+%global cockpitstorver 311
 
 Requires: cockpit-storaged >= %{cockpitstorver}
 Requires: cockpit-bridge >= %{cockpitver}

--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -65,6 +65,13 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtim
     const osRelease = useContext(OsReleaseContext);
     const isBootIso = useContext(SystemTypeContext) === "BOOT_ISO";
     const selectedDisks = storageData.diskSelection.selectedDisks;
+    const [scenarioPartitioningMapping, setScenarioPartitioningMapping] = useState({});
+
+    useEffect(() => {
+        if (storageScenarioId && storageData.partitioning.path) {
+            setScenarioPartitioningMapping({ [storageScenarioId]: storageData.partitioning.path });
+        }
+    }, [storageData.partitioning.path, storageScenarioId]);
 
     const availableDevices = useMemo(() => {
         return Object.keys(storageData.devices);
@@ -108,6 +115,8 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtim
                 deviceNames: storageData.deviceNames,
                 diskSelection: storageData.diskSelection,
                 dispatch,
+                partitioning: storageData.partitioning.path,
+                scenarioPartitioningMapping,
                 storageScenarioId,
                 setStorageScenarioId: (scenarioId) => {
                     window.sessionStorage.setItem("storage-scenario-id", scenarioId);
@@ -275,6 +284,7 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtim
               deviceData={storageData.devices}
               dispatch={dispatch}
               onCritFail={onCritFail}
+              scenarioPartitioningMapping={scenarioPartitioningMapping}
               selectedDisks={selectedDisks}
               setShowStorage={setShowStorage}
               setStorageScenarioId={setStorageScenarioId}

--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -177,7 +177,14 @@ export const ReviewConfiguration = ({ deviceData, diskSelection, language, local
                     <DescriptionListDescription id={idPrefix + "-target-storage"}>
                         <Stack hasGutter>
                             {diskSelection.selectedDisks.map(disk => {
-                                return <DeviceRow key={disk} deviceData={deviceData} disk={disk} requests={storageScenarioId === "mount-point-mapping" ? requests : null} />;
+                                return (
+                                    <DeviceRow
+                                      key={disk}
+                                      deviceData={deviceData}
+                                      disk={disk}
+                                      requests={["mount-point-mapping", "use-configured-storage"].includes(storageScenarioId) ? requests : null}
+                                    />
+                                );
                             })}
                         </Stack>
                     </DescriptionListDescription>

--- a/src/components/storage/CockpitStorageIntegration.jsx
+++ b/src/components/storage/CockpitStorageIntegration.jsx
@@ -257,27 +257,18 @@ const CheckStorageDialog = ({
             return;
         }
 
-        const cockpitDevices = (
-            Object.keys(newMountPoints)
-                    .map(devicePath => ({
-                        devicePath,
-                        deviceName: getDeviceNameByPath(deviceData, devicePath),
-                    }))
-        );
-
         const devicesToUnlock = (
-            cockpitDevices
-                    .filter(({ devicePath, deviceName }) => {
-                        return (
-                            newMountPoints[devicePath].type === "crypto" &&
+            Object.keys(cockpitPassphrases)
+                    .map(dev => ({
+                        deviceName: deviceData[dev] ? dev : getDeviceNameByPath(deviceData, dev),
+                        passphrase: cockpitPassphrases[dev]
+                    })))
+                .filter(({ devicePath, deviceName }) => {
+                    return (
+                        deviceData[deviceName].formatData.type.v === "luks" &&
                             deviceData[deviceName].formatData.attrs.v.has_key !== "True"
-                        );
-                    })
-                    .map(({ devicePath, deviceName }) => ({
-                        deviceName,
-                        passphrase: cockpitPassphrases[devicePath],
-                    }))
-        );
+                    );
+                });
 
         if (devicesToUnlock.some(dev => !dev.passphrase)) {
             onCritFail()({ message: _("Cockpit storage did not provide the passphrase to unlock encrypted device.") });
@@ -341,11 +332,7 @@ const CheckStorageDialog = ({
                         task,
                         onSuccess: () => dispatch(getDevicesAction())
                                 .then(() => {
-                                    if (useConfiguredStorage) {
-                                        setCheckStep("luks");
-                                    } else {
-                                        setCheckStep();
-                                    }
+                                    setCheckStep("luks");
                                 })
                                 .catch(exc => {
                                     setCheckStep();

--- a/src/components/storage/CockpitStorageIntegration.jsx
+++ b/src/components/storage/CockpitStorageIntegration.jsx
@@ -228,13 +228,14 @@ const CheckStorageDialog = ({
 
     const useConfiguredStorage = useMemo(() => {
         const availability = checkConfiguredStorage({
+            deviceData,
             mountPointConstraints,
             scenarioPartitioningMapping,
             newMountPoints,
         });
 
         return availability.available;
-    }, [mountPointConstraints, newMountPoints, scenarioPartitioningMapping]);
+    }, [deviceData, mountPointConstraints, newMountPoints, scenarioPartitioningMapping]);
 
     const useFreeSpace = useMemo(() => {
         const availability = checkUseFreeSpace({ diskFreeSpace, diskTotalSpace, requiredSize });

--- a/src/components/storage/CockpitStorageIntegration.jsx
+++ b/src/components/storage/CockpitStorageIntegration.jsx
@@ -220,7 +220,7 @@ const CheckStorageDialog = ({
     const mountPointConstraints = useMountPointConstraints();
     const requiredSize = useRequiredSize();
 
-    const newMountPoints = useMemo(() => JSON.parse(window.localStorage.getItem("cockpit_mount_points") || "{}"), []);
+    const newMountPoints = useMemo(() => JSON.parse(window.sessionStorage.getItem("cockpit_mount_points") || "{}"), []);
 
     const useConfiguredStorage = useMemo(() => {
         const availability = checkConfiguredStorage({

--- a/src/components/storage/CockpitStorageIntegration.scss
+++ b/src/components/storage/CockpitStorageIntegration.scss
@@ -3,6 +3,10 @@
     width: 100%;
 }
 
+.cockpit-storage-integration-page-section-storage-alert {
+    padding-bottom: 0;
+}
+
 .cockpit-storage-integration-iframe-cockpit-storage {
     height: 100%;
 }
@@ -31,4 +35,14 @@ ul.cockpit-storage-integration-requirements-hint-list {
 
 .cockpit-storage-integration-requirements-hint-detail {
     font-size: small;
+}
+
+// Hide the [x] button in the loading mode
+.cockpit-storage-integration-check-storage-dialog--loading .pf-v5-c-modal-box__close {
+    display: none;
+}
+
+// Make Spinner smaller - default EmptyStatePanel svg size is too big
+.cockpit-storage-integration-check-storage-dialog--loading svg.pf-v5-c-spinner {
+    --pf-v5-c-spinner--diameter: var(--pf-v5-c-spinner--m-lg--diameter);
 }

--- a/src/components/storage/InstallationMethod.jsx
+++ b/src/components/storage/InstallationMethod.jsx
@@ -37,6 +37,8 @@ export const InstallationMethod = ({
     isEfi,
     isFormDisabled,
     onCritFail,
+    partitioning,
+    scenarioPartitioningMapping,
     setIsFormDisabled,
     setIsFormValid,
     setShowStorage,
@@ -64,11 +66,13 @@ export const InstallationMethod = ({
             <InstallationScenario
               deviceData={deviceData}
               deviceNames={deviceNames}
-              diskSelection={diskSelection}
+              selectedDisks={diskSelection.selectedDisks}
               dispatch={dispatch}
               idPrefix={idPrefix}
-              onCritFail={onCritFail}
               isFormDisabled={isFormDisabled}
+              onCritFail={onCritFail}
+              scenarioPartitioningMapping={scenarioPartitioningMapping}
+              partitioning={partitioning}
               setIsFormValid={setIsFormValid}
               setStorageScenarioId={setStorageScenarioId}
               storageScenarioId={storageScenarioId}

--- a/src/components/storage/InstallationScenario.jsx
+++ b/src/components/storage/InstallationScenario.jsx
@@ -199,7 +199,7 @@ export const scenarios = [{
     check: checkConfiguredStorage,
     // CLEAR_PARTITIONS_NONE = 0
     initializationMode: 0,
-    buttonLabel: _("Apply storage configuration and install"),
+    buttonLabel: _("Install"),
     buttonVariant: "danger",
     screenWarning: _("To prevent loss, make sure to backup your data."),
     dialogTitleIconVariant: "",

--- a/src/components/storage/InstallationScenario.jsx
+++ b/src/components/storage/InstallationScenario.jsx
@@ -99,7 +99,7 @@ const checkMountPointMapping = ({ hasFilesystems, duplicateDeviceNames }) => {
     return availability;
 };
 
-export const checkConfiguredStorage = ({ mountPointConstraints, partitioning, newMountPoints, scenarioPartitioningMapping }) => {
+export const checkConfiguredStorage = ({ deviceData, mountPointConstraints, partitioning, newMountPoints, scenarioPartitioningMapping }) => {
     const availability = new AvailabilityState();
 
     const currentPartitioningMatches = partitioning !== undefined && scenarioPartitioningMapping["use-configured-storage"] === partitioning;
@@ -135,9 +135,10 @@ export const checkConfiguredStorage = ({ mountPointConstraints, partitioning, ne
                             return allDirs.includes(m["mount-point"].v);
                         }
 
-                        // FIXME: cockpit does not return the biosboot partitions in the cockpit_mount_points
                         if (m["required-filesystem-type"].v === "biosboot") {
-                            return true;
+                            const biosboot = Object.keys(deviceData).find(d => deviceData[d].formatData.type.v === "biosboot");
+
+                            return biosboot !== undefined;
                         }
 
                         return false;

--- a/src/components/storage/ModifyStorage.jsx
+++ b/src/components/storage/ModifyStorage.jsx
@@ -47,8 +47,6 @@ export const ModifyStorage = ({ idPrefix, onCritFail, onRescan, setShowStorage, 
               icon={<WrenchIcon />}
               onClick={() => {
                   window.sessionStorage.setItem("cockpit_anaconda", cockpitAnaconda);
-                  // FIXME: Remove when cockpit-storaged 311 is available in Rawhide
-                  window.localStorage.setItem("cockpit_anaconda", cockpitAnaconda);
                   setShowStorage(true);
               }}
             >

--- a/test/check-storage
+++ b/test/check-storage
@@ -1201,7 +1201,6 @@ class TestStorageCockpitIntegration(anacondalib.VirtInstallMachineCase, StorageC
         r = Review(b)
 
         tmp_mount = "/btrfs-mount-test"
-        tmp_name = "btrfs-mount-test"
 
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
@@ -1225,10 +1224,9 @@ class TestStorageCockpitIntegration(anacondalib.VirtInstallMachineCase, StorageC
         self.dialog({"size": 1070, "type": "ext4", "mount_point": "/boot"})
 
         self.click_dropdown(self.card_row("Storage", 4), "Create partition")
-        self.dialog({"type": "btrfs", "name": tmp_name})
+        self.dialog({"type": "btrfs"})
 
-        self.click_card_row("Storage", name=tmp_name)
-        self.click_card_row("btrfs subvolumes", 1)
+        self.click_card_row("Storage", name="/")
 
         b.click(self.card_button("btrfs subvolume", "Mount"))
         self.dialog({"mount_point": tmp_mount})

--- a/test/check-storage
+++ b/test/check-storage
@@ -539,6 +539,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         s = Storage(b, m)
 
         disk1 = "/dev/vda"
+        dev1 = "vda"
         s.partition_disk(
             disk1,
             [("1MiB", "biosboot"), ("1GB", "xfs"), ("1GB", "xfs"), ("1GB", "xfs"), ("", "xfs")]
@@ -563,15 +564,6 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         i.reach(i.steps.INSTALLATION_METHOD)
         s.rescan_disks()
 
-        self._testEncryptedUnlock(b, m)
-
-    def _testEncryptedUnlock(self, b, m):
-        dev1 = "vda"
-
-        i = Installer(b, m)
-        s = Storage(b, m)
-        r = Review(b)
-
         s.select_mountpoint([(dev1, True)], encrypted=True)
 
         s.unlock_all_encrypted()
@@ -594,6 +586,15 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         # The 'Unlock' dialog closes when all LUKS devices are unlocked
         s.unlock_device("einszweidreivier", ["vda4"], ["vda4"])
         b.wait_not_present("#mount-point-mapping-table tbody tr:nth-child(4) td[data-label='Format type'] #unlock-luks-btn")
+
+        self._testEncryptedUnlock(b, m)
+
+    def _testEncryptedUnlock(self, b, m):
+        dev1 = "vda"
+
+        i = Installer(b, m)
+        s = Storage(b, m)
+        r = Review(b)
 
         s.check_mountpoint_row_mountpoint(2, "/boot")
         s.select_mountpoint_row_device(2, "vda5")
@@ -674,6 +675,8 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         s.return_to_installation()
         s.return_to_installation_confirm()
         i.wait_current_page(i.steps.INSTALLATION_METHOD)
+
+        s.select_mountpoint([("vda", True)])
 
         self._testEncryptedUnlock(b, m)
 

--- a/test/check-storage
+++ b/test/check-storage
@@ -620,7 +620,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
 
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
-        s.check_single_disk_destination("vda", "16.1 GB")
+        s.check_single_disk_destination("vda")
 
         s.modify_storage()
         b.wait_visible(".cockpit-storage-integration-sidebar")
@@ -672,6 +672,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         # Exit the cockpit-storage iframe
         b.switch_to_top()
         s.return_to_installation()
+        s.return_to_installation_confirm()
         i.wait_current_page(i.steps.INSTALLATION_METHOD)
 
         self._testEncryptedUnlock(b, m)
@@ -1045,6 +1046,217 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         # unformatted and unmountable devices should not be available
         s.check_mountpoint_row_device_available(1, f"{dev}2", False)
         s.check_mountpoint_row_device_available(1, f"{dev}3", False)
+
+
+class TestStorageCockpitIntegration(anacondalib.VirtInstallMachineCase, StorageCase):
+    @nondestructive
+    def testEncryptedUnlock(self):
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m, scenario="use-configured-storage")
+        s = Storage(b, m)
+        r = Review(b)
+
+        dev = "vda"
+
+        i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+        s.wait_scenario_visible("use-configured-storage", False)
+        s.check_single_disk_destination("vda")
+        s.modify_storage()
+        b.wait_visible(".cockpit-storage-integration-sidebar")
+
+        frame = "iframe[name='cockpit-storage']"
+        b._wait_present(frame)
+        b.switch_to_frame("cockpit-storage")
+        b._wait_present("#storage.ct-page-fill")
+
+        self.click_dropdown(self.card_row("Storage", 1), "Create partition table")
+        self.confirm()
+
+        self.click_dropdown(self.card_row("Storage", 2), "Create partition")
+        self.dialog({"size": 1, "type": "biosboot"})
+
+        self.click_dropdown(self.card_row("Storage", 3), "Create partition")
+        self.dialog({"size": 1070, "type": "ext4", "mount_point": "/boot"})
+
+        self.click_dropdown(self.card_row("Storage", 4), "Create partition")
+        self.dialog({
+            "type": "ext4", "mount_point": "/",
+            "crypto": self.default_crypto_type,
+            "passphrase": "redhat",
+            "passphrase2": "redhat",
+        })
+        # FIXME: Cockpit should leave open LUKS devices afetr creation
+        self.click_card_row("Storage", name=(dev + "3"))
+        b.click(self.card_button("Filesystem", "Mount"))
+        self.dialog({"passphrase": "redhat"})
+        self.wait_mounted("ext4 filesystem")
+
+        # Exit the cockpit-storage iframe
+        b.switch_to_top()
+
+        s.return_to_installation()
+        s.return_to_installation_confirm()
+
+        s.set_partitioning("use-configured-storage")
+
+        self.addCleanup(lambda: dbus_reset_users(m))
+        i.reach(i.steps.REVIEW)
+
+        r.check_in_disk_row(dev, 2, "luks-")
+
+    @nondestructive
+    def testLVM(self):
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m, scenario="use-configured-storage")
+        s = Storage(b, m)
+        r = Review(b)
+
+        vgname = "fedoravg"
+
+        self.addCleanup(m.execute, f"vgremove -y -ff {vgname}")
+
+        disk = "/dev/vda"
+        dev = "vda"
+
+        i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+        s.wait_scenario_visible("use-configured-storage", False)
+        s.check_single_disk_destination("vda")
+        s.modify_storage()
+        b.wait_visible(".cockpit-storage-integration-sidebar")
+
+        frame = "iframe[name='cockpit-storage']"
+        b._wait_present(frame)
+        b.switch_to_frame("cockpit-storage")
+        b._wait_present("#storage.ct-page-fill")
+
+        self.click_dropdown(self.card_row("Storage", 1), "Create partition table")
+        self.confirm()
+
+        self.click_dropdown(self.card_row("Storage", 2), "Create partition")
+        self.dialog({"size": 1, "type": "biosboot"})
+
+        self.click_dropdown(self.card_row("Storage", 3), "Create partition")
+        self.dialog({"size": 1070, "type": "ext4", "mount_point": "/boot"})
+
+        self.click_devices_dropdown("Create LVM2 volume group")
+        self.dialog({"name": vgname, "disks": {dev: True}})
+
+        self.click_card_row("Storage", name=vgname)
+
+        b.click(self.card_button("LVM2 logical volumes", "Create new logical volume"))
+        self.dialog({"name": "root", "size": 6010})
+        self.click_card_row("LVM2 logical volumes", 1)
+        self.click_card_dropdown("Unformatted data", "Format")
+        self.dialog({"type": "ext4", "mount_point": "/"})
+
+        b.click(self.card_parent_link())
+
+        b.click(self.card_button("LVM2 logical volumes", "Create new logical volume"))
+        self.dialog({"name": "home", "size": 8120})
+        self.click_card_row("LVM2 logical volumes", 1)
+        self.click_card_dropdown("Unformatted data", "Format")
+        self.dialog({"type": "ext4", "mount_point": "/home"})
+
+        b.click(self.card_parent_link())
+
+        b.click(self.card_button("LVM2 logical volumes", "Create new logical volume"))
+        self.dialog({"name": "swap", "size": 898})
+        self.click_card_row("LVM2 logical volumes", 3)
+        self.click_card_dropdown("Unformatted data", "Format")
+        self.dialog({"type": "swap"})
+
+        # Exit the cockpit-storage iframe
+        b.switch_to_top()
+
+        s.return_to_installation()
+        s.return_to_installation_confirm()
+
+        s.set_partitioning("use-configured-storage")
+
+        self.addCleanup(lambda: dbus_reset_users(m))
+        i.reach(i.steps.REVIEW)
+
+        # verify review screen
+        disk = "vda"
+        r.check_disk(disk, "16.1 GB vda (0x1af4)")
+
+        r.check_disk_row(disk, 1, "vda2, 1.07 GB: mount, /boot")
+        r.check_disk_row(disk, 2, f"{vgname}-root, 6.01 GB: mount, /")
+        r.check_disk_row(disk, 3, f"{vgname}-home, 8.12 GB: mount, /home")
+        r.check_disk_row(disk, 4, f"{vgname}-swap, 898 MB: mount, swap")
+
+    @nondestructive
+    def testBtrfsSubvolumes(self):
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m, scenario="use-configured-storage")
+        s = Storage(b, m)
+        r = Review(b)
+
+        tmp_mount = "/btrfs-mount-test"
+        tmp_name = "btrfs-mount-test"
+
+        i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+        s.wait_scenario_visible("use-configured-storage", False)
+        s.check_single_disk_destination("vda")
+        s.modify_storage()
+        b.wait_visible(".cockpit-storage-integration-sidebar")
+
+        frame = "iframe[name='cockpit-storage']"
+        b._wait_present(frame)
+        b.switch_to_frame("cockpit-storage")
+        b._wait_present("#storage.ct-page-fill")
+
+        self.click_dropdown(self.card_row("Storage", 1), "Create partition table")
+        self.confirm()
+
+        self.click_dropdown(self.card_row("Storage", 2), "Create partition")
+        self.dialog({"size": 1, "type": "biosboot"})
+
+        self.click_dropdown(self.card_row("Storage", 3), "Create partition")
+        self.dialog({"size": 1070, "type": "ext4", "mount_point": "/boot"})
+
+        self.click_dropdown(self.card_row("Storage", 4), "Create partition")
+        self.dialog({"type": "btrfs", "name": tmp_name})
+
+        self.click_card_row("Storage", name=tmp_name)
+        self.click_card_row("btrfs subvolumes", 1)
+
+        b.click(self.card_button("btrfs subvolume", "Mount"))
+        self.dialog({"mount_point": tmp_mount})
+
+        b.click(self.card_button("btrfs subvolume", "Create subvolume"))
+        self.dialog({"name": "root", "mount_point": "/"})
+
+        b.click(self.card_button("btrfs subvolume", "Create subvolume"))
+        self.dialog({"name": "unused"})
+
+        b.click(self.card_button("btrfs subvolume", "Create subvolume"))
+        self.dialog({"name": "home", "mount_point": "/home"})
+
+        # Exit the cockpit-storage iframe
+        b.switch_to_top()
+
+        s.return_to_installation()
+        s.return_to_installation_confirm()
+
+        s.set_partitioning("use-configured-storage")
+
+        self.addCleanup(lambda: dbus_reset_users(m))
+        i.reach(i.steps.REVIEW)
+
+        # verify review screen
+        dev = "vda"
+        r.check_disk(dev, "16.1 GB vda (0x1af4)")
+
+        r.check_disk_row(dev, 1, "vda2, 1.07 GB: mount, /boot")
+        r.check_disk_row(dev, 2, "root, 15.0 GB: mount, /")
+        r.check_disk_row(dev, 3, "home, 15.0 GB: mount, /home")
 
 
 class TestStorageMountPointsEFI(anacondalib.VirtInstallMachineCase):

--- a/test/helpers/installer.py
+++ b/test/helpers/installer.py
@@ -31,7 +31,6 @@ class InstallerSteps(UserDict):
 
     _steps_jump = {}
     _steps_jump[WELCOME] = [INSTALLATION_METHOD]
-    _steps_jump[INSTALLATION_METHOD] = [DISK_ENCRYPTION, CUSTOM_MOUNT_POINT]
     _steps_jump[DISK_ENCRYPTION] = [ACCOUNTS]
     _steps_jump[CUSTOM_MOUNT_POINT] = [ACCOUNTS]
     _steps_jump[ACCOUNTS] = [REVIEW]
@@ -47,11 +46,17 @@ class InstallerSteps(UserDict):
 
 
 class Installer():
-    def __init__(self, browser, machine, hidden_steps=None):
+    def __init__(self, browser, machine, hidden_steps=None, scenario=None):
         self.browser = browser
         self.machine = machine
         self.steps = InstallerSteps()
         self.hidden_steps = hidden_steps or []
+
+        if (scenario == 'use-configured-storage'):
+            self.steps._steps_jump[self.steps.INSTALLATION_METHOD] = [self.steps.ACCOUNTS]
+            self.hidden_steps.extend([self.steps.CUSTOM_MOUNT_POINT, self.steps.DISK_ENCRYPTION])
+        else:
+            self.steps._steps_jump[self.steps.INSTALLATION_METHOD] = [self.steps.DISK_ENCRYPTION, self.steps.CUSTOM_MOUNT_POINT]
 
     @log_step(snapshot_before=True)
     def begin_installation(self, should_fail=False, confirm_erase=True):

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -113,6 +113,10 @@ class StorageDestination():
     def return_to_installation(self):
         self.browser.click("#cockpit-storage-integration-return-to-installation-button")
 
+    def return_to_installation_confirm(self):
+        with self.browser.wait_timeout(30):
+            self.browser.click("#cockpit-storage-integration-check-storage-dialog-continue")
+
     def modify_storage(self):
         self.browser.click(f"#{self._step}-modify-storage")
 

--- a/test/vm.install
+++ b/test/vm.install
@@ -12,7 +12,7 @@ import sys
 BOTS_DIR = os.path.realpath(f'{__file__}/../../bots')
 sys.path.append(BOTS_DIR)
 
-missing_packages = "cockpit-ws cockpit-bridge fedora-logos"
+missing_packages = "cockpit-ws cockpit-bridge fedora-logos udisks2-lvm2 udisks2-btrfs"
 # Install missing firefox dependencies.
 # Resolving all dependencies with dnf download is possible,
 # but it packs to many packages to updates.img

--- a/test/vm.install
+++ b/test/vm.install
@@ -49,8 +49,7 @@ def vm_install(image, verbose, quick):
             # cockpit-storaged is also available in the default rawhide compose, make sure we don't pull it from there
             download_from_copr(f"packit/cockpit-project-cockpit-{cockpit_pr}", "cockpit-storaged", machine)
         else:
-            # FIXME: Download cockpit-storaged from custom COPR
-            # till https://github.com/cockpit-project/cockpit/pull/19924#event-11785480839 is released
+            # FIXME: Download cockpit-storaged from custom COPR till release 311 is available in rawhide
             download_from_copr("@cockpit/main-builds", "cockpit-storaged", machine)
 
         # Build anaconda-webui from SRPM unless we are testing a anaconda-webui PR scenario


### PR DESCRIPTION
Blocked on:
- [x] https://github.com/rhinstaller/anaconda/pull/5422
- [x] https://github.com/cockpit-project/cockpit/pull/19883
- [x] https://github.com/cockpit-project/cockpit/pull/19876
- [x] https://issues.redhat.com/browse/INSTALLER-3880
- [x] LUKS spport in the new scenario - TODO katerina this PR
- [x] Rescanning deactivates LVM volumes - Marius introduced a workaround where c-storage handles inactive volumes
- [x] Btrfs full support https://github.com/cockpit-project/cockpit/pull/19880 https://github.com/cockpit-project/cockpit/pull/19872
- [ ] Set "default_fsys_type" in "cockpit_anaconda" when starting Cockpit Storage.
- [x] Merge https://github.com/cockpit-project/cockpit/pull/19924
