### PR TITLE
package.json: Drop date-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "devDependencies": {
     "chrome-remote-interface": "0.33.0",
-    "date-fns": "3.6.0",
     "deep-equal": "2.2.3",
     "esbuild": "0.21.5",
     "esbuild-plugin-copy": "2.1.1",


### PR DESCRIPTION
It's not used by anything. This avoids some unnecessary dependabot noise.

---

Context: I recently eliminated date-fns from cockpit's `timeformat` lib, see https://github.com/cockpit-project/cockpit/pull/20671 and https://github.com/cockpit-project/cockpit/pull/20685 . I am now dropping this npm dependency from all our projects.