### PR TITLE
test: Cockpit now leaves LUKS devices open after creation

### DIFF
--- a/test/check-storage
+++ b/test/check-storage
@@ -1116,11 +1116,6 @@ class TestStorageCockpitIntegration(anacondalib.VirtInstallMachineCase, StorageC
             "passphrase": "redhat",
             "passphrase2": "redhat",
         })
-        # FIXME: Cockpit should leave open LUKS devices afetr creation
-        self.click_card_row("Storage", name=(dev + "3"))
-        b.click(self.card_button("Filesystem", "Mount"))
-        self.dialog({"passphrase": "redhat"})
-        self.wait_mounted("ext4 filesystem")
 
         # Exit the cockpit-storage iframe
         b.switch_to_top()


### PR DESCRIPTION
The workaround can be removed.

This needs to go in together with https://github.com/cockpit-project/cockpit/pull/20016.