### PR TITLE
Revert "test: bring latest available python3-kickstart till version 358 is available

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -41,9 +41,6 @@ def vm_install(image, verbose, quick):
         # Make sure builder can build packages if required, /var/tmp/build needs to be owned by builder
         machine.execute("su builder -c 'mkdir -p /var/tmp/build/SRPMS'")
 
-        # FIXME: remove python3-kickstart once version 3.58 is available in Fedora Rawhide
-        machine.execute("dnf download --destdir /var/tmp/build/ python3-kickstart", stdout=sys.stdout, timeout=300)
-
         # Pull cockpit dependencies from the image default compose
         # unless we are testing a PR on cockpit-project/cockpit, then pull it from the PR COPR repo
         packages_to_download = missing_packages


### PR DESCRIPTION
This reverts commit d71b0dde6b988a5de2fa07fd8cff106904ce8bc9.