### PR TITLE
Add anaconda-tui package to updates-image

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -77,11 +77,11 @@ def vm_install(image, verbose, quick):
         # unless we are testing a PR on rhinstaller/anaconda, then pull it from the PR COPR repo
         if not scenario or not scenario.startswith("anaconda-pr-"):
             # anaconda-core is also available in the default rawhide compose, make sure we don't pull it from there
-            download_from_copr("@rhinstaller/Anaconda", "anaconda-core", machine)
+            download_from_copr("@rhinstaller/Anaconda", "anaconda-core anaconda-tui", machine)
         else:
             anaconda_pr = scenario.split("-")[-1]
             # anaconda-core is also available in the default rawhide compose, make sure we don't pull it from there
-            download_from_copr(f"packit/rhinstaller-anaconda-{anaconda_pr}", "anaconda-core", machine)
+            download_from_copr(f"packit/rhinstaller-anaconda-{anaconda_pr}", "anaconda-core anaconda-tui", machine)
 
         # Download missing dependencies rpms
         # FIXME boot.iso on rawhide does not currently contain the new anaconda-webui dependencies


### PR DESCRIPTION
We don't need other packages because these only have dependencies or they have GTK UI. However, we do want to keep tui code even when Web UI is the only requested option as the fallback solution.