### PR TITLE
Anaconda needs latest pykickstart but image refresh is currently blocked on blivet regression

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -12,7 +12,8 @@ import sys
 BOTS_DIR = os.path.realpath(f'{__file__}/../../bots')
 sys.path.append(BOTS_DIR)
 
-missing_packages = "cockpit-ws cockpit-bridge fedora-logos"
+# FIXME: Remove 'pykickstart' this as soon as https://github.com/cockpit-project/bots/pull/5860 is merged
+missing_packages = "cockpit-ws cockpit-bridge fedora-logos python3-kickstart pykickstart"
 # Install missing firefox dependencies.
 # Resolving all dependencies with dnf download is possible,
 # but it packs to many packages to updates.img


### PR DESCRIPTION
This should be reverted ASAP.