### PR TITLE
tests: ignore the whole hint list in pixel test for cockpit integration

### DIFF
--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -47,14 +47,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         b._wait_present("#storage.ct-page-fill")
 
         self.click_dropdown(self.card_row("Storage", 1), "Create partition table")
-        # Pixel test the cockpit storage view, modal backdrops should cover the whole screen
-        b.switch_to_top()
-        b.assert_pixels(
-            "#app",
-            "storage-editor",
-            ignore=[*pixel_tests_ignore, ".cockpit-storage-integration-requirements-hint"],
-        )
-        b.switch_to_frame("cockpit-storage")
         self.confirm()
 
         self.click_dropdown(self.card_row("Storage", 2), "Create partition")


### PR DESCRIPTION
Ignoring just some lines was not sufficient.