### PR TITLE
storage: fix crash when device path is not existing

### DIFF
--- a/src/actions/storage-actions.js
+++ b/src/actions/storage-actions.js
@@ -71,12 +71,20 @@ export const getDevicesAction = () => {
 
                     // FIXME: https://github.com/storaged-project/blivet/issues/1258
                     // This is a workaround for the issue with missing partition label human readable strings in blivet
-                    const partName = await cockpit.script(`udevadm info --query=property --name=${devData.path.v} | grep PARTNAME= | cut -d= -f2`);
-                    const fsLabel = await cockpit.script(`udevadm info --query=property --name=${devData.path.v} | grep ID_FS_LABEL= | cut -d= -f2`);
-                    devData.misc = {
-                        fsLabel: fsLabel.trim(),
-                        partName: partName.trim(),
-                    };
+                    try {
+                        const partName = await cockpit.script(`udevadm info --query=property --name=${devData.path.v} | grep PARTNAME= | cut -d= -f2`);
+                        const fsLabel = await cockpit.script(`udevadm info --query=property --name=${devData.path.v} | grep ID_FS_LABEL= | cut -d= -f2`);
+                        devData.misc = {
+                            fsLabel: fsLabel.trim(),
+                            partName: partName.trim(),
+                        };
+                    } catch (e) {
+                        console.warning("Failed to get partition label", e);
+                        devData.misc = {
+                            fsLabel: "",
+                            partName: "",
+                        };
+                    }
 
                     deviceData[device] = devData;
                 } catch (error) {


### PR DESCRIPTION
This happens when there are deleted backing files from loop devices.

Ex:
$ cat /sys/block/loop0/loop/backing_file
/home/vtrefny/disk.img2 (deleted)

Resolves: rhbz#2308278