### PR TITLE
tests: ignore logo in the tests everywhere

### DIFF
--- a/test/check-progress
+++ b/test/check-progress
@@ -48,7 +48,7 @@ class TestInstallationProgress(anacondalib.VirtInstallMachineCase):
         b.assert_pixels(
             "#app",
             "installation-progress-complete",
-            ignore=["#betanag-icon"],
+            ignore=[".logo", "#betanag-icon"],
         )
 
         self.handleReboot()


### PR DESCRIPTION
Last missing pixel tests was the in progress, which was sometimes failing. The logo sometimes fails to load in the tests.