### PR TITLE
tests: run CI against firefox only

### DIFF
--- a/test/browser-layouts.json
+++ b/test/browser-layouts.json
@@ -1,6 +1,7 @@
 [
     {
        "name": "desktop",
+       "theme": "light",
        "content_size": [1920, 1200],
        "theme": "light",
        "shell_size": [1920, 1200]

--- a/test/run
+++ b/test/run
@@ -5,4 +5,10 @@
 set -eux
 
 make codecheck
+
+# The default and only available browser inside the installation environment is firefox so even
+# though we are testing remote installation we are closer to the real use case by testing against
+# firefox
+export TEST_BROWSER=firefox
+
 make integration-test


### PR DESCRIPTION
Chromium is the default browser for cockpit based tests but we care only about firefox at this point.