### PR TITLE
test: install missing packages also in gating scenario

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -43,13 +43,13 @@ def vm_install(image, verbose, quick):
 
         # Pull cockpit dependencies from the image default compose
         # unless we are testing a PR on cockpit-project/cockpit, then pull it from the PR COPR repo
-        packages_to_download = None
+        packages_to_download = missing_packages
         if scenario and scenario.startswith("cockpit-pr-"):
             cockpit_pr = scenario.split("-")[-1]
             # cockpit-storaged is also available in the default rawhide compose, make sure we don't pull it from there
             download_from_copr(f"packit/cockpit-project-cockpit-{cockpit_pr}", "cockpit-storaged", machine)
         else:
-            packages_to_download = missing_packages + " cockpit-storaged"
+            packages_to_download += " cockpit-storaged"
 
 
         # Build anaconda-webui from SRPM unless we are testing a anaconda-webui PR scenario


### PR DESCRIPTION
When testing in a Cockpit storage PR scenario we also need cockpit-ws, cockpit-bridge installed. This was broken by b14ac44f16c3414f569f as that changed the cockpit-pr scenario to not install the bridge/ws and fedora-logos anymore.

Note that this does not fix the gating tests, locally I get stuck on:

![image](https://github.com/rhinstaller/anaconda-webui/assets/67428/2a658294-fdfa-4cd5-a5c1-e6127882099b)

But before I got:

```
[anaconda root@localhost ~]# /usr/bin/bash /usr/libexec/webui-desktop -t default -r 1 /cockpit/@localhost/anaconda-webui/index.html
Cleaning up existing Anaconda Firefox profile directory.
/usr/libexec/webui-desktop: line 100: /usr/libexec/cockpit-ws: No such file or directory
```