### PR TITLE
Fix bridge crashing installation on boot.iso

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,8 @@ install: $(DIST_TEST) po/LINGUAS
 	mkdir -p $(DESTDIR)/usr/libexec/anaconda
 	cp webui-desktop $(DESTDIR)/usr/libexec/anaconda
 	ln -sTfr $(DESTDIR)/usr/share/pixmaps/fedora-logo-sprite.svg $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)/logo.svg
+	mkdir -p $(DESTDIR)/usr/lib/systemd/system/
+	cp src/systemd/webui-cockpit-ws.service $(DESTDIR)/usr/lib/systemd/system/
 
 # required for running integration tests;
 TEST_NPMS = \

--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -10,6 +10,8 @@ BuildArch:      noarch
 BuildRequires:  libappstream-glib
 BuildRequires:  make
 BuildRequires:  gettext
+# Needed for the unitdir macro
+BuildRequires: systemd-rpm-macros
 
 %global anacondacorever 0
 
@@ -19,6 +21,8 @@ BuildRequires:  gettext
 
 %global cockpitver 275
 %global cockpitstorver 311
+
+%define _unitdir /usr/lib/systemd/system
 
 Requires: cockpit-storaged >= %{cockpitstorver}
 Requires: cockpit-bridge >= %{cockpitver}
@@ -79,6 +83,7 @@ exit 0
 %{_datadir}/anaconda/firefox-theme/live/user.js
 %{_datadir}/anaconda/firefox-theme/live/chrome/userChrome.css
 %{_libexecdir}/anaconda/webui-desktop
+%{_unitdir}/webui-cockpit-ws.service
 
 
 # The changelog is automatically generated and merged

--- a/src/systemd/webui-cockpit-ws.service
+++ b/src/systemd/webui-cockpit-ws.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Cockpit Web Service for Anaconda Installer
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=/tmp/webui-cockpit-ws.env
+Environment="COCKPIT_SUPERUSER=pkexec"
+ExecStart=/usr/libexec/cockpit-ws -p 80 -a "$WEBUI_ADDRESS" --no-tls --local-session=cockpit-bridge
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -69,6 +69,7 @@ class VirtInstallMachineCase(MachineCase):
             self.addCleanup(self.resetUsers)
             self.addCleanup(self.resetStorage)
             self.addCleanup(self.resetLanguage)
+            self.addCleanup(self.resetMisc)
 
         super().setUp()
 
@@ -149,6 +150,12 @@ class VirtInstallMachineCase(MachineCase):
         # CLEAR_PARTITIONS_DEFAULT = -1
         s.dbus_set_initialization_mode(-1)
         s.dbus_scan_devices()
+
+    def resetMisc(self):
+        # Restart cockpit-ws/cockpit-bridge to avoid crashes in the next test
+        m = self.machine
+
+        m.execute("systemctl restart webui-cockpit-ws.service")
 
     def downloadLogs(self):
         if not self.ext_logging:

--- a/test/machine_install.py
+++ b/test/machine_install.py
@@ -151,7 +151,7 @@ class VirtInstallMachine(VirtMachine):
                 "--noautoconsole "
                 f"--graphics vnc,listen={self.ssh_address} "
                 "--extra-args "
-                f"'inst.sshd inst.webui.remote inst.webui inst.updates=http://10.0.2.2:{self.http_updates_img_port}/{self.label}-updates.img' "
+                f"'inst.sshd inst.webui.remote inst.updates=http://10.0.2.2:{self.http_updates_img_port}/{self.label}-updates.img' "
                 "--network none "
                 f"--qemu-commandline="
                 "'-netdev user,id=hostnet0,"

--- a/test/vm.install
+++ b/test/vm.install
@@ -13,10 +13,6 @@ BOTS_DIR = os.path.realpath(f'{__file__}/../../bots')
 sys.path.append(BOTS_DIR)
 
 missing_packages = "cockpit-ws cockpit-bridge fedora-logos udisks2 libudisks2 udisks2-lvm2 udisks2-btrfs udisks2-iscsi"
-# Install missing firefox dependencies.
-# Resolving all dependencies with dnf download is possible,
-# but it packs to many packages to updates.img
-missing_packages_incl_deps = "firefox"
 
 from machine.machine_core import machine_virtual
 
@@ -89,9 +85,6 @@ def vm_install(image, verbose, quick):
         # Then we can enable this only for the various scenarios above
         if packages_to_download is not None:
             machine.execute(f"dnf download --destdir /var/tmp/build/ {packages_to_download}", stdout=sys.stdout, timeout=300)
-        machine.execute(
-            f"dnf download --resolve --setopt=install_weak_deps=False --destdir /var/tmp/build/ {missing_packages_incl_deps}",
-            stdout=sys.stdout, timeout=300)
 
         # download rpms
         vm_rpms = machine.execute("find /var/tmp/build -name '*.rpm' -not -name '*.src.rpm'").strip().split()

--- a/webui-desktop
+++ b/webui-desktop
@@ -64,59 +64,65 @@ case "$1" in
         ;;
 esac
 
-# prepare empty firefox profile dir with theme based on the passed profile id
-FIREFOX_THEME_DIR="/usr/share/anaconda/firefox-theme"
-FIREFOX_PROFILE_PATH="/tmp/anaconda-firefox-profile"
-
-# make sure the profile directory exists and is empty
-if [ -d ${FIREFOX_PROFILE_PATH} ]
-then
-    echo "Cleaning up existing Anaconda Firefox profile directory."
-    rm -rf ${FIREFOX_PROFILE_PATH}
-fi
-mkdir -p ${FIREFOX_PROFILE_PATH}
-
-# populate the profile directory with our custom Firefox theme
-# - theme id is passed as the second argument of this script
-THEME_PATH="${FIREFOX_THEME_DIR}/${THEME_ID}"
-
-cp -a "${THEME_PATH}/." ${FIREFOX_PROFILE_PATH}
-
-# FIXME: is this hardcoded resolution necessary ?
-BROWSER="/usr/bin/firefox --new-instance --window-size 1024,768 --profile ${FIREFOX_PROFILE_PATH}"
-
-# start browser in a temporary home dir, so that it does not interfere with your real one
-BROWSER_HOME=$(mktemp --directory --tmpdir cockpit.desktop.XXXXXX)
-
 WEBUI_ADDRESS="127.0.0.1"
 if [[ "$WEBUI_REMOTE" == "1" ]]
 then
     WEBUI_ADDRESS="0.0.0.0"
 fi
 
-echo "WEBUI_ADDRESS=$WEBUI_ADDRESS\nXDG_CONFIG_DIRS=$BROWSER_HOME" > /tmp/webui-cockpit-ws.env
+echo "WEBUI_ADDRESS=$WEBUI_ADDRESS" > /tmp/webui-cockpit-ws.env
 systemctl start webui-cockpit-ws
+
+if [[ "$WEBUI_REMOTE" == "1" ]]
+then
+    /bin/sleep infinity &
+    BLOCK_ON_PID=$!
+else
+    # prepare empty firefox profile dir with theme based on the passed profile id
+    FIREFOX_THEME_DIR="/usr/share/anaconda/firefox-theme"
+    FIREFOX_PROFILE_PATH="/tmp/anaconda-firefox-profile"
+
+    # make sure the profile directory exists and is empty
+    if [ -d ${FIREFOX_PROFILE_PATH} ]
+    then
+        echo "Cleaning up existing Anaconda Firefox profile directory."
+        rm -rf ${FIREFOX_PROFILE_PATH}
+    fi
+    mkdir -p ${FIREFOX_PROFILE_PATH}
+
+    # populate the profile directory with our custom Firefox theme
+    # - theme id is passed as the second argument of this script
+    THEME_PATH="${FIREFOX_THEME_DIR}/${THEME_ID}"
+
+    cp -a "${THEME_PATH}/." ${FIREFOX_PROFILE_PATH}
+
+    # FIXME: is this hardcoded resolution necessary ?
+    BROWSER="/usr/bin/firefox --new-instance --window-size 1024,768 --profile ${FIREFOX_PROFILE_PATH}"
+
+    # start browser in a temporary home dir, so that it does not interfere with your real one
+    BROWSER_HOME=$(mktemp --directory --tmpdir cockpit.desktop.XXXXXX)
+
+    # if we have netcat, use it for waiting until ws is up
+    if type nc >/dev/null 2>&1; then
+        for _ in `seq 10`; do
+            nc -z "$WEBUI_ADDRESS" 80 && break
+            sleep 0.5;
+        done
+    else
+        # otherwise, just wait a bit
+        sleep 3
+    fi
+
+    HOME="$BROWSER_HOME" MOZ_APP_TITLE="" MOZ_APP_REMOTINGNAME="liveinst" XDG_CURRENT_DESKTOP=GNOME MOZ_GTK_TITLEBAR_DECORATION=client $BROWSER http://"$WEBUI_ADDRESS""$URL_PATH" &
+    BLOCK_ON_PID=$!
+fi
 
 # Cleanup function
 cleanup() {
     set +e
-    kill $B_PID
-    rm -rf $BROWSER_HOME
+    kill $BLOCK_ON_PID
+    [[ -n $BROWSER_HOME ]] && rm -rf $BROWSER_HOME
 }
 trap 'cleanup' EXIT INT QUIT PIPE
 
-# if we have netcat, use it for waiting until ws is up
-if type nc >/dev/null 2>&1; then
-    for _ in `seq 10`; do
-        nc -z "$WEBUI_ADDRESS" 80 && break
-        sleep 0.5;
-    done
-else
-    # otherwise, just wait a bit
-    sleep 3
-fi
-
-HOME="$BROWSER_HOME" MOZ_APP_TITLE="" MOZ_APP_REMOTINGNAME="liveinst" XDG_CURRENT_DESKTOP=GNOME MOZ_GTK_TITLEBAR_DECORATION=client $BROWSER http://"$WEBUI_ADDRESS""$URL_PATH" &
-B_PID=$!
-
-wait $B_PID
+wait $BLOCK_ON_PID

--- a/webui-desktop
+++ b/webui-desktop
@@ -94,18 +94,12 @@ then
     WEBUI_ADDRESS="0.0.0.0"
 fi
 
-# forward parent stdin and stdout (from bridge) to cockpit-ws
-# it pretty well does not matter which port we use in our own namespace, so use standard http
-# disable /etc/cockpit/
-XDG_CONFIG_DIRS="$BROWSER_HOME" COCKPIT_SUPERUSER="pkexec" /usr/libexec/cockpit-ws -p 80 -a "$WEBUI_ADDRESS" --no-tls --local-session=cockpit-bridge &
-WS_PID=$!
-exec > >(systemd-cat -t anaconda) 2>&1
+echo "WEBUI_ADDRESS=$WEBUI_ADDRESS\nXDG_CONFIG_DIRS=$BROWSER_HOME" > /tmp/webui-cockpit-ws.env
+systemctl start webui-cockpit-ws
 
 # Cleanup function
 cleanup() {
     set +e
-    kill $WS_PID
-    wait $WS_PID
     kill $B_PID
     rm -rf $BROWSER_HOME
 }


### PR DESCRIPTION
Do not start firefox in the VM for remote installations. So far remote installations are used only for testing. Let's abuse this and switch firefox instance in the VM with a plain sleep, to avoid the crash. [1]

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2320964