### PR TITLE
Exclude Firefox on ELN

### DIFF
--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -19,8 +19,10 @@ Requires: cockpit-ws >= %{cockpitver}
 Requires: anaconda-core  >= %{anacondacorever}
 # Firefox dependency needs to be specified there as cockpit web-view does not have a hard dependency on Firefox as
 # it can often fall back to a diferent browser. This does not work in the limited installer
-# environment, so we need to make sure Firefox is available.
+# environment, so we need to make sure Firefox is available. Exclude on RHEL, only Flatpak version will be there.
+%if ! 0%{?rhel}
 Requires: firefox
+%endif
 %if 0%{?fedora}
 Requires: fedora-logos
 %endif


### PR DESCRIPTION
We can't use Firefox in ELN because it was removed. This Requires is dragging it back.

https://github.com/minimization/content-resolver-input/pull/1061