### PR TITLE
review: remove 'Disk encryption' section and conditionally hide 'Account'

### DIFF
--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -103,17 +103,19 @@ const ReviewConfiguration = ({ idPrefix, setIsFormValid }) => {
                           description={language ? language["native-name"].v : localizationData.language}
                         />
                     </ReviewDescriptionList>
-                    <ReviewDescriptionList>
-                        <ReviewDescriptionListItem
-                          id={`${idPrefix}-target-system-account`}
-                          term={_("Account")}
-                          description={accounts.fullName ? `${accounts.fullName} (${accounts.userName})` : accounts.userName}
-                        />
-                    </ReviewDescriptionList>
                     {isBootIso &&
-                    <ReviewDescriptionList>
-                        <HostnameRow />
-                    </ReviewDescriptionList>}
+                    <>
+                        <ReviewDescriptionList>
+                            <ReviewDescriptionListItem
+                              id={`${idPrefix}-target-system-account`}
+                              term={_("Account")}
+                              description={accounts.fullName ? `${accounts.fullName} (${accounts.userName})` : accounts.userName}
+                            />
+                        </ReviewDescriptionList>
+                        <ReviewDescriptionList>
+                            <HostnameRow />
+                        </ReviewDescriptionList>
+                    </>}
                 </ReviewDescriptionList>
             </FlexItem>
             <FlexItem>

--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -28,7 +28,7 @@ import {
 } from "@patternfly/react-core";
 
 import { AnacondaWizardFooter } from "../AnacondaWizardFooter.jsx";
-import { FooterContext, LanguageContext, OsReleaseContext, StorageContext, SystemTypeContext, UsersContext } from "../Common.jsx";
+import { FooterContext, LanguageContext, OsReleaseContext, SystemTypeContext, UsersContext } from "../Common.jsx";
 import { useScenario } from "../storage/InstallationScenario.jsx";
 import { ReviewDescriptionListItem } from "./Common.jsx";
 import { HostnameRow } from "./Hostname.jsx";
@@ -60,7 +60,6 @@ const ReviewConfiguration = ({ idPrefix, setIsFormValid }) => {
     const osRelease = useContext(OsReleaseContext);
     const localizationData = useContext(LanguageContext);
     const accounts = useContext(UsersContext);
-    const { partitioning, storageScenarioId } = useContext(StorageContext);
     const { label: scenarioLabel } = useScenario();
     const isBootIso = useContext(SystemTypeContext) === "BOOT_ISO";
 
@@ -126,14 +125,6 @@ const ReviewConfiguration = ({ idPrefix, setIsFormValid }) => {
                           description={scenarioLabel}
                         />
                     </ReviewDescriptionList>
-                    {storageScenarioId !== "mount-point-mapping" &&
-                    <ReviewDescriptionList>
-                        <ReviewDescriptionListItem
-                          id={`${idPrefix}-target-system-encrypt`}
-                          term={_("Disk encryption")}
-                          description={partitioning.method === "AUTOMATIC" && partitioning.requests[0].encrypted ? _("Enabled") : _("Disabled")}
-                        />
-                    </ReviewDescriptionList>}
                     <ReviewDescriptionList>
                         <ReviewDescriptionListItem
                           id={`${idPrefix}-target-storage`}

--- a/test/check-review
+++ b/test/check-review
@@ -18,7 +18,9 @@
 import anacondalib
 from installer import Installer
 from language import Language
+from password import Password
 from review import Review
+from storage import Storage
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 from utils import pretend_live_iso
 
@@ -30,6 +32,8 @@ class TestReview(anacondalib.VirtInstallMachineCase):
         b = self.browser
         m = self.machine
         i = Installer(b, m)
+        s = Storage(b, m)
+        p = Password(b, s.encryption_id_prefix)
         r = Review(b, m)
 
         pretend_live_iso(self, i)
@@ -46,9 +50,6 @@ class TestReview(anacondalib.VirtInstallMachineCase):
         r.check_disk_row("vda", "/boot", "vda2", "1.07 GB", True, "xfs")
         r.check_disk_row("vda", "/", "vda3, LVM", "15.0 GB", True, "xfs")
 
-        # check encryption choice
-        r.check_encryption("Disabled")
-
         # check storage configuration
         r.check_storage_config("Erase data and install")
 
@@ -59,6 +60,25 @@ class TestReview(anacondalib.VirtInstallMachineCase):
         b.assert_pixels(
             "#app",
             "review-step-basic",
+            ignore=anacondalib.pixel_tests_ignore,
+        )
+
+        i.reach_on_sidebar(i.steps.DISK_ENCRYPTION)
+        s.set_encryption_selected(True)
+        strong_password = "Rwce82ybF7dXtCzFumanchu!!!!!!!!"
+        p.set_password(strong_password)
+        p.set_password_confirm(strong_password)
+        i.reach(i.steps.REVIEW)
+
+        # check selected disks are shown
+        r.check_disk("vda", "16.1 GB vda (0x1af4)")
+        r.check_disk_row("vda", "/boot", "vda2", "1.07 GB", True, "xfs", is_encrypted=False)
+        r.check_disk_row("vda", "/", "vda3, LVM", "15.0 GB", True, "xfs", is_encrypted=True)
+
+        # Pixel test the review step with encrypted disk
+        b.assert_pixels(
+            "#app",
+            "review-step-basic-encrypted",
             ignore=anacondalib.pixel_tests_ignore,
         )
 

--- a/test/helpers/review.py
+++ b/test/helpers/review.py
@@ -47,10 +47,6 @@ class Review(NetworkDBus):
         self.browser.wait_in_text(f"#{self._step}-target-system-account > .pf-v5-c-description-list__text", account)
 
     @log_step()
-    def check_encryption(self, state):
-        self.browser.wait_in_text(f"#{self._step}-target-system-encrypt > .pf-v5-c-description-list__text", state)
-
-    @log_step()
     def check_storage_config(self, scenario):
         self.browser.wait_in_text(f"#{self._step}-target-system-mode > .pf-v5-c-description-list__text", scenario)
 


### PR DESCRIPTION
If a device is encrypted is shown as a column in the storage overview.