### PR TITLE
test: stop making assumptions about the partition sizes of installed images

### DIFF
--- a/test/check-existing-system
+++ b/test/check-existing-system
@@ -141,7 +141,7 @@ class TestFedoraPlansUseFreeSpace(VirtInstallMachineCase):
         s.reclaim_set_checkbox(True)
         i.next(True)
 
-        s.reclaim_shrink_device("vda1", "5", "10.6", rowIndex=3)
+        s.reclaim_shrink_device("vda1", "5", rowIndex=3)
         s.reclaim_modal_submit()
 
         i.reach(i.steps.REVIEW)
@@ -194,11 +194,12 @@ class TestExistingSystemUbuntu(VirtInstallMachineCase):
         s.reclaim_set_checkbox(True)
         i.next(True)
 
-        s.reclaim_shrink_device("vda1", "7", "11.3", rowIndex=3)
+        s.reclaim_shrink_device("vda1", "7", rowIndex=3)
         s.reclaim_modal_submit()
 
         i.reach(i.steps.REVIEW)
-        r.check_disk_row("vda", parent="vda1", size="7.00 GB", action="resized from 11.3 GB")
+        # Don't specify the exact original size as this might change with image refreshes
+        r.check_disk_row("vda", parent="vda1", size="7.00 GB", action="resized from")
         r.check_resized_system("Ubuntu", ["vda1"])
 
 

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -399,14 +399,15 @@ class StorageReclaimDialog():
         self.browser.click("button:contains('Reclaim space')")
         self.browser.wait_in_text("#reclaim-space-modal .pf-v5-c-alert", warning)
 
-    def reclaim_shrink_device(self, device, new_size, current_size, rowIndex=None):
+    def reclaim_shrink_device(self, device, new_size, current_size=None, rowIndex=None):
         self.browser.click(
             "#reclaim-space-modal-table "
             f"tbody{'' if rowIndex is None else f':nth-child({rowIndex})'} "
             f"tr:contains('{device}') button[aria-label='shrink']"
         )
         self.browser.wait_visible("#popover-reclaim-space-modal-shrink-body")
-        self.browser.wait_val("#reclaim-space-modal-shrink-slider input", current_size)
+        if current_size is not None:
+            self.browser.wait_val("#reclaim-space-modal-shrink-slider input", current_size)
         # HACK: there is some race here which steals the focus from the input and selects the page text instead
         for _ in range(3):
             self.browser.focus('#reclaim-space-modal-shrink-slider input')


### PR DESCRIPTION
Some tests use the images for ubuntu/debian/fedora from bots as backing files for target disks. The partitions on this disk can change with image refreshes, let's not bother about partition current sizes in reclaim dialog.