### PR TITLE
Handle bootloader partition constraints

### DIFF
--- a/src/components/storage/MountPointMapping.jsx
+++ b/src/components/storage/MountPointMapping.jsx
@@ -67,7 +67,8 @@ const _ = cockpit.gettext;
  * @returns {Array} filtered requests
  */
 const getInitialRequests = (requests, mountPointConstraints) => {
-    const constrainedRequests = mountPointConstraints.map((constraint, idx) => {
+    const constrainedRequests = mountPointConstraints.filter(constraint =>
+        !!constraint["mount-point"].v).map((constraint, idx) => {
         const originalRequest = requests.find(request => request["mount-point"] === constraint["mount-point"].v);
         const request = ({ "mount-point": constraint["mount-point"].v, reformat: constraint["mount-point"].v === "/" });
 

--- a/src/components/storage/MountPointMapping.jsx
+++ b/src/components/storage/MountPointMapping.jsx
@@ -67,9 +67,9 @@ const _ = cockpit.gettext;
  * @returns {Array} filtered requests
  */
 const getInitialRequests = (requests, mountPointConstraints) => {
-    const constrainedRequests = mountPointConstraints.map((mountPoint, idx) => {
-        const originalRequest = requests.find(request => request["mount-point"] === mountPoint["mount-point"].v);
-        const request = ({ "mount-point": mountPoint["mount-point"].v, reformat: mountPoint["mount-point"].v === "/" });
+    const constrainedRequests = mountPointConstraints.map((constraint, idx) => {
+        const originalRequest = requests.find(request => request["mount-point"] === constraint["mount-point"].v);
+        const request = ({ "mount-point": constraint["mount-point"].v, reformat: constraint["mount-point"].v === "/" });
 
         if (originalRequest) {
             return { ...originalRequest, ...request };


### PR DESCRIPTION
Adds two commits on top of https://github.com/rhinstaller/anaconda-webui/pull/95 that should make sure constraints without mount point (eg biosboot partition) won't mess up Mount Point Assignment screen.