### PR TITLE
Revert "tests: download cockpit-storaged from custom COPR till release 311"

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -49,8 +49,7 @@ def vm_install(image, verbose, quick):
             # cockpit-storaged is also available in the default rawhide compose, make sure we don't pull it from there
             download_from_copr(f"packit/cockpit-project-cockpit-{cockpit_pr}", "cockpit-storaged", machine)
         else:
-            # FIXME: Download cockpit-storaged from custom COPR till release 311 is available in rawhide
-            download_from_copr("@cockpit/main-builds", "cockpit-storaged", machine)
+            packages_to_download += " cockpit-storaged"
 
         # Build anaconda-webui from SRPM unless we are testing a anaconda-webui PR scenario
         # from a different repo, then pull it from the anaconda-webui PR COPR repo


### PR DESCRIPTION
This reverts commit fe4a11f53d07014407e238ff5acce0ca8ea12ea3.