### PR TITLE
test: Reset the language at the start of each test

### DIFF
--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -50,6 +50,8 @@ class VirtInstallMachineCase(MachineCase):
 
         super().setUp()
 
+        self.resetLanguage()
+
         self.allow_journal_messages('.*cockpit.bridge-WARNING: Could not start ssh-agent.*')
         self.installation_finished = False
 


### PR DESCRIPTION
Running tests locally would otherwise use geolocation to determine the language, and might end up putting the UI into Finnish.  The tests of course expect English button labels, etc.