### PR TITLE
Fix issue when browser pid file containes newline

### DIFF
--- a/src/helpers/exit.js
+++ b/src/helpers/exit.js
@@ -21,7 +21,7 @@ export const exitGui = () => {
     let pid;
     pidFile.read()
             .then(content => {
-                pid = content;
+                pid = content.trim();
                 console.log("Killing WebUI process, PID: ", pid);
                 return cockpit.spawn(["kill", pid]);
             })


### PR DESCRIPTION
There were change in Anaconda core which accidentally added a new line to the pid file created. It will be fixed also there but I think this worth to fix this here also.

Issue was introduced by https://github.com/rhinstaller/anaconda/commit/1843885f6b70278790bdb3cd2ecfe43a2cb35846 .

Resolves: rhbz#2262413