### PR TITLE
Move stepNotification to the AnacondaPage component

### DIFF
--- a/src/components/AnacondaPage.jsx
+++ b/src/components/AnacondaPage.jsx
@@ -14,10 +14,12 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with This program; If not, see <http://www.gnu.org/licenses/>.
  */
-import React from "react";
+import React, { cloneElement, useState } from "react";
 import { Alert, Stack, Title } from "@patternfly/react-core";
 
-export const AnacondaPage = ({ children, step, stepNotification, title }) => {
+export const AnacondaPage = ({ children, step, title }) => {
+    const [stepNotification, setStepNotification] = useState();
+
     return (
         <Stack hasGutter>
             {title && <Title headingLevel="h2">{title}</Title>}
@@ -27,7 +29,7 @@ export const AnacondaPage = ({ children, step, stepNotification, title }) => {
                   title={stepNotification.message}
                   variant="danger"
                 />}
-            {children}
+            {cloneElement(children, { idPrefix: step, setStepNotification })}
         </Stack>
     );
 };

--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -35,7 +35,6 @@ import { CockpitStorageIntegration } from "./storage/CockpitStorageIntegration.j
 export const AnacondaWizard = ({ dispatch, onCritFail, setShowStorage, showStorage }) => {
     const [isFormDisabled, setIsFormDisabled] = useState(false);
     const [isFormValid, setIsFormValid] = useState(false);
-    const [stepNotification, setStepNotification] = useState();
     const [showWizard, setShowWizard] = useState(true);
     const [currentStepId, setCurrentStepId] = useState();
 
@@ -72,12 +71,8 @@ export const AnacondaWizard = ({ dispatch, onCritFail, setShowStorage, showStora
             if (s.component) {
                 stepProps = {
                     children: (
-                        <AnacondaPage step={s.id} title={s.title} stepNotification={stepNotification}>
-                            <s.component
-                              idPrefix={s.id}
-                              setStepNotification={ex => setStepNotification({ step: s.id, ...ex })}
-                              {...componentProps}
-                            />
+                        <AnacondaPage step={s.id} title={s.title}>
+                            <s.component {...componentProps} />
                         </AnacondaPage>
                     ),
                     ...stepProps
@@ -146,7 +141,6 @@ export const AnacondaWizard = ({ dispatch, onCritFail, setShowStorage, showStora
                 setIsFormDisabled,
                 setIsFormValid,
                 setShowWizard,
-                setStepNotification,
             }}>
                 <Wizard
                   id="installation-wizard"

--- a/src/components/AnacondaWizardFooter.jsx
+++ b/src/components/AnacondaWizardFooter.jsx
@@ -49,7 +49,6 @@ export const AnacondaWizardFooter = ({
         isFormValid,
         setIsFormDisabled,
         setIsFormValid,
-        setStepNotification
     } = useContext(FooterContext);
 
     const onNextButtonClicked = () => {
@@ -60,7 +59,6 @@ export const AnacondaWizardFooter = ({
                 isFormValid,
                 setIsFormDisabled,
                 setIsFormValid,
-                setStepNotification,
             });
         } else {
             goToNextStep();

--- a/src/components/storage/DiskEncryption.jsx
+++ b/src/components/storage/DiskEncryption.jsx
@@ -66,6 +66,7 @@ const DiskEncryption = ({
     idPrefix,
     isInProgress,
     setIsFormValid,
+    setStepNotification,
 }) => {
     const { partitioning } = useContext(StorageContext);
     const request = partitioning?.requests?.[0];
@@ -75,7 +76,10 @@ const DiskEncryption = ({
     const luksPolicy = useContext(RuntimeContext).passwordPolicies.luks;
 
     // Display custom footer
-    const getFooter = useMemo(() => <CustomFooter encrypt={isEncrypted} encryptPassword={password} />, [isEncrypted, password]);
+    const getFooter = useMemo(
+        () => <CustomFooter encrypt={isEncrypted} encryptPassword={password} setStepNotification={setStepNotification} />,
+        [isEncrypted, password, setStepNotification]
+    );
     useWizardFooter(getFooter);
 
     const encryptedDevicesCheckbox = content => (
@@ -128,9 +132,9 @@ const DiskEncryption = ({
     );
 };
 
-const CustomFooter = ({ encrypt, encryptPassword }) => {
+const CustomFooter = ({ encrypt, encryptPassword, setStepNotification }) => {
     const step = usePage({}).id;
-    const onNext = ({ goToNextStep, setIsFormDisabled, setStepNotification }) => {
+    const onNext = ({ goToNextStep, setIsFormDisabled }) => {
         return applyStorage({
             encrypt,
             encryptPassword,

--- a/src/components/storage/MountPointMapping.jsx
+++ b/src/components/storage/MountPointMapping.jsx
@@ -681,7 +681,7 @@ const MountPointMapping = ({
     );
 
     // Display custom footer
-    const getFooter = useMemo(() => <CustomFooter />, []);
+    const getFooter = useMemo(() => <CustomFooter setStepNotification={setStepNotification} />, [setStepNotification]);
     useWizardFooter(getFooter);
 
     const showLuksUnlock = lockedLUKSDevices?.length > 0 && !skipUnlock;
@@ -710,10 +710,10 @@ const MountPointMapping = ({
     );
 };
 
-const CustomFooter = () => {
+const CustomFooter = ({ setStepNotification }) => {
     const { partitioning } = useContext(StorageContext);
     const step = usePage().id;
-    const onNext = ({ goToNextStep, setIsFormDisabled, setStepNotification }) => {
+    const onNext = ({ goToNextStep, setIsFormDisabled }) => {
         return applyStorage({
             onFail: ex => {
                 console.error(ex);


### PR DESCRIPTION
These notifications are page specific are belong better to the page wrapper, rather than the global AnacondaWizard component.

With this change the notifications are now reset / removed when changing pages. This is the desired behavior, as failures should appear only dynamically after clicking 'Next'.