### PR TITLE
tests: pull anaconda-core from COPR build from master and include firefox dependencies

### DIFF
--- a/test/build-rpms
+++ b/test/build-rpms
@@ -23,7 +23,7 @@ from machine.machine_core import machine_virtual  # NOQA: imported through paren
 def build_rpms(srpm, image, verbose, quick):
     subprocess.check_call([os.path.join(BOTS_DIR, "image-download"), image])
     machine = machine_virtual.VirtMachine(image=image)
-    packages_to_download = missing_packages
+    packages_to_download = missing_packages + " anaconda-core";
     try:
         machine.start()
         machine.wait_boot()
@@ -41,10 +41,11 @@ def build_rpms(srpm, image, verbose, quick):
             if scenario.startswith("cockpit-pr-"):
                 cockpit_pr = scenario.split("-")[-1]
                 machine.execute(f"dnf copr enable -y packit/cockpit-project-cockpit-{cockpit_pr}", stdout=sys.stdout)
-            elif scenario.startswith("anaconda-pr-"):
+            if scenario.startswith("anaconda-pr-"):
                 anaconda_pr = scenario.split("-")[-1]
                 machine.execute(f"dnf copr enable -y packit/rhinstaller-anaconda-{anaconda_pr}", stdout=sys.stdout)
-                packages_to_download += " anaconda-core"
+            else:
+                machine.execute(f"dnf copr enable @rhinstaller/Anaconda ", stdout=sys.stdout)
 
         # download cockpit rpms
         # FIXME boot.iso on rawhide does not currently contain the new cockpit dependencies

--- a/test/build-rpms
+++ b/test/build-rpms
@@ -11,11 +11,11 @@ import sys
 BOTS_DIR = os.path.realpath(f'{__file__}/../../bots')
 sys.path.append(BOTS_DIR)
 
-# libvpx is a firefox dependency, but it is not available in the boot.iso
-# https://bugzilla.redhat.com/show_bug.cgi?id=2242446
+missing_packages = "cockpit-ws cockpit-bridge cockpit-storaged fedora-logos"
+# Install missing firefox dependencies.
 # Resolving all dependencies with dnf download is possible,
 # but it packs to many packages to updates.img
-missing_packages = "cockpit-ws cockpit-bridge cockpit-storaged firefox dbus-glib libvpx fedora-logos"
+missing_packages_incl_deps = "firefox"
 
 from machine.machine_core import machine_virtual  # NOQA: imported through parent.py
 
@@ -52,6 +52,7 @@ def build_rpms(srpm, image, verbose, quick):
         # This will change once we include this changes upstream and start building boot.iso with the new dependencies
         # Then we can move this to the /cockpit-pr scenario above
         machine.execute(f"dnf download --destdir /var/tmp/build/ {packages_to_download}", stdout=sys.stdout, timeout=300)
+        machine.execute(f"dnf download --resolve --destdir /var/tmp/build/ {missing_packages_incl_deps}", stdout=sys.stdout, timeout=300)
 
         # download rpms
         vm_rpms = machine.execute("find /var/tmp/build -name '*.rpm' -not -name '*.src.rpm'").strip().split()

--- a/test/machine_install.py
+++ b/test/machine_install.py
@@ -144,7 +144,7 @@ class VirtInstallMachine(VirtMachine):
                 f"{boot_arg} "
                 f"--name {self.label} "
                 f"--os-variant=detect=on "
-                "--memory 2048 "
+                "--memory 4096 "
                 "--noautoconsole "
                 f"--graphics vnc,listen={self.ssh_address} "
                 "--extra-args "


### PR DESCRIPTION
See https://copr.fedorainfracloud.org/coprs/g/rhinstaller/Anaconda/

With this change we will be testing latest commited changes in the core repository.