### PR TITLE
packaging: bump anaconda core requirement version

### DIFF
--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -11,7 +11,7 @@ BuildRequires:  libappstream-glib
 BuildRequires:  make
 BuildRequires:  gettext
 
-%global anacondacorever 40.9
+%global anacondacorever 40.20
 %global cockpitver 275
 
 Requires: cockpit-bridge >= %{cockpitver}


### PR DESCRIPTION
The newly used GetMountPointConstraints API needs latest anaconda.