### PR TITLE
Move eslint/stylelint to static-code tests

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -41,7 +41,7 @@ Running eslint
 Anaconda Web UI uses `ESLint <https://eslint.org/>`_ to automatically check
 JavaScript code style in `.js` and `.jsx` files.
 
-The linter is executed within every build as a plugin of esbuild.
+ESLint is executed as part of `test/static-code`, aka. `make codecheck`.
 
 For developer convenience, the ESLint can be started explicitly by::
 
@@ -52,6 +52,24 @@ Violations of some rules can be fixed automatically by::
     npm run eslint:fix
 
 Rules configuration can be found in the `.eslintrc.json` file.
+
+Running stylelint
+------------------
+
+Cockpit uses `Stylelint <https://stylelint.io/>`_ to automatically check CSS code
+style in `.css` and `scss` files.
+
+Styleint is executed as part of `test/static-code`, aka. `make codecheck`.
+
+For developer convenience, the Stylelint can be started explicitly by::
+
+    npm run stylelint
+
+Violations of some rules can be fixed automatically by::
+
+    npm run stylelint:fix
+
+Rules configuration can be found in the `.stylelintrc.json` file.
 
 Development with rsync mode
 ---------------------------

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = 9dfaf9d08cab46b2bbd65cbfaabcf23440ce4e6c # 310.1 + 12 commits
+COCKPIT_REPO_COMMIT = 35c80af69f43b6676dc9f1de6c83a11600266c00 # 310.2 + 4 commits
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'

--- a/build.js
+++ b/build.js
@@ -9,14 +9,10 @@ import { cockpitCompressPlugin } from "./pkg/lib/esbuild-compress-plugin.js";
 import { cleanPlugin } from "./pkg/lib/esbuild-cleanup-plugin.js";
 import { cockpitPoEsbuildPlugin } from "./pkg/lib/cockpit-po-plugin.js";
 import { cockpitRsyncEsbuildPlugin } from "./pkg/lib/cockpit-rsync-plugin.js";
-import { eslintPlugin } from "./pkg/lib/esbuild-eslint-plugin.js";
-import { stylelintPlugin } from "./pkg/lib/esbuild-stylelint-plugin.js";
 import { sassPlugin } from "esbuild-sass-plugin";
 
 const production = process.env.NODE_ENV === "production";
 const watchMode = process.env.ESBUILD_WATCH === "true" || false;
-// linters dominate the build time, so disable them for production builds by default, but enable in watch mode
-const lint = process.env.LINT ? (process.env.LINT !== "0") : (watchMode || !production);
 /* List of directories to use when resolving import statements */
 const nodePaths = ["pkg/lib"];
 const outdir = "dist";
@@ -26,8 +22,6 @@ const packageJson = JSON.parse(fs.readFileSync("package.json"));
 
 const getTime = () => new Date().toTimeString()
         .split(" ")[0];
-
-const cwd = process.cwd();
 
 // similar to fs.watch(), but recursively watches all subdirectories
 function watchDirs (dir, onChange) {
@@ -75,12 +69,6 @@ const context = await esbuild.context({
     target: ["es2020"],
     plugins: [
         cleanPlugin(),
-        ...lint
-            ? [
-                stylelintPlugin({ filter: new RegExp(cwd + "/src/.*\\.(css?|scss?)$") }),
-                eslintPlugin({ filter: new RegExp(cwd + "/src/.*\\.(jsx?|js?)$") })
-            ]
-            : [],
         // Esbuild will only copy assets that are explicitly imported and used
         // in the code. This is a problem for index.html and manifest.json which are not imported
         copy({

--- a/firefox-theme/default/chrome/userChrome.css
+++ b/firefox-theme/default/chrome/userChrome.css
@@ -1,3 +1,6 @@
+/* type selector "tab" is not standard CSS */
+/* stylelint-disable selector-type-no-unknown */
+
 /* Hide things we're not going to use when there's only 1 tab */
 :has(#tabbrowser-tabs tab:only-of-type) :is(#tab-notification-deck, #PersonalToolbar, #statuspanel) {
   display: none;

--- a/firefox-theme/live/chrome/userChrome.css
+++ b/firefox-theme/live/chrome/userChrome.css
@@ -1,3 +1,6 @@
+/* type selector "tab" is not standard CSS */
+/* stylelint-disable selector-type-no-unknown */
+
 /* Hide things we're not going to use when there's only 1 tab */
 :has(#tabbrowser-tabs tab:only-of-type) :is(#tab-notification-deck, #PersonalToolbar, #statuspanel) {
   display: none;

--- a/test/run
+++ b/test/run
@@ -4,8 +4,5 @@
 
 set -eux
 
-# linters are off by default for production builds, but we want to run them in CI
-export LINT=1
-
 make codecheck
 make integration-test

--- a/test/webui_testvm.py
+++ b/test/webui_testvm.py
@@ -52,7 +52,7 @@ def cmd_cli():
             # rsync development files over so /usr/local/share/cockpit is created with a development version
             if args.rsync:
                 # Rather annoying the node_modules path needs to be explicitly added for webpack
-                subprocess.check_call(["npm", "run", "build"], env={'RSYNC': args.host, "PATH": "/usr/bin/:node_modules/.bin", "LINT": "0"})
+                subprocess.check_call(["npm", "run", "build"], env={'RSYNC': args.host, "PATH": "/usr/bin/:node_modules/.bin"})
         else:
             print("You can start the installer by running the following command on the terminal in the test VM:")
             print("liveinst --graphical --updates=http://10.0.2.2:%s/updates.img" % (machine.http_updates_img_port))


### PR DESCRIPTION
stylelint 16 causes a deadlock/crash in esbuild [1]. There's no movement
on that issue, and we want stylelint 16 to be able to support the
Browser Baseline 2023.

Follow https://github.com/cockpit-project/cockpit/commit/1a28b31828e and
move the linters into test/static-code. This also starts to lint files
which are outside of esbuild's realm, such as documentation and
examples.

[1] https://github.com/evanw/esbuild/issues/3542

Taken from https://github.com/cockpit-project/starter-kit/commit/15be8835955f8

---

This will unblock the next round of stylelint refresh, see PR #156 . It also unblocks keeping up with cockpit.git shared files, see #166