### PR TITLE
packaging: recommended dependencies from cockpit-storage are installed by default

### DIFF
--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -17,10 +17,6 @@ BuildRequires:  gettext
 
 # LVM and BTRFS are only recommended by cockpit-storaged
 Requires: cockpit-storaged >= %{cockpitstorver}
-Requires: udisks2-lvm
-%if 0%{?fedora}
-Requires: udisks2-btrfs
-%endif
 
 Requires: cockpit-bridge >= %{cockpitver}
 Requires: cockpit-ws >= %{cockpitver}


### PR DESCRIPTION
Also udisks2-lvm is wrong - it's udisks2-lvm2.