### PR TITLE
storage: use `console.warn` not `console.warning` to fix crash

### DIFF
--- a/src/actions/storage-actions.js
+++ b/src/actions/storage-actions.js
@@ -79,7 +79,7 @@ export const getDevicesAction = () => {
                             partName: partName.trim(),
                         };
                     } catch (e) {
-                        console.warning("Failed to get partition label", e);
+                        console.warn("Failed to get partition label", e);
                         devData.misc = {
                             fsLabel: "",
                             partName: "",


### PR DESCRIPTION
f66f8f4 mistakenly tried to log a warning with `console.warning`, which doesn't exist. It's `console.warn`. This means we still crash on the path where we crashed before, now with an error about `console.warning` being undefined.