### PR TITLE
tests: some improvements for non-destructive tests

### DIFF
--- a/src/apis/storage.js
+++ b/src/apis/storage.js
@@ -98,9 +98,8 @@ export class StorageClient {
 
         const partitioning = await getProperty("CreatedPartitioning");
         if (partitioning.length !== 0) {
-            for (const path of partitioning) {
-                await this.dispatch(getPartitioningDataAction({ partitioning: path }));
-            }
+            const lastPartitioning = partitioning[partitioning.length - 1];
+            await this.dispatch(getPartitioningDataAction({ partitioning: lastPartitioning }));
         }
         await this.dispatch(getDevicesAction());
         await this.dispatch(getDiskSelectionAction());

--- a/test/check-storage
+++ b/test/check-storage
@@ -102,6 +102,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         # Disk Encryption
 
         i.check_next_disabled(False)
+        s.check_encryption_selected(False)
 
         b.assert_pixels(
             "#app",

--- a/test/helpers/installer.py
+++ b/test/helpers/installer.py
@@ -16,6 +16,7 @@ from collections import UserDict
 from time import sleep
 
 from step_logger import log_step
+from storage import StorageEncryption
 from users import create_user
 
 
@@ -43,6 +44,7 @@ class InstallerSteps(UserDict):
 
     _steps_callbacks = {}
     _steps_callbacks[ACCOUNTS] = create_user
+    _steps_callbacks[DISK_ENCRYPTION] = lambda browser, machine: StorageEncryption(browser, machine).set_encryption_selected(False)
 
 
 class Installer():

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -20,7 +20,6 @@ import sys
 HELPERS_DIR = os.path.dirname(__file__)
 sys.path.append(HELPERS_DIR)
 
-from installer import Installer, InstallerSteps  # pylint: disable=import-error
 from step_logger import log_step
 
 STORAGE_SERVICE = "org.fedoraproject.Anaconda.Modules.Storage"
@@ -34,7 +33,7 @@ id_prefix = "installation-method"
 
 class StorageDestination():
     def __init__(self, browser, machine):
-        self._step = InstallerSteps.INSTALLATION_METHOD
+        self._step = "installation-method"
         self.browser = browser
         self.machine = machine
 
@@ -387,8 +386,8 @@ class StorageMountPointMapping(StorageDBus, StorageDestination):
         self.set_partitioning("mount-point-mapping")
         self.browser.wait_visible("div[data-scenario='mount-point-mapping']")
 
-        i = Installer(self.browser, self.machine)
-        i.next(next_page=i.steps.CUSTOM_MOUNT_POINT)
+        self.browser.click("button:contains(Next)")
+        self.browser.wait_js_cond('window.location.hash === "#/mount-point-mapping"')
 
         with self.browser.wait_timeout(30):
             if not encrypted:

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -339,6 +339,7 @@ class StorageScenario():
     def set_partitioning(self, scenario):
         self.browser.click(self._partitioning_selector(scenario))
         self.browser.wait_visible(self._partitioning_selector(scenario) + ":checked")
+        self.browser.wait_visible(f"div[data-scenario='{scenario}']")
 
 
 class StorageMountPointMapping(StorageDBus, StorageDestination):
@@ -384,7 +385,6 @@ class StorageMountPointMapping(StorageDBus, StorageDestination):
         self.select_disks(disks)
 
         self.set_partitioning("mount-point-mapping")
-        self.browser.wait_visible("div[data-scenario='mount-point-mapping']")
 
         self.browser.click("button:contains(Next)")
         self.browser.wait_js_cond('window.location.hash === "#/mount-point-mapping"')


### PR DESCRIPTION
The UI remembers the encryption choice from the last created partitioning. Since the tests are non-destructive this can create test failures, since tests expect the 'encryption' checkbox to be disabled at start.

For fixing that this commit introduces a callback on the disk encryption page.
For implementing the later we needed to solve a circular import scenario, therefore we stopped importing the Installer* classes from the Storage helpers file.