### PR TITLE
infra: run all tests when triggered with non bots defined scenario

### DIFF
--- a/test/run
+++ b/test/run
@@ -28,12 +28,10 @@ case "${TEST_SCENARIO:=}" in
     *other*)
         RUN_OPTS="$(echo "$ALL_TESTS" | grep -Ev "$RE_EXPENSIVE")"
         ;;&
+    *)
+        RUN_OPTS="$ALL_TESTS"
+        ;;&
 esac
-
-if [ -n "$TEST_SCENARIO" ] && [ -z "$RUN_OPTS" ]; then
-    echo "Unknown test scenario: $TEST_SCENARIO"
-    exit 1
-fi
 
 # test runs in kernel_t context and triggers massive amounts of SELinux
 # denials; SELinux gets disabled, but would still trigger unexpected messages


### PR DESCRIPTION
The are a few more TEST_SCENARIOS values aside from 'expensive' and 'other'. Such an example are the anaconda-pr-* and cockpit-pr-* scenarios, which are defined when we trigger Web UI tests from anaconda core and cockpit repositories respectively.