### PR TITLE
No need to use useMemo when the resolved value is a primitive data type

### DIFF
--- a/src/components/Password.jsx
+++ b/src/components/Password.jsx
@@ -147,9 +147,7 @@ export const PasswordFormFields = ({
         return getRuleResults(rules, policy, checkPassword);
     }, [policy, checkPassword, rules]);
 
-    const ruleConfirmMatches = useMemo(() => {
-        return checkPassword.length > 0 ? checkPassword === checkConfirmPassword : null;
-    }, [checkPassword, checkConfirmPassword]);
+    const ruleConfirmMatches = checkPassword.length > 0 ? checkPassword === checkConfirmPassword : null;
 
     const ruleHelperItems = ruleResults.map(rule => {
         let variant = rule.isSatisfied === null ? "indeterminate" : rule.isSatisfied ? "success" : "error";


### PR DESCRIPTION
When saving into a variable a primitive data type, then the reference never changes unless the value changes.