### PR TITLE
Clear partitions during test cleanup better

### DIFF
--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -75,7 +75,9 @@ class VirtInstallMachineCase(MachineCase):
         b = self.browser
         s = Storage(b, m)
 
-        m.execute(r"find /dev -regex '/dev/[v|s]d.' -exec wipefs --all {} \;")
+        # Clear partitions before disks
+        m.execute(r"find /dev -regex '/dev/[v|s]d[a-z][0-9]+' -exec wipefs --all {} \;")
+        m.execute(r"find /dev -regex '/dev/[v|s]d[a-z]' -exec wipefs --all {} \;")
         s.dbus_reset_partitioning()
         s.dbus_reset_selected_disks()
         # CLEAR_PARTITIONS_DEFAULT = -1


### PR DESCRIPTION
Without the patch the filesystem on a partition is not wiped and in a following test, if a partition without a filesystem is created on the same offset the original filesystem is detected errorneously.