### PR TITLE
tests: cleanup journal before opening the report modal

### DIFF
--- a/test/check-basic
+++ b/test/check-basic
@@ -168,7 +168,7 @@ class TestBasic(anacondalib.VirtInstallMachineCase):
             b.wait(lambda: self.file_exists(logfile))
 
         # Reviewed log contains more than 100 lines
-        wait(lambda: int(m.execute(f"wc -l {logfile} | cut -d' ' -f1").strip()) > 100)
+        wait(lambda: int(m.execute(f"wc -l {logfile} | cut -d' ' -f1").strip()) > 1)
 
         # Test editing of the log
         user_text = "STRING_ADDED_BY_USER_TO_LOG"
@@ -187,6 +187,11 @@ class TestBasic(anacondalib.VirtInstallMachineCase):
         b.wait_not_present("#user-issue-bz-report-modal.pf-v5-c-modal-box")
 
         b.click("#toggle-kebab")
+
+        # Clean up the journal before we open Report dialog
+        # (Report dialog presents all journal in a textarea)
+        # to avoid crashing the test browser
+        m.execute("journalctl --rotate; journalctl --vacuum-time=1s")
 
         b.click("#about-modal-dropdown-item-report")
 
@@ -221,6 +226,11 @@ class TestBasic(anacondalib.VirtInstallMachineCase):
         # FIXME: Remove PF5 specific selector: https://github.com/patternfly/patternfly-react/issues/9512
         b.wait_not_present("#critical-error-bz-report-modal.pf-v5-c-modal-box")
 
+        # Clean up the journal before we open Report dialog
+        # (Report dialog presents all journal in a textarea)
+        # to avoid crashing the test browser
+        m.execute("journalctl --rotate; journalctl --vacuum-time=1s")
+
         s.rescan_disks()
 
         b.wait_visible("#critical-error-bz-report-modal.pf-v5-c-modal-box")
@@ -233,6 +243,11 @@ class TestBasic(anacondalib.VirtInstallMachineCase):
         i = Installer(b, m)
 
         i.open()
+
+        # Clean up the journal before we open Report dialog
+        # (Report dialog presents all journal in a textarea)
+        # to avoid crashing the test browser
+        m.execute("journalctl --rotate; journalctl --vacuum-time=1s")
 
         b.wait_not_present("#critical-error-bz-report-modal.pf-v5-c-modal-box")
 

--- a/test/check-language
+++ b/test/check-language
@@ -68,6 +68,12 @@ class TestLanguage(anacondalib.VirtInstallMachineCase):
         lang.select_locale("de_DE")
         lang.check_selected_locale("de_DE")
         i.reach(i.steps.INSTALLATION_METHOD)
+
+        # Clean up the journal before we open Report dialog
+        # (Report dialog presents all journal in a textarea)
+        # to avoid crashing the test browser
+        m.execute("journalctl --rotate; journalctl --vacuum-time=1s")
+
         s.rescan_disks()
 
         b.wait_in_text(


### PR DESCRIPTION
Seems like the chromium used for the tests crashes when the Report dialog gets opened with the full journal input.