### PR TITLE
tests: execute anaconda specific cleanup handlers after the cockpit's ones

### DIFF
--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -47,19 +47,20 @@ class VirtInstallMachineCase(MachineCase):
         cls.ext_logging = bool(int(os.environ.get('EXTENDED_LOGGING', '0')))
 
     def setUp(self):
-        super().setUp()
-
         # FIXME: running this in destructive tests fails because the SSH session closes before this is run
         if self.is_nondestructive():
             self.addCleanup(self.resetStorage)
             self.addCleanup(self.resetLanguage)
-        else:
-            # Assume destructive tests may reboot the machine and ignore errors related to that
-            self.allow_browser_errors(".*client closed.*")
-            self.allow_browser_errors(".*Server has closed the connection.*")
+
+        super().setUp()
 
         self.allow_journal_messages('.*cockpit.bridge-WARNING: Could not start ssh-agent.*')
         self.installation_finished = False
+
+        if not self.is_nondestructive():
+            # Assume destructive tests may reboot the machine and ignore errors related to that
+            self.allow_browser_errors(".*client closed.*")
+            self.allow_browser_errors(".*Server has closed the connection.*")
 
     def resetLanguage(self):
         m = self.machine


### PR DESCRIPTION
Cockpit's cleanup handlers are responsible among others for cleaning up per-test added disks, such as SCSI disks. We need to invoke the parent class setUp after adding the anaconda specific cleanup handers.
This sequence guarantees that re-scanning occurs at the very end of the cleanup process, after all disks are removed.

This was causing problems in CI and regressed with 899d47eb8d22ed2bfa52c215dbec31fa7efe1abf.