### PR TITLE
Create copr builds and such only on the rawhide now

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -19,7 +19,7 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-    - fedora-development
+    - fedora-rawhide
 
   # for cross-project testing
   - job: copr_build
@@ -31,12 +31,12 @@ jobs:
   - job: propose_downstream
     trigger: release
     dist_git_branches:
-      - fedora-development
+      - fedora-rawhide
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
-      - fedora-development
+      - fedora-rawhide
 
 #  - job: bodhi_update
 #    trigger: commit


### PR DESCRIPTION
Packit thinks that fedora-development is also f39 and f-rawhide, it starts to build the anaconda webui RPM in f39 and as expected this does not work.

Let's make the target more explicit.