### PR TITLE
build: spec: require anaconda-core 42.5 only on fedora 42

### DIFF
--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -13,11 +13,7 @@ BuildRequires:  gettext
 
 %global anacondacorever 0
 
-%if 0%{?fedora} >= 40
-%global anacondacorever 40.22.2
-%endif
-
-%if 0%{?fedora} >= 41
+%if 0%{?fedora} > 41
 %global anacondacorever 42.5
 %endif
 


### PR DESCRIPTION
Fedora 41 does not contain that version, and also we don't plan to rebase there anymore, so it does not really matter.

Also clean up the specfile from conditions for Fedora < 41.