### PR TITLE
package.json: Explicitly depend on stylelint-config-recommended-scss

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "sizzle": "2.3.10",
     "stdio": "2.1.3",
     "stylelint": "16.6.1",
+    "stylelint-config-recommended-scss": "14.0.0",
     "stylelint-config-standard-scss": "13.1.0",
     "stylelint-formatter-pretty": "4.0.0"
   },


### PR DESCRIPTION
The latest version 14.1.0 does not work with our other stylelint package versions. Pin down the version we've used so far, and let dependabot take care of grouped updates.

Taken from https://github.com/cockpit-project/starter-kit/commit/71940a9c9fe

----

Fixes [this spontaneous breakage](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6603-eb046fe4-20240710-224213-fedora-rawhide-boot-rhinstaller-anaconda-webui/log.html), seen in e.g. #350 or https://github.com/cockpit-project/bots/pull/6603