### PR TITLE
storage: show the partitioning request review for the 'Use configured storage'

### DIFF
--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -119,6 +119,7 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtim
                 diskSelection: storageData.diskSelection,
                 dispatch,
                 partitioning: storageData.partitioning.path,
+                requests: storageData.partitioning.requests,
                 scenarioPartitioningMapping,
                 storageScenarioId,
                 setStorageScenarioId: (scenarioId) => {

--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -288,6 +288,7 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtim
               deviceData={storageData.devices}
               dispatch={dispatch}
               onCritFail={onCritFail}
+              requests={storageData.partitioning.requests}
               scenarioPartitioningMapping={scenarioPartitioningMapping}
               selectedDisks={selectedDisks}
               setShowStorage={setShowStorage}

--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -52,7 +52,7 @@ import { SystemTypeContext, OsReleaseContext } from "./Common.jsx";
 const _ = cockpit.gettext;
 const N_ = cockpit.noop;
 
-export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtimeData, onCritFail, onJsError, showStorage, setShowStorage, title, conf }) => {
+export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtimeData, onCritFail, showStorage, setShowStorage, title, conf }) => {
     const [isFormDisabled, setIsFormDisabled] = useState(false);
     const [isFormValid, setIsFormValid] = useState(false);
     const [reusePartitioning, setReusePartitioning] = useState(false);
@@ -287,7 +287,6 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtim
               deviceData={storageData.devices}
               dispatch={dispatch}
               onCritFail={onCritFail}
-              onJsError={onJsError}
               scenarioPartitioningMapping={scenarioPartitioningMapping}
               selectedDisks={selectedDisks}
               setShowStorage={setShowStorage}

--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -22,7 +22,6 @@ import {
     DescriptionList, DescriptionListGroup,
     DescriptionListTerm, DescriptionListDescription,
     HelperText, HelperTextItem,
-    List, ListItem,
     Modal, ModalVariant,
     Stack,
 } from "@patternfly/react-core";
@@ -32,10 +31,10 @@ import {
     getPartitioningRequest,
     getPartitioningMethod,
 } from "../../apis/storage_partitioning.js";
-import { checkDeviceInSubTree } from "../../helpers/storage.js";
 
 import { getScenario } from "../storage/InstallationScenario.jsx";
 import { OsReleaseContext } from "../Common.jsx";
+import { StorageReview } from "./StorageReview.jsx";
 
 import "./ReviewConfiguration.scss";
 
@@ -56,46 +55,6 @@ const ReviewDescriptionList = ({ children }) => {
         >
             {children}
         </DescriptionList>
-    );
-};
-
-const DeviceRow = ({ deviceData, disk, requests }) => {
-    const data = deviceData[disk];
-    const name = data.name.v;
-
-    const renderRow = row => {
-        const name = row["device-spec"];
-        const action = (
-            row.reformat
-                ? (row["format-type"] ? cockpit.format(_("format as $0"), row["format-type"]) : null)
-                : ((row["format-type"] === "biosboot") ? row["format-type"] : _("mount"))
-        );
-        const mount = row["mount-point"] || null;
-        const actions = [action, mount].filter(Boolean).join(", ");
-        const size = cockpit.format_bytes(deviceData[name].size.v);
-
-        return (
-            <ListItem className="pf-v5-u-font-size-s" key={name}>
-                {name}, {size}: {actions}
-            </ListItem>
-        );
-    };
-
-    const partitionRows = requests?.filter(req => {
-        if (!req.reformat && req["mount-point"] === "") {
-            return false;
-        }
-
-        return checkDeviceInSubTree({ device: req["device-spec"], rootDevice: name, deviceData });
-    }).map(renderRow) || [];
-
-    return (
-        <Stack id={`disk-${name}`} hasGutter>
-            <span>{cockpit.format_bytes(data.size.v)} {name} {"(" + data.description.v + ")"}</span>
-            <List>
-                {partitionRows}
-            </List>
-        </Stack>
     );
 };
 
@@ -176,16 +135,12 @@ export const ReviewConfiguration = ({ deviceData, diskSelection, language, local
                     </DescriptionListTerm>
                     <DescriptionListDescription id={idPrefix + "-target-storage"}>
                         <Stack hasGutter>
-                            {diskSelection.selectedDisks.map(disk => {
-                                return (
-                                    <DeviceRow
-                                      key={disk}
-                                      deviceData={deviceData}
-                                      disk={disk}
-                                      requests={["mount-point-mapping", "use-configured-storage"].includes(storageScenarioId) ? requests : null}
-                                    />
-                                );
-                            })}
+                            <StorageReview
+                              deviceData={deviceData}
+                              requests={requests}
+                              selectedDisks={diskSelection.selectedDisks}
+                              storageScenarioId={storageScenarioId}
+                            />
                         </Stack>
                     </DescriptionListDescription>
                 </DescriptionListGroup>

--- a/src/components/review/StorageReview.jsx
+++ b/src/components/review/StorageReview.jsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from "cockpit";
+import React from "react";
+
+import {
+    List, ListItem,
+    Stack,
+} from "@patternfly/react-core";
+
+import { checkDeviceInSubTree } from "../../helpers/storage.js";
+
+const _ = cockpit.gettext;
+
+export const StorageReview = ({ selectedDisks, deviceData, requests, storageScenarioId }) => {
+    return (
+        <>
+            {selectedDisks.map(disk => {
+                return (
+                    <DeviceRow
+                      key={disk}
+                      deviceData={deviceData}
+                      disk={disk}
+                      requests={["mount-point-mapping", "use-configured-storage"].includes(storageScenarioId) ? requests : null}
+                    />
+                );
+            })}
+        </>
+    );
+};
+
+const DeviceRow = ({ deviceData, disk, requests }) => {
+    const data = deviceData[disk];
+    const name = data.name.v;
+
+    const renderRow = row => {
+        const name = row["device-spec"];
+        const action = (
+            row.reformat
+                ? (row["format-type"] ? cockpit.format(_("format as $0"), row["format-type"]) : null)
+                : ((row["format-type"] === "biosboot") ? row["format-type"] : _("mount"))
+        );
+        const mount = row["mount-point"] || null;
+        const actions = [action, mount].filter(Boolean).join(", ");
+        const size = cockpit.format_bytes(deviceData[name].size.v);
+
+        return (
+            <ListItem className="pf-v5-u-font-size-s" key={name}>
+                {name}, {size}: {actions}
+            </ListItem>
+        );
+    };
+
+    const partitionRows = requests?.filter(req => {
+        if (!req.reformat && req["mount-point"] === "") {
+            return false;
+        }
+
+        return checkDeviceInSubTree({ device: req["device-spec"], rootDevice: name, deviceData });
+    }).map(renderRow) || [];
+
+    return (
+        <Stack id={`disk-${name}`} hasGutter>
+            <span>{cockpit.format_bytes(data.size.v)} {name} {"(" + data.description.v + ")"}</span>
+            <List>
+                {partitionRows}
+            </List>
+        </Stack>
+    );
+};

--- a/src/components/storage/CockpitStorageIntegration.jsx
+++ b/src/components/storage/CockpitStorageIntegration.jsx
@@ -33,6 +33,7 @@ import {
     Modal,
     PageSection,
     PageSectionVariants,
+    Stack,
     Text,
     TextContent,
     Title,
@@ -92,6 +93,7 @@ export const CockpitStorageIntegration = ({
     deviceData,
     dispatch,
     onCritFail,
+    requests,
     setShowStorage,
 }) => {
     const [showDialog, setShowDialog] = useState(false);
@@ -146,6 +148,7 @@ export const CockpitStorageIntegration = ({
               deviceData={deviceData}
               dispatch={dispatch}
               onCritFail={onCritFail}
+              requests={requests}
               scenarioAvailability={scenarioAvailability}
               scenarioPartitioningMapping={scenarioPartitioningMapping}
               selectedDisks={selectedDisks}
@@ -216,6 +219,7 @@ const CheckStorageDialog = ({
     deviceData,
     dispatch,
     onCritFail,
+    requests,
     scenarioPartitioningMapping,
     selectedDisks,
     setShowDialog,
@@ -242,6 +246,27 @@ const CheckStorageDialog = ({
 
         return availability.available;
     }, [deviceData, mountPointConstraints, newMountPoints, scenarioPartitioningMapping]);
+
+    const useConfiguredStorageReview = useMemo(() => {
+        const availability = checkConfiguredStorage({
+            deviceData,
+            mountPointConstraints,
+            newMountPoints,
+            requests,
+            scenarioPartitioningMapping,
+            selectedDisks,
+            storageScenarioId: "use-configured-storage"
+        });
+
+        return availability.review;
+    }, [
+        deviceData,
+        mountPointConstraints,
+        newMountPoints,
+        requests,
+        scenarioPartitioningMapping,
+        selectedDisks,
+    ]);
 
     const useFreeSpace = useMemo(() => {
         const availability = checkUseFreeSpace({ diskFreeSpace, diskTotalSpace, requiredSize });
@@ -430,8 +455,15 @@ const CheckStorageDialog = ({
                     {storageRequirementsNotMet ? error?.message : null}
                     <HelperText>
                         {!storageRequirementsNotMet &&
-                        <HelperTextItem variant="success" hasIcon>
-                            {_("Current configuration can be used for installation.")}
+                        <HelperTextItem variant="success" isDynamic>
+                            {useConfiguredStorage
+                                ? (
+                                    <Stack hasGutter>
+                                        <span>{_("Detected valid storage layout:")}</span>
+                                        {useConfiguredStorageReview}
+                                    </Stack>
+                                )
+                                : _("Free space requirements met")}
                         </HelperTextItem>}
                     </HelperText>
                 </>}

--- a/src/components/storage/CockpitStorageIntegration.jsx
+++ b/src/components/storage/CockpitStorageIntegration.jsx
@@ -92,7 +92,6 @@ export const CockpitStorageIntegration = ({
     deviceData,
     dispatch,
     onCritFail,
-    onJsError,
     setShowStorage,
 }) => {
     const [showDialog, setShowDialog] = useState(false);
@@ -105,7 +104,7 @@ export const CockpitStorageIntegration = ({
         });
 
         resetPartitioning().then(() => setNeedsResetPartitioning(false), onCritFail);
-    }, [onCritFail, onJsError]);
+    }, [onCritFail]);
 
     return (
         <>

--- a/src/components/storage/CockpitStorageIntegration.scss
+++ b/src/components/storage/CockpitStorageIntegration.scss
@@ -46,3 +46,9 @@ ul.cockpit-storage-integration-requirements-hint-list {
 .cockpit-storage-integration-check-storage-dialog--loading svg.pf-v5-c-spinner {
     --pf-v5-c-spinner--diameter: var(--pf-v5-c-spinner--m-lg--diameter);
 }
+
+.cockpit-storage-integration-check-storage-dialog {
+    .pf-v5-c-helper-text__item-text {
+        color: unset;
+    }
+}

--- a/src/components/storage/InstallationMethod.jsx
+++ b/src/components/storage/InstallationMethod.jsx
@@ -38,6 +38,7 @@ export const InstallationMethod = ({
     isFormDisabled,
     onCritFail,
     partitioning,
+    requests,
     scenarioPartitioningMapping,
     setIsFormDisabled,
     setIsFormValid,
@@ -73,6 +74,7 @@ export const InstallationMethod = ({
               onCritFail={onCritFail}
               scenarioPartitioningMapping={scenarioPartitioningMapping}
               partitioning={partitioning}
+              requests={requests}
               setIsFormValid={setIsFormValid}
               setStorageScenarioId={setStorageScenarioId}
               storageScenarioId={storageScenarioId}

--- a/src/components/storage/InstallationScenario.jsx
+++ b/src/components/storage/InstallationScenario.jsx
@@ -31,6 +31,8 @@ import {
     setInitializationMode,
 } from "../../apis/storage_disk_initialization.js";
 
+import { StorageReview } from "../review/StorageReview.jsx";
+
 import "./InstallationScenario.scss";
 
 const _ = cockpit.gettext;
@@ -99,7 +101,16 @@ const checkMountPointMapping = ({ hasFilesystems, duplicateDeviceNames }) => {
     return availability;
 };
 
-export const checkConfiguredStorage = ({ deviceData, mountPointConstraints, partitioning, newMountPoints, scenarioPartitioningMapping }) => {
+export const checkConfiguredStorage = ({
+    deviceData,
+    mountPointConstraints,
+    partitioning,
+    newMountPoints,
+    requests,
+    scenarioPartitioningMapping,
+    selectedDisks,
+    storageScenarioId,
+}) => {
     const availability = new AvailabilityState();
 
     const currentPartitioningMatches = partitioning !== undefined && scenarioPartitioningMapping["use-configured-storage"] === partitioning;
@@ -144,6 +155,15 @@ export const checkConfiguredStorage = ({ deviceData, mountPointConstraints, part
                         return false;
                     })
         )
+    );
+
+    availability.review = deviceData && requests && selectedDisks && storageScenarioId && (
+        <StorageReview
+          deviceData={deviceData}
+          requests={requests}
+          selectedDisks={selectedDisks}
+          storageScenarioId={storageScenarioId}
+        />
     );
 
     return availability;
@@ -230,6 +250,7 @@ const InstallationScenarioSelector = ({
     isFormDisabled,
     onCritFail,
     partitioning,
+    requests,
     scenarioPartitioningMapping,
     selectedDisks,
     setIsFormValid,
@@ -256,14 +277,17 @@ const InstallationScenarioSelector = ({
 
             for (const scenario of scenarios) {
                 const availability = scenario.check({
+                    deviceData,
                     diskFreeSpace,
                     diskTotalSpace,
                     duplicateDeviceNames,
                     hasFilesystems,
                     mountPointConstraints,
                     partitioning,
+                    requests,
                     requiredSize,
                     scenarioPartitioningMapping,
+                    selectedDisks,
                     storageScenarioId,
                 });
                 newAvailability[scenario.id] = availability;
@@ -271,15 +295,18 @@ const InstallationScenarioSelector = ({
             return newAvailability;
         });
     }, [
+        deviceData,
         diskFreeSpace,
         diskTotalSpace,
         duplicateDeviceNames,
         hasFilesystems,
         mountPointConstraints,
         partitioning,
+        requests,
         requiredSize,
-        storageScenarioId,
         scenarioPartitioningMapping,
+        selectedDisks,
+        storageScenarioId,
     ]);
 
     useEffect(() => {
@@ -343,6 +370,7 @@ const InstallationScenarioSelector = ({
                       {scenarioAvailability[scenario.id].reason}
                   </span>}
                   {selectedDisks.length > 0 && <span className={idPrefix + "-scenario-disabled-shorthint"}>{scenarioAvailability[scenario.id].hint}</span>}
+                  {scenarioAvailability[scenario.id].review && <span className={idPrefix + "-scenario-review"}>{scenarioAvailability[scenario.id].review}</span>}
               </>
           } />
     ));
@@ -357,6 +385,7 @@ export const InstallationScenario = ({
     isFormDisabled,
     onCritFail,
     partitioning,
+    requests,
     scenarioPartitioningMapping,
     selectedDisks,
     setIsFormValid,
@@ -377,6 +406,7 @@ export const InstallationScenario = ({
                   isFormDisabled={isFormDisabled}
                   onCritFail={onCritFail}
                   partitioning={partitioning}
+                  requests={requests}
                   scenarioPartitioningMapping={scenarioPartitioningMapping}
                   selectedDisks={selectedDisks}
                   setIsFormValid={setIsFormValid}

--- a/src/components/storage/InstallationScenario.scss
+++ b/src/components/storage/InstallationScenario.scss
@@ -7,5 +7,9 @@
       font-weight: var(--pf-v5-global--FontWeight--bold);
       margin-inline-end: var(--pf-v5-global--spacer--xs);
     }
+
+    .installation-method-scenario-review {
+        color: var(--pf-v5-c-radio__description--Color);
+    }
   }
 }

--- a/test/check-storage
+++ b/test/check-storage
@@ -1154,7 +1154,6 @@ class TestStorageCockpitIntegration(anacondalib.VirtInstallMachineCase, StorageC
 
         self.addCleanup(m.execute, f"vgremove -y -ff {vgname}")
 
-        disk = "/dev/vda"
         dev = "vda"
 
         i.open()
@@ -1208,7 +1207,18 @@ class TestStorageCockpitIntegration(anacondalib.VirtInstallMachineCase, StorageC
         # Exit the cockpit-storage iframe
         b.switch_to_top()
 
+        def checkStorageReview():
+            disk = "vda"
+            r.check_disk(disk, "16.1 GB vda (0x1af4)")
+            r.check_disk_row(disk, "vda2, 1.07 GB: mount, /boot")
+            r.check_disk_row(disk, f"{vgname}-root, 6.01 GB: mount, /")
+            r.check_disk_row(disk, f"{vgname}-home, 8.12 GB: mount, /home")
+            r.check_disk_row(disk, f"{vgname}-swap, 898 MB: mount, swap")
+
         s.return_to_installation()
+
+        # verify storage layout review in Cockpit storage exit dialog
+        checkStorageReview()
         s.return_to_installation_confirm()
 
         s.set_partitioning("use-configured-storage")
@@ -1217,13 +1227,7 @@ class TestStorageCockpitIntegration(anacondalib.VirtInstallMachineCase, StorageC
         i.reach(i.steps.REVIEW)
 
         # verify review screen
-        disk = "vda"
-        r.check_disk(disk, "16.1 GB vda (0x1af4)")
-
-        r.check_disk_row(disk, "vda2, 1.07 GB: mount, /boot")
-        r.check_disk_row(disk, f"{vgname}-root, 6.01 GB: mount, /")
-        r.check_disk_row(disk, f"{vgname}-home, 8.12 GB: mount, /home")
-        r.check_disk_row(disk, f"{vgname}-swap, 898 MB: mount, swap")
+        checkStorageReview()
 
     @nondestructive
     def testBtrfsSubvolumes(self):

--- a/test/check-storage
+++ b/test/check-storage
@@ -1219,6 +1219,11 @@ class TestStorageCockpitIntegration(anacondalib.VirtInstallMachineCase, StorageC
 
         # verify storage layout review in Cockpit storage exit dialog
         checkStorageReview()
+        b.assert_pixels(
+            "#cockpit-storage-integration-check-storage-dialog",
+            "cockpit-storage-integration-check-storage-dialog-LVM",
+            ignore=anacondalib.pixel_tests_ignore,
+        )
         s.return_to_installation_confirm()
 
         s.set_partitioning("use-configured-storage")


### PR DESCRIPTION
When the user exits the cockpit-storage, they need to see somewhere a review of their actions. Show that as a hint item, in the scenario description.

![Screen Shot 2024-02-18 at 22 31 49](https://github.com/rhinstaller/anaconda-webui/assets/14921356/14f50070-d3ca-4d18-9000-0e585675c4d6)
