### PR TITLE
Fix wrong background when dialog in the cockpit storage modal view is…

### DIFF
--- a/src/components/Common.jsx
+++ b/src/components/Common.jsx
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with This program; If not, see <http://www.gnu.org/licenses/>.
  */
-import React, { createContext, useEffect, useState } from "react";
+import React, { createContext } from "react";
 import { Popover, PopoverPosition } from "@patternfly/react-core";
 import { HelpIcon } from "@patternfly/react-icons";
 
@@ -79,38 +79,14 @@ const SystemInfoContextWrapper = ({ children, conf, osRelease }) => {
     );
 };
 
-const MaybeBackdrop = ({ children }) => {
-    const [hasDialogOpen, setHasDialogOpen] = useState(false);
-
-    useEffect(() => {
-        const handleStorageEvent = (event) => {
-            if (event.key === "cockpit_has_modal") {
-                setHasDialogOpen(event.newValue === "true");
-            }
-        };
-
-        window.addEventListener("storage", handleStorageEvent);
-
-        return () => window.removeEventListener("storage", handleStorageEvent);
-    }, []);
-
-    return (
-        <div className={hasDialogOpen ? "cockpit-has-modal" : ""}>
-            {children}
-        </div>
-    );
-};
-
 export const MainContextWrapper = ({ address, children, conf, osRelease, state }) => {
     return (
         <ModuleContextWrapper state={state}>
             <SystemInfoContextWrapper osRelease={osRelease} conf={conf}>
                 <WithDialogs>
-                    <MaybeBackdrop>
-                        <AddressContext.Provider value={address}>
-                            {children}
-                        </AddressContext.Provider>
-                    </MaybeBackdrop>
+                    <AddressContext.Provider value={address}>
+                        {children}
+                    </AddressContext.Provider>
                 </WithDialogs>
             </SystemInfoContextWrapper>
         </ModuleContextWrapper>

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -1,5 +1,4 @@
 @import "global-variables";
-@import "@patternfly/patternfly/components/Backdrop/backdrop.scss";
 
 // Copied from cockpit/pkg/lib/page.scss instead of including it in its entirety:
 // Let PF4 handle the scrolling through page component otherwise we might get double scrollbar
@@ -39,26 +38,4 @@ html:not(.index-page) body {
 // Nested tables showing partitions in the local standards disks table don't need extra padding
 .ct-table .pf-v5-c-table__expandable-row-content {
   padding: 0;
-}
-
-// Simulate Backdrop behavior for modals in the iframe
-%iframe-zindex {
-  position: relative;
-  z-index: 10;
-}
-
-iframe {
-  @extend %iframe-zindex;
-}
-
-// Simulate a PF background scrim
-.cockpit-has-modal .pf-v5-c-page__main-section {
-  @extend %iframe-zindex;
-
-  &::after {
-    @extend .pf-v5-c-backdrop;
-    --pf-v5-c-backdrop--Position: absolute;
-    content: "";
-    z-index: 9;
-  }
 }

--- a/src/components/storage/CockpitStorageIntegration.jsx
+++ b/src/components/storage/CockpitStorageIntegration.jsx
@@ -86,6 +86,24 @@ const ReturnToInstallationButton = ({ onAction }) => (
     </Button>
 );
 
+export const useMaybeBackdrop = () => {
+    const [hasDialogOpen, setHasDialogOpen] = useState(false);
+
+    useEffect(() => {
+        const handleStorageEvent = (event) => {
+            if (event.key === "cockpit_has_modal") {
+                setHasDialogOpen(event.newValue === "true");
+            }
+        };
+
+        window.addEventListener("storage", handleStorageEvent);
+
+        return () => window.removeEventListener("storage", handleStorageEvent);
+    }, []);
+
+    return hasDialogOpen ? "cockpit-has-modal" : "";
+};
+
 export const CockpitStorageIntegration = ({
     dispatch,
     isFormDisabled,
@@ -95,6 +113,8 @@ export const CockpitStorageIntegration = ({
     showStorage,
 }) => {
     const [showDialog, setShowDialog] = useState(false);
+    const backdropClass = useMaybeBackdrop();
+
     useEffect(() => {
         const iframe = document.getElementById("cockpit-storage-frame");
         if (iframe) {
@@ -107,7 +127,7 @@ export const CockpitStorageIntegration = ({
     return (
         <Modal
           aria-label={_("Configure storage")}
-          className={idPrefix + "-modal-page-section"}
+          className={backdropClass + " " + idPrefix + "-modal-page-section"}
           footer={<ReturnToInstallationButton onAction={() => setShowDialog(true)} />}
           hasNoBodyWrapper
           isOpen={showStorage}

--- a/src/components/storage/CockpitStorageIntegration.scss
+++ b/src/components/storage/CockpitStorageIntegration.scss
@@ -1,3 +1,6 @@
+@import "global-variables";
+@import "@patternfly/patternfly/components/Backdrop/backdrop.scss";
+
 .cockpit-storage-integration-modal-page-section {
     width: 100%;
     height: 100%;
@@ -56,4 +59,26 @@ ul.cockpit-storage-integration-requirements-hint-list {
     .pf-v5-c-helper-text__item-text {
         color: unset;
     }
+}
+
+// Simulate Backdrop behavior for modals in the iframe
+%iframe-zindex {
+  position: relative;
+  z-index: 10;
+}
+
+iframe {
+  @extend %iframe-zindex;
+}
+
+// Simulate a PF background scrim
+.cockpit-has-modal {
+  @extend %iframe-zindex;
+
+  &::after {
+    @extend .pf-v5-c-backdrop;
+    --pf-v5-c-backdrop--Position: absolute;
+    content: "";
+    z-index: 9;
+  }
 }


### PR DESCRIPTION
After we ported the cockpit storage view to a modal, we forgot to adjust the CSS that handles the backdrop.

![Screen Shot 2024-06-27 at 12 26 48](https://github.com/rhinstaller/anaconda-webui/assets/14921356/c1e2450c-e8a7-4c51-b566-68a48f342ac0)
