### PR TITLE
test: Move from CDP to BiDi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,12 +114,9 @@ install: $(DIST_TEST) po/LINGUAS
 	cp webui-desktop $(DESTDIR)/usr/libexec/
 	ln -sTfr $(DESTDIR)/usr/share/pixmaps/fedora-logo-sprite.svg $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)/logo.svg
 
-# required for running integration tests; commander and ws are deps of chrome-remote-interface
+# required for running integration tests;
 TEST_NPMS = \
-	node_modules/chrome-remote-interface \
-	node_modules/commander \
 	node_modules/sizzle \
-	node_modules/ws \
 	$(NULL)
 
 dist: $(TARFILE)
@@ -155,7 +152,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = 07fddba43934fb256ec8da03812f081eab3baa18 # 321 + 117 commits
+COCKPIT_REPO_COMMIT = 8ede522e5066e680850dd2ae049e2e24f99c4230 # 322 + 30 commits
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "stylelint:fix": "stylelint --fix 'src/**/*{.css,scss}'"
   },
   "devDependencies": {
-    "chrome-remote-interface": "0.33.2",
     "esbuild": "0.23.0",
     "esbuild-plugin-copy": "2.1.1",
     "esbuild-plugin-replace": "1.4.0",
@@ -32,6 +31,7 @@
     "eslint-plugin-simple-import-sort": "^12.0.0",
     "eslint-plugin-sort-destructure-keys": "^2.0.0",
     "gettext-parser": "8.0.0",
+    "glob": "11.0.0",
     "htmlparser": "1.7.7",
     "jed": "1.1.1",
     "qunit": "2.21.1",

--- a/src/components/Error.jsx
+++ b/src/components/Error.jsx
@@ -231,7 +231,7 @@ const quitButton = (isBootIso) => {
 
 export const CriticalError = ({ exception, isConnected, reportLinkURL }) => {
     const isBootIso = useContext(SystemTypeContext) === "BOOT_ISO";
-    const context = exception.backendException?.contextData?.context || exception.frontendException?.jsContext;
+    const context = exception.backendException?.contextData?.context || exception.frontendException?.contextData?.context;
     const description = context
         ? cockpit.format(_("The installer cannot continue due to a critical error: $0"), _(context))
         : _("The installer cannot continue due to a critical error.");

--- a/src/components/storage/CockpitStorageIntegration.jsx
+++ b/src/components/storage/CockpitStorageIntegration.jsx
@@ -157,17 +157,19 @@ export const CockpitStorageIntegration = ({
     setShowStorage,
 }) => {
     const [showDialog, setShowDialog] = useState(false);
+    const [isIframeMounted, setIsIframeMounted] = useState(false);
     const [isConfirmed, setIsConfirmed] = useState(false);
     const backdropClass = useMaybeBackdrop();
+    const handleIframeLoad = () => setIsIframeMounted(true);
 
     useEffect(() => {
-        const iframe = document.getElementById("cockpit-storage-frame");
-        if (iframe) {
+        if (isIframeMounted) {
+            const iframe = document.getElementById("cockpit-storage-frame");
             iframe.contentWindow.addEventListener("error", exception => {
                 onCritFail({ context: _("Storage plugin failed"), isFrontend: true })(exception.error);
             });
         }
-    }, [onCritFail]);
+    }, [isIframeMounted, onCritFail]);
 
     const handleConfirmOpenModal = () => {
         setIsConfirmed(true);
@@ -207,6 +209,7 @@ export const CockpitStorageIntegration = ({
                           src="/cockpit/@localhost/storage/index.html"
                           name="cockpit-storage"
                           id="cockpit-storage-frame"
+                          onLoad={handleIframeLoad}
                           className={idPrefix + "-iframe-cockpit-storage"} />
                     </PageSection>
                     <ModifyStorageSideBar />

--- a/test/check-basic
+++ b/test/check-basic
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
-import time
-
 from anacondalib import VirtInstallMachineCase
 from installer import Installer
 from language import Language
@@ -249,12 +247,8 @@ class TestBasic(VirtInstallMachineCase):
 
         b.wait_not_present("#critical-error-bz-report-modal.pf-v5-c-modal-box")
 
-        with self.assertRaises(RuntimeError):
-            b.eval_js("window.setTimeout(function() { myNonExistingFunction()}, 0);")
-            # Some round trips, one of which should update the deferred exception
-            for _ in range(0, 5):
-                b.wait_in_text("#critical-error-bz-report-modal-details", "myNonExistingFunction is not defined")
-                time.sleep(2)
+        b.eval_js("window.setTimeout(function() { myNonExistingFunction()}, 0);")
+        b.wait_in_text("#critical-error-bz-report-modal-details", "myNonExistingFunction is not defined")
 
         b.wait_visible("a:contains('Report issue'):not([disabled])")
         b.assert_pixels(

--- a/test/check-storage-basic
+++ b/test/check-storage-basic
@@ -32,9 +32,9 @@ ROOT_DIR = os.path.dirname(TEST_DIR)
 BOTS_DIR = f'{ROOT_DIR}/bots'
 
 
+@nondestructive
 class TestStorage(VirtInstallMachineCase, StorageHelpers):
 
-    @nondestructive
     def testLocalStandardDisks(self):
         b = self.browser
         i = Installer(b, self.machine)
@@ -93,7 +93,6 @@ class TestStorage(VirtInstallMachineCase, StorageHelpers):
         # Check clear selection of disks
         s.select_none_disks_and_check([dev, "vda"])
 
-    @nondestructive
     def testScenarioSelection(self):
         """
         Test that the use-free-space scenario is conditionally available
@@ -126,7 +125,6 @@ class TestStorage(VirtInstallMachineCase, StorageHelpers):
         i.back()
         s.check_partitioning_selected("use-free-space")
 
-    @nondestructive
     def testPartitioningObject(self):
         # Test which partitioning object ends up being the AppliedPartitioning
         # when we go back and forward the storage steps
@@ -174,7 +172,6 @@ class TestStorage(VirtInstallMachineCase, StorageHelpers):
         new_applied_partitioning = s.dbus_get_applied_partitioning()
         self.assertEqual(new_applied_partitioning, "")
 
-    @nondestructive
     def testCockpitJsErrorHandling(self):
         b = self.browser
         m = self.machine

--- a/test/check-storage-basic
+++ b/test/check-storage-basic
@@ -174,6 +174,7 @@ class TestStorage(VirtInstallMachineCase, StorageHelpers):
         new_applied_partitioning = s.dbus_get_applied_partitioning()
         self.assertEqual(new_applied_partitioning, "")
 
+    @nondestructive
     def testCockpitJsErrorHandling(self):
         b = self.browser
         m = self.machine
@@ -196,10 +197,10 @@ class TestStorage(VirtInstallMachineCase, StorageHelpers):
 
         b.wait_not_present("#critical-error-bz-report-modal.pf-v5-c-modal-box")
 
-        with self.assertRaises(RuntimeError):
-            b.eval_js("window.setTimeout(function() {throw new Error('Unexpected storage JS error')}, 0);")
-            b.wait_in_text("#critical-error-bz-report-modal-details", "Unexpected storage JS error")
-            b.wait_in_text("#critical-error-bz-report-modal header", "The installer cannot continue due to a critical error: Storage plugin failed")
+        b.eval_js("window.setTimeout(function() {throw new Error('Unexpected storage JS error')}, 0);")
+        b.switch_to_top()
+        b.wait_in_text("#critical-error-bz-report-modal-details", "Unexpected storage JS error")
+        b.wait_in_text("#critical-error-bz-report-modal header", "The installer cannot continue due to a critical error: Storage plugin failed")
 
 @nondestructive
 class TestMultipleDisks(VirtInstallMachineCase, StorageHelpers):


### PR DESCRIPTION
See cockpit-project/cockpit#20832

Drop chrome-remote-interface NPM dependency.

Explicitly add a "glob" devDependency to follow suit with cockpit-project/cockpit@680decc155a
It was previously used implicitly through a transient dependency of something else, but our esbuild po-plugin uses it explicitly.