### PR TITLE
test: Update all of udisks2, not just the lvm2 and btrfs modules

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -12,7 +12,7 @@ import sys
 BOTS_DIR = os.path.realpath(f'{__file__}/../../bots')
 sys.path.append(BOTS_DIR)
 
-missing_packages = "cockpit-ws cockpit-bridge fedora-logos udisks2-lvm2 udisks2-btrfs"
+missing_packages = "cockpit-ws cockpit-bridge fedora-logos udisks2 libudisks2 udisks2-lvm2 udisks2-btrfs udisks2-iscsi"
 # Install missing firefox dependencies.
 # Resolving all dependencies with dnf download is possible,
 # but it packs to many packages to updates.img


### PR DESCRIPTION
All pieces need to have the same version, otherwise the modules will likely not load, or UDisks2 will crash.

This should fix failures like these in https://cockpit-logs.us-east-1.linodeobjects.com/pull-6954-50025d8c-20241006-232043-fedora-rawhide-boot-other-rhinstaller-anaconda-webui/log.html#23

```
> warn: Can't enable storaged btrfs module Error initializing module 'btrfs': /usr/lib64/udisks2/modules/libudisks2_btrfs.so: undefined symbol: udisks_mdraid_set_consistency_policy
> warn: Can't enable storaged lvm2 module Error initializing module 'lvm2': /usr/lib64/udisks2/modules/libudisks2_lvm2.so: undefined symbol: udisks_mdraid_set_consistency_policy
```
