### PR TITLE
Revert koji automation done by packit

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -32,13 +32,3 @@ jobs:
     trigger: release
     dist_git_branches:
       - fedora-development
-
-  - job: koji_build
-    trigger: commit
-    dist_git_branches:
-      - fedora-development
-
-#  - job: bodhi_update
-#    trigger: commit
-#    dist_git_branches:
-#      # rawhide updates are created automatically


### PR DESCRIPTION
As pointed out in https://bugzilla.redhat.com/show_bug.cgi?id=2260395#c18 , anaconda and anaconda-webui contain often inter-dependent changes which *must* be submitted as a single update: https://docs.fedoraproject.org/en-US/fesco/Updates_Policy/#updating-inter-dependent-packages

Packit unfortunately does not support this packit/packit#1870 so we need to do this manually.

For release guidelines read https://github.com/rhinstaller/anaconda/blob/master/docs/release.rst#the-mostly-automated-build-path