### PR TITLE
Hotfix for Anaconda Wayland migration changes

### DIFF
--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -36,6 +36,16 @@ def addRpms(updates, add_rpms):
 
 def createUpdatesImage(cwd, updates):
     os.chdir(updates)
+    # FIXME: hotfix for issue with missing file - remove when new Wayland native
+    #        Anaconda is on Fedora Rawhide
+    if not os.path.exists("usr/lib64/python3.13/site-packages/pyanaconda/ui/tui/spokes/askvnc.py"):
+        try:
+            os.makedirs("usr/lib64/python3.13/site-packages/pyanaconda/ui/tui/spokes")
+        except FileExistsError:
+            pass
+        with open("usr/lib64/python3.13/site-packages/pyanaconda/ui/tui/spokes/askvnc.py", "w") as f:
+            f.close()
+
     os.system("find . | cpio -c -o | gzip -9cv > %s/updates.img" % (cwd,))
     sys.stdout.write("updates.img ready\n")
 

--- a/test/machine_install.py
+++ b/test/machine_install.py
@@ -147,7 +147,7 @@ class VirtInstallMachine(VirtMachine):
                 f"{boot_arg} "
                 f"--name {self.label} "
                 f"--os-variant=detect=on "
-                "--memory 4096 "
+                "--memory 6144 "
                 "--noautoconsole "
                 f"--graphics vnc,listen={self.ssh_address} "
                 "--extra-args "

--- a/test/vm.install
+++ b/test/vm.install
@@ -41,6 +41,13 @@ def vm_install(image, verbose, quick):
         # Make sure builder can build packages if required, /var/tmp/build needs to be owned by builder
         machine.execute("su builder -c 'mkdir -p /var/tmp/build/SRPMS'")
 
+        # FIXME: remove when Anaconda migrated to Wayland native is present in Fedora Rawhide
+        machine.execute(
+            "dnf download --destdir /var/tmp/build/ systemd-devel python3-pam mesa-dri-drivers openssl llvm-libs",
+            stdout=sys.stdout,
+            timeout=300
+        )
+
         # Pull cockpit dependencies from the image default compose
         # unless we are testing a PR on cockpit-project/cockpit, then pull it from the PR COPR repo
         packages_to_download = missing_packages


### PR DESCRIPTION
There is a new patchset to migrate Anaconda to Wayland native application. This patchset is unfortunately quite big and complicated. https://github.com/rhinstaller/anaconda/pull/5829

Current Web UI testing depends on updates image creation from the Anaconda RPMs which are downloaded from Rawhide and/or COPR repos. However, we are hitting issues for updates images in this case.

- Removal of spoke in Anaconda will not be covered by updates image. This is expected because RPM don't have information that some file was removed. Usually this is not an issue because the removed code is not imported. Unfortunately, here the code is imported by our dynamic spoke importer. That will result in traceback because of missing imports in the removed spoke.
- The patchset in Anaconda is adding new dependencies required to be able to start the Wayland environment, however, these are not covered when an updates image is created because we can't tell which deps are new and should be part of the ISO.

We should resolve this somehow by improving the workflow in the future. For now we can continue with this hotfix.