### PR TITLE
WIP: Trying to de-emphasize the option descriptions.

### DIFF
--- a/src/components/storage/InstallationScenario.jsx
+++ b/src/components/storage/InstallationScenario.jsx
@@ -70,9 +70,9 @@ export const checkUseFreeSpace = ({ diskFreeSpace, diskTotalSpace, requiredSize 
     }
     if (diskFreeSpace < requiredSize) {
         availability.available = false;
-        availability.reason = _("Not enough free space on the selected disks.");
+        availability.reason = _("Not enough free space.");
         availability.hint = cockpit.format(
-            _("To use this option, resize or remove existing partitions to free up at least $0."),
+            _("At least $0 of space is required."),
             cockpit.format_bytes(requiredSize)
         );
     } else {
@@ -335,14 +335,14 @@ const InstallationScenarioSelector = ({
           isDisabled={!scenarioAvailability[scenario.id].available || isFormDisabled}
           isChecked={storageScenarioId === scenario.id}
           onChange={() => onScenarioToggled(scenario.id)}
-          description={scenario.detail}
-          body={
+          description={
               <>
+                  <p>{scenario.detail}</p>
                   {selectedDisks.length > 0 && scenarioAvailability[scenario.id].reason &&
-                  <span className={idPrefix + "-scenario-disabled-reason"}>
+                  <p className={idPrefix + "-scenario-disabled-reason"}>
                       {scenarioAvailability[scenario.id].reason}
-                  </span>}
-                  {selectedDisks.length > 0 && <span className={idPrefix + "-scenario-disabled-shorthint"}>{scenarioAvailability[scenario.id].hint}</span>}
+                  </p>}
+                  {selectedDisks.length > 0 && <p className={idPrefix + "-scenario-disabled-shorthint"}>{scenarioAvailability[scenario.id].hint}</p>}
               </>
           } />
     ));


### PR DESCRIPTION
I'm trying to make the options less emphasized, as having them with darker text and bolding make them too emphasized, especially when the option is in an inactive state.

This is especially an issue when some other item is selected, such as "Use configured storage". The "Not enough free space" message _really_ jumps out and looks relevant to the situation due to it being:
1. Darker (not using the same description text color)
2. Bolder.
3. Very wordy.

Here's what I'm trying to do (mockup):

![Welcome, disk, method_ configured storage replacement (8)](https://github.com/rhinstaller/anaconda-webui/assets/10246/cb342231-a966-4a23-901d-12401c67a2ac)


Here's what it currently looks like (outside of this PR):

![image](https://github.com/rhinstaller/anaconda-webui/assets/10246/c388bed0-e3c4-4c2e-bffe-e79e56c1bad2)
