### PR TITLE
storage: keep all scenarios in the partitioning object mapping

### DIFF
--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -69,7 +69,10 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtim
 
     useEffect(() => {
         if (storageScenarioId && storageData.partitioning.path) {
-            setScenarioPartitioningMapping({ [storageScenarioId]: storageData.partitioning.path });
+            setScenarioPartitioningMapping(_scenarioPartitioningMapping => ({
+                ..._scenarioPartitioningMapping,
+                [storageScenarioId]: storageData.partitioning.path
+            }));
         }
     }, [storageData.partitioning.path, storageScenarioId]);
 

--- a/test/check-storage
+++ b/test/check-storage
@@ -1128,6 +1128,13 @@ class TestStorageCockpitIntegration(anacondalib.VirtInstallMachineCase, StorageC
         s.return_to_installation()
         s.return_to_installation_confirm()
 
+        s.check_partitioning_selected("use-configured-storage")
+
+        # Check that choosing another storage scenario without diving into that,
+        # preserves the visibility of "Use configured storage"
+        s.set_partitioning("erase-all")
+        s.wait_scenario_available("use-configured-storage")
+
         s.set_partitioning("use-configured-storage")
 
         self.addCleanup(lambda: dbus_reset_users(m))


### PR DESCRIPTION
This prevents the 'Use configured storage' scenario from disappearing when selecting another scenario. The 'Use configured storage' should disappear when the applied partitioning is not longer the one created from the storage page.