### PR TITLE
localization: update the language direction also when switching back to EN_US

### DIFF
--- a/src/components/localization/InstallationLanguage.jsx
+++ b/src/components/localization/InstallationLanguage.jsx
@@ -220,14 +220,20 @@ class LanguageSelector extends React.Component {
                                     cockpit.locale(null);
                                     // en_US is always null
                                     if (body.trim() === "") {
-                                        cockpit.locale(null);
+                                        cockpit.locale({
+                                            "": {
+                                                language: "en_US",
+                                                "language-direction": "ltr",
+                                            }
+                                        });
                                     } else {
                                         // eslint-disable-next-line no-eval
                                         eval(body);
-
-                                        const langEvent = new CustomEvent("cockpit-lang");
-                                        window.dispatchEvent(langEvent);
                                     }
+
+                                    const langEvent = new CustomEvent("cockpit-lang");
+                                    window.dispatchEvent(langEvent);
+
                                     this.props.reRenderApp(item);
                                 });
                         return;

--- a/test/check-language
+++ b/test/check-language
@@ -141,6 +141,12 @@ class TestLanguage(VirtInstallMachineCase):
         l.check_selected_locale("he_IL")
         b.wait_attr("html", "dir", "rtl")
 
+        # Expect language direction to be set to LTR when switching to EN_US from RTL language
+        # as this has special handling
+        l.select_locale("en_US")
+        l.check_selected_locale("en_US")
+        b.wait_attr("html", "dir", "ltr")
+
         l.select_locale("de_DE")
         l.check_selected_locale("de_DE")
         b.wait_attr("html", "dir", "ltr")


### PR DESCRIPTION
When switching back to EN_US after an RTL language choice, the UI previously kept the old language direction.