### PR TITLE
tests: fix test scenario picking always all tests

### DIFF
--- a/test/run
+++ b/test/run
@@ -24,13 +24,13 @@ RE_EXPENSIVE='FedoraPlans'
 case "${TEST_SCENARIO:=}" in
     *expensive*)
         RUN_OPTS="$(echo "$ALL_TESTS" | grep -E "$RE_EXPENSIVE")"
-        ;;&
+        ;;
     *other*)
         RUN_OPTS="$(echo "$ALL_TESTS" | grep -Ev "$RE_EXPENSIVE")"
-        ;;&
+        ;;
     *)
         RUN_OPTS="$ALL_TESTS"
-        ;;&
+        ;;
 esac
 
 # test runs in kernel_t context and triggers massive amounts of SELinux


### PR DESCRIPTION
Dont move to next condition if we matched one already. Commit e04d939dbfabd5aec357ca108395d40ae72fd7fa incorrectly introduced a new case, which matched always because of the ;;$.

From man bash:

Using ;;& in place of ;; causes the shell to test
the next pattern list in the statement, if any, and execute any associated list on a successful match.