### PR TITLE
Introduce flake8, ruff, use shared test/static-code

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+# we want 118, but fix tests first
+#max-line-length = 118
+max-line-length = 149
+# E402: module level import not at top of file; needs updating the tests to current cockpit standard
+# W504: line break after binary operator
+# E741: ambiguous variable name 'l'
+ignore = E402, W504, E741

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@
 /po/LINGUAS
 /test/common/
 /test/images
+/test/static-code
 /test/ks*.cfg

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,7 @@ EXTRA_DIST = dist src firefox-theme
 COCKPIT_REPO_FILES = \
 	pkg/lib \
 	test/common \
+	test/static-code \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
@@ -162,6 +163,10 @@ $(COCKPIT_REPO_STAMP): Makefile
 	@git rev-list --quiet --objects $(COCKPIT_REPO_TREE) -- 2>/dev/null || \
 	     git fetch --no-tags --no-write-fetch-head --depth=1 $(COCKPIT_REPO_URL) $(COCKPIT_REPO_COMMIT)
 	git archive $(COCKPIT_REPO_TREE) -- $(COCKPIT_REPO_FILES) | tar x
+
+.PHONY: codecheck
+codecheck: test/static-code $(NODE_MODULES_TEST)
+	test/static-code
 
 # checkout Cockpit's bots for standard test VM images and API to launch them
 # must be from main, as only that has current and existing images; but testvm.py API is stable

--- a/build.js
+++ b/build.js
@@ -1,44 +1,44 @@
 #!/usr/bin/env node
-import fs from 'fs';
-import path from 'path';
+import fs from "fs";
+import path from "path";
 
-import copy from 'esbuild-plugin-copy';
+import copy from "esbuild-plugin-copy";
 import esbuild from "esbuild";
 
-import { cockpitCompressPlugin } from './pkg/lib/esbuild-compress-plugin.js';
-import { cleanPlugin } from './pkg/lib/esbuild-cleanup-plugin.js';
-import { cockpitPoEsbuildPlugin } from './pkg/lib/cockpit-po-plugin.js';
-import { cockpitRsyncEsbuildPlugin } from './pkg/lib/cockpit-rsync-plugin.js';
-import { eslintPlugin } from './pkg/lib/esbuild-eslint-plugin.js';
-import { stylelintPlugin } from './pkg/lib/esbuild-stylelint-plugin.js';
-import { replace } from 'esbuild-plugin-replace';
-import { sassPlugin } from 'esbuild-sass-plugin';
+import { cockpitCompressPlugin } from "./pkg/lib/esbuild-compress-plugin.js";
+import { cleanPlugin } from "./pkg/lib/esbuild-cleanup-plugin.js";
+import { cockpitPoEsbuildPlugin } from "./pkg/lib/cockpit-po-plugin.js";
+import { cockpitRsyncEsbuildPlugin } from "./pkg/lib/cockpit-rsync-plugin.js";
+import { eslintPlugin } from "./pkg/lib/esbuild-eslint-plugin.js";
+import { stylelintPlugin } from "./pkg/lib/esbuild-stylelint-plugin.js";
+import { sassPlugin } from "esbuild-sass-plugin";
 
-const production = process.env.NODE_ENV === 'production';
+const production = process.env.NODE_ENV === "production";
 const watchMode = process.env.ESBUILD_WATCH === "true" || false;
 // linters dominate the build time, so disable them for production builds by default, but enable in watch mode
-const lint = process.env.LINT ? (process.env.LINT !== '0') : (watchMode || !production);
+const lint = process.env.LINT ? (process.env.LINT !== "0") : (watchMode || !production);
 /* List of directories to use when resolving import statements */
-const nodePaths = ['pkg/lib'];
-const outdir = 'dist';
+const nodePaths = ["pkg/lib"];
+const outdir = "dist";
 
 // Obtain package name from package.json
-const packageJson = JSON.parse(fs.readFileSync('package.json'));
+const packageJson = JSON.parse(fs.readFileSync("package.json"));
 
 const getTime = () => new Date().toTimeString()
-        .split(' ')[0];
+        .split(" ")[0];
 
 const cwd = process.cwd();
 
 // similar to fs.watch(), but recursively watches all subdirectories
-function watch_dirs(dir, on_change) {
+function watchDirs (dir, onChange) {
     const callback = (ev, dir, fname) => {
         // only listen for "change" events, as renames are noisy
         // ignore hidden files and the "4913" temporary file created by vim
         const isHidden = /^\./.test(fname);
-        if (ev !== "change" || isHidden || fname === "4913")
+        if (ev !== "change" || isHidden || fname === "4913") {
             return;
-        on_change(path.join(dir, fname));
+        }
+        onChange(path.join(dir, fname));
     };
 
     fs.watch(dir, {}, (ev, path) => callback(ev, dir, path));
@@ -47,8 +47,9 @@ function watch_dirs(dir, on_change) {
     const d = fs.opendirSync(dir);
     let dirent;
     while ((dirent = d.readSync()) !== null) {
-        if (dirent.isDirectory())
-            watch_dirs(path.join(dir, dirent.name), on_change);
+        if (dirent.isDirectory()) {
+            watchDirs(path.join(dir, dirent.name), onChange);
+        }
     }
     d.closeSync();
 }
@@ -58,11 +59,11 @@ const context = await esbuild.context({
     bundle: true,
     entryPoints: ["./src/index.js"],
     external: [
-        '*.woff', '*.woff2', '*.jpg',
-        '@patternfly/react-core/src/components/assets/*.svg',
-        '@patternfly/react-core/src/demos/assets/*svg'
+        "*.woff", "*.woff2", "*.jpg",
+        "@patternfly/react-core/src/components/assets/*.svg",
+        "@patternfly/react-core/src/demos/assets/*svg"
     ], // Allow external font files which live in ../../static/fonts
-    legalComments: 'external', // Move all legal comments to a .LEGAL.txt file
+    legalComments: "external", // Move all legal comments to a .LEGAL.txt file
     loader: {
         ".js": "jsx",
         ".py": "text",
@@ -71,32 +72,32 @@ const context = await esbuild.context({
     minify: production,
     nodePaths,
     outdir,
-    target: ['es2020'],
+    target: ["es2020"],
     plugins: [
         cleanPlugin(),
         ...lint
             ? [
-                stylelintPlugin({ filter: new RegExp(cwd + '/src/.*\\.(css?|scss?)$') }),
-                eslintPlugin({ filter: new RegExp(cwd + '\/src\/.*\.(jsx?|js?)$') })
+                stylelintPlugin({ filter: new RegExp(cwd + "/src/.*\\.(css?|scss?)$") }),
+                eslintPlugin({ filter: new RegExp(cwd + "/src/.*\\.(jsx?|js?)$") })
             ]
             : [],
         // Esbuild will only copy assets that are explicitly imported and used
         // in the code. This is a problem for index.html and manifest.json which are not imported
         copy({
             assets: [
-                { from: ['./images/qr-code-feedback.svg'], to: ['./qr-code-feedback.svg'] },
-                { from: ['./src/manifest.json'], to: ['./manifest.json'] },
-                { from: ['./src/index.html'], to: ['./index.html'] },
+                { from: ["./images/qr-code-feedback.svg"], to: ["./qr-code-feedback.svg"] },
+                { from: ["./src/manifest.json"], to: ["./manifest.json"] },
+                { from: ["./src/index.html"], to: ["./index.html"] },
             ]
         }),
         sassPlugin({
-            loadPaths: [...nodePaths, 'node_modules'],
+            loadPaths: [...nodePaths, "node_modules"],
             quietDeps: true,
-            async transform(source, resolveDir, path) {
-                if (path.includes('patternfly-4-cockpit.scss')) {
+            async transform (source, resolveDir, path) {
+                if (path.includes("patternfly-4-cockpit.scss")) {
                     return source
-                            .replace(/url.*patternfly-icons-fake-path.*;/g, 'url("../base1/fonts/patternfly.woff") format("woff");')
-                            .replace(/@font-face[^}]*patternfly-fonts-fake-path[^}]*}/g, '');
+                            .replace(/url.*patternfly-icons-fake-path.*;/g, "url(\"../base1/fonts/patternfly.woff\") format(\"woff\");")
+                            .replace(/@font-face[^}]*patternfly-fonts-fake-path[^}]*}/g, "");
                 }
                 return source;
             }
@@ -106,8 +107,8 @@ const context = await esbuild.context({
         cockpitRsyncEsbuildPlugin({ dest: packageJson.name }),
 
         {
-            name: 'notify-end',
-            setup(build) {
+            name: "notify-end",
+            setup (build) {
                 build.onEnd(() => console.log(`${getTime()}: Build finished`));
             }
         },
@@ -117,13 +118,14 @@ const context = await esbuild.context({
 try {
     await context.rebuild();
 } catch (e) {
-    if (!watchMode)
+    if (!watchMode) {
         process.exit(1);
+    }
     // ignore errors in watch mode
 }
 
 if (watchMode) {
-    const on_change = async path => {
+    const onChange = async path => {
         console.log("change detected:", path);
         await context.cancel();
         try {
@@ -131,7 +133,7 @@ if (watchMode) {
         } catch (e) {} // ignore in watch mode
     };
 
-    watch_dirs('src', on_change);
+    watchDirs("src", onChange);
     // wait forever until Control-C
     await new Promise(() => {});
 }

--- a/firefox-theme/default/user.js
+++ b/firefox-theme/default/user.js
@@ -1,3 +1,4 @@
+/* global user_pref */
 // Let us use userChrome.css
 user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);
 
@@ -44,4 +45,3 @@ user_pref("datareporting.healthreport.uploadEnabled", false);
 user_pref("datareporting.policy.dataSubmissionEnabled", false);
 user_pref("toolkit.telemetry.unified", false);
 user_pref("trailhead.firstrun.didSeeAboutWelcome", true);
-

--- a/firefox-theme/live/user.js
+++ b/firefox-theme/live/user.js
@@ -1,3 +1,4 @@
+/* global user_pref */
 // Let us use userChrome.css
 user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);
 
@@ -41,4 +42,3 @@ user_pref("datareporting.healthreport.uploadEnabled", false);
 user_pref("datareporting.policy.dataSubmissionEnabled", false);
 user_pref("toolkit.telemetry.unified", false);
 user_pref("trailhead.firstrun.didSeeAboutWelcome", true);
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,51 @@
+[tool.ruff]
+exclude = [
+    ".git/",
+    "modules/",
+    "node_modules/",
+]
+# we want 118, but fix tests first
+# line-length = 118
+line-length = 149
+src = []
+
+[tool.ruff.lint]
+select = [
+    "A",       # flake8-builtins
+    "B",       # flake8-bugbear
+    "C4",      # flake8-comprehensions
+    "D300",    # pydocstyle: Forbid ''' in docstrings
+    "DTZ",     # flake8-datetimez
+    "E",       # pycodestyle
+    "EXE",     # flake8-executable
+    "F",       # pyflakes
+    "FBT",     # flake8-boolean-trap
+    "G",       # flake8-logging-format
+    "I",       # isort
+    "ICN",     # flake8-import-conventions
+    "ISC",     # flake8-implicit-str-concat
+    "PLE",     # pylint errors
+    "PGH",     # pygrep-hooks
+    "RSE",     # flake8-raise
+    "RUF",     # ruff rules
+    "T10",     # flake8-debugger
+    "TCH",     # flake8-type-checking
+    "UP032",   # f-string
+    "W",       # warnings (mostly whitespace)
+    "YTT",     # flake8-2020
+]
+ignore = [
+    "E402",   # Module level import not at top of file"
+    "E741",   # ambiguous variable name
+    "FBT002", # Boolean default value in function definition
+    "FBT003", # Boolean positional value in function call
+    "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
+    "RUF100", # Unused `noqa` directive (used by flake8)
+]
+
+[tool.ruff.lint.flake8-pytest-style]
+fixture-parentheses = false
+mark-parentheses = false
+
+[tool.ruff.lint.isort]
+known-first-party = ["cockpit"]

--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -24,26 +24,28 @@
 import getopt
 import os
 import shutil
-import six
-import subprocess
 import sys
+
 
 def addRpms(updates, add_rpms):
     for rpm in add_rpms:
         cmd = "cd %s && rpm2cpio %s | cpio -dium" % (updates, rpm)
-        sys.stdout.write(cmd+"\n")
+        sys.stdout.write(cmd + "\n")
         os.system(cmd)
+
 
 def createUpdatesImage(cwd, updates):
     os.chdir(updates)
     os.system("find . | cpio -c -o | gzip -9cv > %s/updates.img" % (cwd,))
     sys.stdout.write("updates.img ready\n")
 
+
 def usage(cmd):
     sys.stdout.write("Usage: %s [OPTION]...\n" % (cmd,))
     sys.stdout.write("Options:\n")
     sys.stdout.write("    -h, --help       Display this help and exit.\n")
     sys.stdout.write("    -a, --add        Add contents of rpm to the update\n")
+
 
 def main(argv):
     prog = os.path.basename(argv[0])
@@ -55,9 +57,7 @@ def main(argv):
     add_rpms = []
 
     try:
-        opts, _args = getopt.getopt(argv[1:], 'a',
-                                   ['add=',
-                                    'help'])
+        opts, _args = getopt.getopt(argv[1:], 'a', ['add=', 'help'])
     except getopt.GetoptError:
         show_help = True
 
@@ -90,6 +90,7 @@ def main(argv):
     createUpdatesImage(cwd, updates)
 
     shutil.rmtree(updates)
+
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/src/scripts/encrypt-user-pw.py
+++ b/src/scripts/encrypt-user-pw.py
@@ -1,6 +1,6 @@
 import crypt
-from random import SystemRandom as sr
 import sys
+from random import SystemRandom as sr
 
 
 # Using the function from pyanaconda/core/users.py
@@ -29,7 +29,7 @@ def crypt_password(password):
             cryptpw = crypt.crypt(password, crypt.METHOD_SHA512)
         except OSError as exc:
             raise RuntimeError(
-                "Unable to encrypt password: unsupported algorithm {}".format(crypt.METHOD_SHA512)
+                f"Unable to encrypt password: unsupported algorithm {crypt.METHOD_SHA512}"
             ) from exc
 
     return cryptpw

--- a/src/scripts/encrypt-user-pw.py
+++ b/src/scripts/encrypt-user-pw.py
@@ -2,8 +2,8 @@ import crypt
 from random import SystemRandom as sr
 import sys
 
-# Using the function from pyanaconda/core/users.py
 
+# Using the function from pyanaconda/core/users.py
 def crypt_password(password):
     """Crypt a password.
 

--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -65,9 +65,8 @@ class VirtInstallMachineCase(MachineCase):
     def resetLanguage(self):
         m = self.machine
         b = self.browser
-        l = Language(b, m)
-
-        l.dbus_set_language("en_US.UTF-8")
+        lang = Language(b, m)
+        lang.dbus_set_language("en_US.UTF-8")
 
     def resetStorage(self):
         # Ensures that anaconda has the latest storage configuration data

--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-#
 # Copyright (C) 2023 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -25,14 +23,12 @@ sys.path.append(os.path.join(TEST_DIR, "common"))
 sys.path.insert(0, os.path.join(TEST_DIR, "helpers"))
 sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
 
+from language import Language
 from machine_install import VirtInstallMachine
+from progress import Progress
+from storage import Storage
 from testlib import MachineCase  # pylint: disable=import-error
 from utils import add_public_key
-
-from storage import Storage
-from language import Language
-from progress import Progress
-
 
 pixel_tests_ignore = [".logo", "#betanag-icon"]
 

--- a/test/check-basic
+++ b/test/check-basic
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
+import time
+
 import anacondalib
 
 from installer import Installer
@@ -22,7 +24,7 @@ from language import Language
 from review import Review
 from storage import Storage
 from users import dbus_reset_users
-from testlib import nondestructive, test_main, wait, Error  # pylint: disable=import-error
+from testlib import nondestructive, test_main, wait  # pylint: disable=import-error
 from utils import pretend_live_iso, get_pretty_name
 
 
@@ -148,7 +150,7 @@ class TestBasic(anacondalib.VirtInstallMachineCase):
             ignore=["#about-modal-versions dd"],
         )
 
-        #Close about modal
+        # Close about modal
         b.click(".pf-v5-c-button[aria-label='Close Dialog']")
         b.wait_not_present("#about-modal")
 
@@ -200,12 +202,11 @@ class TestBasic(anacondalib.VirtInstallMachineCase):
         b = self.browser
         m = self.machine
         i = Installer(b, m)
-        l = Language(b, m)
+        _l = Language(b, m)  # noqa: F841
         s = Storage(b, m)
 
         # BIOS boot /boot on ext4 / on xfs /home on btrfs
         disk = "/dev/vda"
-        dev = "vda"
         s.partition_disk(disk, [("1MiB", "biosboot"), ("1GB", "ext4"), ("10GiB", "xfs"), ("", "ext4")])
 
         # Two partitions on the same disk with the same UUID raise exception in

--- a/test/check-basic
+++ b/test/check-basic
@@ -18,14 +18,13 @@
 import time
 
 import anacondalib
-
 from installer import Installer
 from language import Language
 from review import Review
 from storage import Storage
-from users import dbus_reset_users
 from testlib import nondestructive, test_main, wait  # pylint: disable=import-error
-from utils import pretend_live_iso, get_pretty_name
+from users import dbus_reset_users
+from utils import get_pretty_name, pretend_live_iso
 
 
 @nondestructive

--- a/test/check-language
+++ b/test/check-language
@@ -36,27 +36,26 @@ class TestLanguage(anacondalib.VirtInstallMachineCase):
         b = self.browser
         m = self.machine
         i = Installer(b, m)
-        l = Language(b, m)
+        lang = Language(b, m)
 
         # Set the language in the localization module to German before opening the page
-        l.dbus_set_language("de_DE.UTF-8")
+        lang.dbus_set_language("de_DE.UTF-8")
 
         i.open()
 
         # Expect the backend set language to be preselected and the WebUI translated
-        l.check_selected_locale("de_DE")
+        lang.check_selected_locale("de_DE")
         b.wait_in_text("h2 + h3", "Wählen Sie eine Sprache aus")
 
     def testBackendTranslations(self):
         b = self.browser
         m = self.machine
         i = Installer(b, m)
-        l = Language(b, m)
+        lang = Language(b, m)
         s = Storage(b, m)
 
         # BIOS boot /boot on ext4 / on xfs /home on btrfs
         disk = "/dev/vda"
-        dev = "vda"
         s.partition_disk(disk, [("1MiB", "biosboot"), ("1GB", "ext4"), ("10GiB", "xfs"), ("", "ext4")])
 
         # Two partitions on the same disk with the same UUID raise exception in
@@ -67,12 +66,14 @@ class TestLanguage(anacondalib.VirtInstallMachineCase):
         s.udevadm_settle()
 
         i.open()
-        l.select_locale("de_DE")
-        l.check_selected_locale("de_DE")
+        lang.select_locale("de_DE")
+        lang.check_selected_locale("de_DE")
         i.reach(i.steps.INSTALLATION_METHOD)
         s.rescan_disks()
 
-        b.wait_in_text("#critical-error-bz-report-modal.pf-v5-c-modal-box", "In diesem Fall können Sie entweder eines der Geräte trennen oder es neu formatieren.")
+        b.wait_in_text(
+            "#critical-error-bz-report-modal.pf-v5-c-modal-box",
+            "In diesem Fall können Sie entweder eines der Geräte trennen oder es neu formatieren.")
 
     def testLanguageSwitching(self):
         b = self.browser
@@ -89,7 +90,7 @@ class TestLanguage(anacondalib.VirtInstallMachineCase):
 
         # Assert that search bar starts empty.
         assert l.get_locale_search() == ""
-        #b.wait_visible(f".{i.steps.WELCOME}-menu.pf-m-invalid")
+        # b.wait_visible(f".{i.steps.WELCOME}-menu.pf-m-invalid")
 
         # Check that the language menu shows all menu entries when clicking the toggle button
         l.locale_option_visible('en_US')
@@ -138,6 +139,7 @@ class TestLanguage(anacondalib.VirtInstallMachineCase):
         l.select_locale("de_DE")
         l.check_selected_locale("de_DE")
         b.wait_attr("html", "dir", "ltr")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/check-language
+++ b/test/check-language
@@ -16,10 +16,9 @@
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
 import anacondalib
-
-from storage import Storage
 from installer import Installer
 from language import Language
+from storage import Storage
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 
 
@@ -120,7 +119,7 @@ class TestLanguage(anacondalib.VirtInstallMachineCase):
             "language-step-basic",
             # HACK pf-v5-c-menu__item-text is ignored because some of our CI infrastructure is
             # missing CJK and Cyrillic fonts..
-            ignore=anacondalib.pixel_tests_ignore + [".pf-v5-c-menu__item-text"],
+            ignore=[*anacondalib.pixel_tests_ignore, ".pf-v5-c-menu__item-text"],
         )
 
         b.wait_in_text("h2 + h3", "Wählen Sie eine Sprache aus")

--- a/test/check-progress
+++ b/test/check-progress
@@ -20,7 +20,7 @@ import anacondalib
 from installer import Installer
 from progress import Progress
 from storage import Storage
-from utils import add_public_key, get_pretty_name
+from utils import get_pretty_name
 from testlib import test_main  # pylint: disable=import-error
 
 
@@ -34,7 +34,7 @@ class TestInstallationProgress(anacondalib.VirtInstallMachineCase):
         m = self.machine
         i = Installer(b, self.machine)
         p = Progress(b)
-        s = Storage(b, self.machine)
+        _s = Storage(b, self.machine)  # noqa: F841
 
         i.open()
 
@@ -53,6 +53,7 @@ class TestInstallationProgress(anacondalib.VirtInstallMachineCase):
         )
 
         self.handleReboot()
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/check-progress
+++ b/test/check-progress
@@ -16,12 +16,11 @@
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
 import anacondalib
-
 from installer import Installer
 from progress import Progress
 from storage import Storage
-from utils import get_pretty_name
 from testlib import test_main  # pylint: disable=import-error
+from utils import get_pretty_name
 
 
 class TestInstallationProgress(anacondalib.VirtInstallMachineCase):

--- a/test/check-review
+++ b/test/check-review
@@ -21,9 +21,7 @@ from installer import Installer
 from storage import Storage  # pylint: disable=import-error
 from review import Review
 from language import Language
-from progress import Progress
 from users import dbus_reset_users
-from utils import add_public_key
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 
 
@@ -97,6 +95,7 @@ class TestReview(anacondalib.VirtInstallMachineCase):
 
         # test the macedonian language selected
         r.check_language("mk_MK.UTF-8")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/check-review
+++ b/test/check-review
@@ -16,13 +16,12 @@
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
 import anacondalib
-
 from installer import Installer
-from storage import Storage  # pylint: disable=import-error
-from review import Review
 from language import Language
-from users import dbus_reset_users
+from review import Review
+from storage import Storage  # pylint: disable=import-error
 from testlib import nondestructive, test_main  # pylint: disable=import-error
+from users import dbus_reset_users
 
 
 @nondestructive

--- a/test/check-storage
+++ b/test/check-storage
@@ -25,7 +25,6 @@ from password import Password
 from testlib import nondestructive, skipImage, test_main  # pylint: disable=import-error
 from progress import Progress
 from storagelib import StorageCase, StorageHelpers  # pylint: disable=import-error
-from utils import pretend_live_iso
 
 
 class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
@@ -345,7 +344,6 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         s = Storage(b, m)
         r = Review(b)
 
-
         disk = "/dev/vda"
         dev = "vda"
         btrfsname = "btrfstest"
@@ -362,7 +360,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         # verify gathered requests
         # root partition is not auto-mapped
         s.check_mountpoint_row(1, "/", "Select a device", True)
-        s.select_mountpoint_row_device(1, f"btrfstest")
+        s.select_mountpoint_row_device(1, "btrfstest")
         s.check_mountpoint_row_format_type(1, "btrfs")
 
         s.check_mountpoint_row(2, "/boot", "Select a device", False)
@@ -388,7 +386,6 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         self.addCleanup(lambda: dbus_reset_users(self.machine))
         i.reach(i.steps.REVIEW)
 
-
         # verify review screen
         r.check_disk(dev, "16.1 GB vda (0x1af4)")
 
@@ -407,7 +404,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         s.check_mountpoint_row_device(1, "Select a device")
         s.check_mountpoint_row_device(2, "Select a device")
         s.select_mountpoint_row_device(1, f"{dev}2")
-        s.select_mountpoint_row_device(2, f"btrfstest")
+        s.select_mountpoint_row_device(2, "btrfstest")
 
         i.next()
         new_applied_partitioning = s.dbus_get_applied_partitioning()
@@ -567,8 +564,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         i.reach(i.steps.INSTALLATION_METHOD)
         s.rescan_disks()
 
-        self._testEncryptedUnlock(b, m);
-
+        self._testEncryptedUnlock(b, m)
 
     def _testEncryptedUnlock(self, b, m):
         dev1 = "vda"
@@ -621,10 +617,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         m = self.machine
         i = Installer(b, m)
         s = Storage(b, m)
-        r = Review(b)
-
-        disk = "/dev/vda"
-        dev = "vda"
+        _r = Review(b)  # noqa: F841
 
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
@@ -645,7 +638,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         self.confirm()
 
         self.click_dropdown(self.card_row("Storage", 2), "Create partition")
-        self.dialog({ "size": 1, "type": "biosboot" })
+        self.dialog({"size": 1, "type": "biosboot"})
 
         self.click_dropdown(self.card_row("Storage", 3), "Create partition")
         self.dialog({
@@ -675,7 +668,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         })
 
         self.click_dropdown(self.card_row("Storage", 6), "Create partition")
-        self.dialog({"size": 1000, "type": "ext4" })
+        self.dialog({"size": 1000, "type": "ext4"})
 
         # Exit the cockpit-storage iframe
         b.switch_to_top()
@@ -850,7 +843,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         r.check_disk_row(dev, 1, "vda2, 1.07 GB: format as ext4, /boot")
         r.check_disk_row(dev, 2, "root, 15.0 GB: format as btrfs, /")
         r.check_disk_row(dev, 3, "home, 15.0 GB: mount, /home")
-        r.check_disk_row_not_present(dev, f"unused")
+        r.check_disk_row_not_present(dev, "unused")
 
         i.reach_on_sidebar(i.steps.INSTALLATION_METHOD)
 
@@ -920,10 +913,9 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         m = self.machine
         i = Installer(b, m)
         s = Storage(b, m)
-        r = Review(b)
+        _r = Review(b)  # noqa: F841
 
         disk = "/dev/vda"
-        dev = "vda"
         tmp_mount = "/tmp/btrfs-mount-test"
         s.partition_disk(disk, [("1MiB", "biosboot"), ("1GB", "btrfs"), ("", "btrfs")])
         m.execute(f"""
@@ -1054,6 +1046,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageCase):
         # unformatted and unmountable devices should not be available
         s.check_mountpoint_row_device_available(1, f"{dev}2", False)
         s.check_mountpoint_row_device_available(1, f"{dev}3", False)
+
 
 class TestStorageMountPointsEFI(anacondalib.VirtInstallMachineCase):
     efi = True

--- a/test/check-storage
+++ b/test/check-storage
@@ -16,15 +16,14 @@
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
 import anacondalib
-
 from installer import Installer
-from storage import Storage
-from users import dbus_reset_users
-from review import Review
 from password import Password
-from testlib import nondestructive, skipImage, test_main  # pylint: disable=import-error
 from progress import Progress
+from review import Review
+from storage import Storage
 from storagelib import StorageCase, StorageHelpers  # pylint: disable=import-error
+from testlib import nondestructive, skipImage, test_main  # pylint: disable=import-error
+from users import dbus_reset_users
 
 
 class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):

--- a/test/check-users
+++ b/test/check-users
@@ -23,6 +23,7 @@ from review import Review
 from users import Users, CREATE_ACCOUNT_ID_PREFIX, create_user, dbus_reset_users
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 
+
 @nondestructive
 class TestUsers(anacondalib.VirtInstallMachineCase):
     def setUp(self):

--- a/test/check-users
+++ b/test/check-users
@@ -16,12 +16,11 @@
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
 import anacondalib
-
 from installer import Installer
 from password import Password
 from review import Review
-from users import Users, CREATE_ACCOUNT_ID_PREFIX, create_user, dbus_reset_users
 from testlib import nondestructive, test_main  # pylint: disable=import-error
+from users import CREATE_ACCOUNT_ID_PREFIX, Users, create_user, dbus_reset_users
 
 
 @nondestructive

--- a/test/helpers/installer.py
+++ b/test/helpers/installer.py
@@ -47,6 +47,7 @@ class InstallerSteps(UserDict):
     _steps_callbacks = {}
     _steps_callbacks[ACCOUNTS] = create_user
 
+
 class Installer():
     def __init__(self, browser, machine, hidden_steps=None):
         self.browser = browser

--- a/test/helpers/installer.py
+++ b/test/helpers/installer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-#
 # Copyright (C) 2022 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -16,8 +14,8 @@
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 from collections import UserDict
 from time import sleep
-from step_logger import log_step
 
+from step_logger import log_step
 from users import create_user
 
 

--- a/test/helpers/language.py
+++ b/test/helpers/language.py
@@ -28,6 +28,7 @@ from step_logger import log_step
 LOCALIZATION_INTERFACE = "org.fedoraproject.Anaconda.Modules.Localization"
 LOCALIZATION_OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Localization"
 
+
 class Language():
     def __init__(self, browser, machine):
         self.browser = browser

--- a/test/helpers/language.py
+++ b/test/helpers/language.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-#
 # Copyright (C) 2021 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -23,7 +21,6 @@ sys.path.append(HELPERS_DIR)
 
 from installer import InstallerSteps  # pylint: disable=import-error
 from step_logger import log_step
-
 
 LOCALIZATION_INTERFACE = "org.fedoraproject.Anaconda.Modules.Localization"
 LOCALIZATION_OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Localization"

--- a/test/helpers/password.py
+++ b/test/helpers/password.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-#
 # Copyright (C) 2022 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it

--- a/test/helpers/password.py
+++ b/test/helpers/password.py
@@ -23,6 +23,7 @@ sys.path.append(HELPERS_DIR)
 
 from step_logger import log_step
 
+
 class Password():
     def __init__(self, browser, id_prefix):
         self.browser = browser

--- a/test/helpers/progress.py
+++ b/test/helpers/progress.py
@@ -43,4 +43,3 @@ class Progress():
     @log_step()
     def reboot(self):
         self.browser.click(self._reboot_selector)
-

--- a/test/helpers/progress.py
+++ b/test/helpers/progress.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-#
 # Copyright (C) 2022 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it

--- a/test/helpers/review.py
+++ b/test/helpers/review.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-#
 # Copyright (C) 2022 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it

--- a/test/helpers/step_logger.py
+++ b/test/helpers/step_logger.py
@@ -1,5 +1,6 @@
 import os
 
+
 class BrowserSnapshot():
     SNAPSHOT_NUMBER = 0
 
@@ -48,4 +49,3 @@ def log_step(snapshots=False, snapshot_before=False, snapshot_after=False, docst
             return result
         return wrapper
     return decorator
-

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -440,7 +440,11 @@ class StorageMountPointMapping(StorageDBus, StorageDestination):
             self.browser.wait_not_present(f"{main_selector}:contains({device})")
         self.toggle_mountpoint_row_device(row)
 
-    def unlock_device(self, passphrase, encrypted_devices=[], successfully_unlocked_devices=[]):
+    def unlock_device(self, passphrase, encrypted_devices=None, successfully_unlocked_devices=None):
+        if encrypted_devices is None:
+            encrypted_devices = []
+        if successfully_unlocked_devices is None:
+            successfully_unlocked_devices = []
         # FIXME: https://github.com/patternfly/patternfly-react/issues/9512
         b = self.browser
         for device in encrypted_devices:

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-#
 # Copyright (C) 2022 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -16,15 +14,14 @@
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import sys
 import re
+import sys
 
 HELPERS_DIR = os.path.dirname(__file__)
 sys.path.append(HELPERS_DIR)
 
 from installer import Installer, InstallerSteps  # pylint: disable=import-error
 from step_logger import log_step
-
 
 STORAGE_SERVICE = "org.fedoraproject.Anaconda.Modules.Storage"
 STORAGE_INTERFACE = STORAGE_SERVICE

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -34,6 +34,7 @@ DISK_INITIALIZATION_OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Storage/D
 
 id_prefix = "installation-method"
 
+
 class StorageDestination():
     def __init__(self, browser, machine):
         self._step = InstallerSteps.INSTALLATION_METHOD
@@ -309,7 +310,7 @@ class StorageDBus():
             {STORAGE_OBJECT_PATH} \
             {STORAGE_INTERFACE} CreatedPartitioning')
 
-        res = ret[ret.find("[")+1:ret.rfind("]")].split()
+        res = ret[ret.find("[") + 1:ret.rfind("]")].split()
         return [item.strip('"') for item in res]
 
     def dbus_set_initialization_mode(self, value):
@@ -382,7 +383,7 @@ class StorageMountPointMapping(StorageDBus, StorageDestination):
             self.check_mountpoint_row_format_type(row, format_type)
 
     def select_mountpoint(self, disks, encrypted=False):
-        self.browser.wait(lambda : self.disks_loaded(disks))
+        self.browser.wait(lambda: self.disks_loaded(disks))
 
         for disk in disks:
             current_selection = self.get_disk_selected(disk[0])
@@ -400,10 +401,10 @@ class StorageMountPointMapping(StorageDBus, StorageDestination):
             else:
                 self.browser.wait_not_present("#unlock-device-dialog")
 
-    def select_mountpoint_row_mountpoint(self, row,  mountpoint):
+    def select_mountpoint_row_mountpoint(self, row, mountpoint):
         self.browser.set_input_text(f"{self.table_row(row)} td[data-label='Mount point'] input", mountpoint)
 
-    def select_mountpoint_row_device(self, row,  device):
+    def select_mountpoint_row_device(self, row, device):
         selector = f"{self.table_row(row)} .pf-v5-c-select__toggle"
 
         self.browser.click(f"{selector}:not([disabled]):not([aria-disabled=true])")
@@ -414,10 +415,10 @@ class StorageMountPointMapping(StorageDBus, StorageDestination):
     def toggle_mountpoint_row_device(self, row):
         self.browser.click(f"{self.table_row(row)}-device-select-toggle")
 
-    def check_mountpoint_row_device(self, row,  device):
+    def check_mountpoint_row_device(self, row, device):
         self.browser.wait_text(f"{self.table_row(row)} .pf-v5-c-select__toggle-text", device)
 
-    def check_mountpoint_row_mountpoint(self, row,  mountpoint, constrained=True):
+    def check_mountpoint_row_mountpoint(self, row, mountpoint, constrained=True):
         if constrained:
             self.browser.wait_text(f"{self.table_row(row)}-mountpoint", mountpoint)
         else:

--- a/test/helpers/users.py
+++ b/test/helpers/users.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-#
 # Copyright (C) 2022 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -23,7 +21,6 @@ sys.path.append(HELPERS_DIR)
 
 from password import Password
 from step_logger import log_step
-
 
 USERS_SERVICE = "org.fedoraproject.Anaconda.Modules.Users"
 USERS_INTERFACE = USERS_SERVICE

--- a/test/helpers/users.py
+++ b/test/helpers/users.py
@@ -72,6 +72,7 @@ class UsersDBus():
 
         return ret.split()[1].strip() == "true"
 
+
 class Users(UsersDBus):
     def __init__(self, browser, machine):
         self.browser = browser
@@ -108,6 +109,7 @@ class Users(UsersDBus):
         password = "password"
         p.set_password(password)
         p.set_password_confirm(password + "" if valid else "X")
+
 
 def create_user(browser, machine):
     p = Password(browser, CREATE_ACCOUNT_ID_PREFIX)

--- a/test/helpers/utils.py
+++ b/test/helpers/utils.py
@@ -17,6 +17,7 @@
 
 import os
 
+
 def add_public_key(machine):
     with open(machine.identity_file + '.pub', 'r') as pub:
         public_key = pub.read()
@@ -26,10 +27,12 @@ def add_public_key(machine):
     machine.execute(f"chmod 700 {sysroot_ssh}")
     machine.write(authorized_keys, public_key, perm="0600")
 
+
 def pretend_live_iso(test, installer):
     installer.hidden_steps.extend([installer.steps.ACCOUNTS, installer.steps.WELCOME])
     test.restore_file('/run/anaconda/anaconda.conf')
     test.machine.execute("sed -i 's/type = BOOT_ISO/type = LIVE_OS/g' /run/anaconda/anaconda.conf")
+
 
 def get_pretty_name(machine):
     return machine.execute("cat /etc/os-release | grep PRETTY_NAME | cut -d '\"' -f 2 | tr -d '\n'")

--- a/test/helpers/utils.py
+++ b/test/helpers/utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-#
 # Copyright (C) 2023 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it

--- a/test/machine_install.py
+++ b/test/machine_install.py
@@ -19,8 +19,8 @@ import os
 import socket
 import subprocess
 import sys
-import time
 import tempfile
+import time
 
 WEBUI_TEST_DIR = os.path.dirname(__file__)
 ROOT_DIR = os.path.dirname(WEBUI_TEST_DIR)
@@ -31,9 +31,11 @@ sys.path.append(BOTS_DIR)
 sys.path.append(f'{BOTS_DIR}/machine')
 
 # pylint: disable=import-error
-from testvm import VirtMachine  # nopep8
-from testvm import Machine  # nopep8
 from machine_core import timeout
+from testvm import (
+    Machine,  # nopep8
+    VirtMachine,  # nopep8
+)
 
 # This env variable must be always set for anaconda webui tests.
 # In the anaconda environment /run/nologin always exists however cockpit test

--- a/test/run
+++ b/test/run
@@ -7,4 +7,5 @@ set -eux
 # linters are off by default for production builds, but we want to run them in CI
 export LINT=1
 
+make codecheck
 make integration-test

--- a/test/vm.install
+++ b/test/vm.install
@@ -19,7 +19,7 @@ missing_packages = "cockpit-ws cockpit-bridge fedora-logos python3-kickstart pyk
 # but it packs to many packages to updates.img
 missing_packages_incl_deps = "firefox"
 
-from machine.machine_core import machine_virtual  # NOQA: imported through parent.py
+from machine.machine_core import machine_virtual
 
 
 def download_from_copr(copr_repo, packages, machine):
@@ -51,7 +51,6 @@ def vm_install(image, verbose, quick):
             download_from_copr(f"packit/cockpit-project-cockpit-{cockpit_pr}", "cockpit-storaged", machine)
         else:
             packages_to_download += " cockpit-storaged"
-
 
         # Build anaconda-webui from SRPM unless we are testing a anaconda-webui PR scenario
         # from a different repo, then pull it from the anaconda-webui PR COPR repo
@@ -87,7 +86,9 @@ def vm_install(image, verbose, quick):
         # Then we can enable this only for the various scenarios above
         if packages_to_download is not None:
             machine.execute(f"dnf download --destdir /var/tmp/build/ {packages_to_download}", stdout=sys.stdout, timeout=300)
-        machine.execute(f"dnf download --resolve --setopt=install_weak_deps=False --destdir /var/tmp/build/ {missing_packages_incl_deps}", stdout=sys.stdout, timeout=300)
+        machine.execute(
+            f"dnf download --resolve --setopt=install_weak_deps=False --destdir /var/tmp/build/ {missing_packages_incl_deps}",
+            stdout=sys.stdout, timeout=300)
 
         # download rpms
         vm_rpms = machine.execute("find /var/tmp/build -name '*.rpm' -not -name '*.src.rpm'").strip().split()
@@ -114,5 +115,6 @@ def main():
     args = parser.parse_args()
 
     vm_install(args.image, args.verbose, args.quick)
+
 
 main()

--- a/test/webui_testvm.py
+++ b/test/webui_testvm.py
@@ -15,11 +15,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
+import argparse
 import signal
 import subprocess
-import argparse
 
-from machine_install import VirtInstallMachine, VirtInstallEFIMachine
+from machine_install import VirtInstallEFIMachine, VirtInstallMachine
 
 
 def cmd_cli():


### PR DESCRIPTION
This is useful to spot errors like the missing `import time`, and keep a consistent code style.

This also prepares us for the next step, see https://github.com/cockpit-project/starter-kit/commit/15be8835955f8