### PR TITLE
storage: fix modal backdrops from modals from cockpit-storage to extend to full page

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -43,6 +43,28 @@ import { initialState, reducer, useReducerWithThunk } from "../reducer.js";
 const _ = cockpit.gettext;
 const N_ = cockpit.noop;
 
+const MaybeBackdrop = ({ children }) => {
+    const [hasDialogOpen, setHasDialogOpen] = useState(false);
+
+    useEffect(() => {
+        const handleStorageEvent = (event) => {
+            if (event.key === "cockpit_has_modal") {
+                setHasDialogOpen(event.newValue === "true");
+            }
+        };
+
+        window.addEventListener("storage", handleStorageEvent);
+
+        return () => window.removeEventListener("storage", handleStorageEvent);
+    }, []);
+
+    return (
+        <div className={hasDialogOpen ? "cockpit-has-modal" : ""}>
+            {children}
+        </div>
+    );
+};
+
 export const Application = () => {
     const [backendReady, setBackendReady] = useState(false);
     const [address, setAddress] = useState();
@@ -195,7 +217,9 @@ export const Application = () => {
     return (
         <WithDialogs>
             <LanguageContext.Provider value={{ language, setLanguage }}>
-                {page}
+                <MaybeBackdrop>
+                    {page}
+                </MaybeBackdrop>
             </LanguageContext.Provider>
         </WithDialogs>
     );

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -1,4 +1,5 @@
 @import "global-variables";
+@import "@patternfly/patternfly/components/Backdrop/backdrop.scss";
 
 // Copied from cockpit/pkg/lib/page.scss instead of including it in its entirety:
 // Let PF4 handle the scrolling through page component otherwise we might get double scrollbar
@@ -38,4 +39,26 @@ html:not(.index-page) body {
 // Nested tables showing partitions in the local standards disks table don't need extra padding
 .ct-table .pf-v5-c-table__expandable-row-content {
   padding: 0;
+}
+
+// Simulate Backdrop behavior for modals in the iframe
+%iframe-zindex {
+  position: relative;
+  z-index: 10;
+}
+
+iframe {
+  @extend %iframe-zindex;
+}
+
+// Simulate a PF background scrim
+.cockpit-has-modal .pf-v5-c-page__main-section {
+  @extend %iframe-zindex;
+
+  &::after {
+    @extend .pf-v5-c-backdrop;
+    --pf-v5-c-backdrop--Position: absolute;
+    content: "";
+    z-index: 9;
+  }
 }

--- a/test/check-storage
+++ b/test/check-storage
@@ -1108,6 +1108,14 @@ class TestStorageCockpitIntegration(anacondalib.VirtInstallMachineCase, StorageC
         b._wait_present("#storage.ct-page-fill")
 
         self.click_dropdown(self.card_row("Storage", 1), "Create partition table")
+        # Pixel test the cockpit storage view, modal backdrops should cover the whole screen
+        b.switch_to_top()
+        b.assert_pixels(
+            "#app",
+            "storage-editor",
+            ignore=anacondalib.pixel_tests_ignore,
+        )
+        b.switch_to_frame("cockpit-storage")
         self.confirm()
 
         self.click_dropdown(self.card_row("Storage", 2), "Create partition")


### PR DESCRIPTION
Resolves: rhbz#2264015

* [x] Blocked on: https://github.com/cockpit-project/cockpit/pull/20046
* [x] CSS is still  not working