### PR TITLE
tests: ignore pixel area showing the exact disk size the installation needs

### DIFF
--- a/test/check-storage
+++ b/test/check-storage
@@ -1113,7 +1113,7 @@ class TestStorageCockpitIntegration(anacondalib.VirtInstallMachineCase, StorageC
         b.assert_pixels(
             "#app",
             "storage-editor",
-            ignore=anacondalib.pixel_tests_ignore,
+            ignore=[*anacondalib.pixel_tests_ignore, ".cockpit-storage-integration-requirements-hint"],
         )
         b.switch_to_frame("cockpit-storage")
         self.confirm()


### PR DESCRIPTION
This can slightly change with payload updates, let's not fail on this.