### PR TITLE
test: adjust for btrfs hidden subvolume rename to top-level

### DIFF
--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -207,7 +207,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         self.click_dropdown(self.card_row("Storage", 4), "Create partition")
         self.dialog({"type": "btrfs"})
 
-        self.click_card_row("Storage", name="/")
+        self.click_card_row("Storage", name="top-level")
 
         b.click(self.card_button("btrfs subvolume", "Mount"))
         self.dialog({"mount_point": tmp_mount})
@@ -281,7 +281,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         self.click_dropdown(self.card_row("Storage", 4), "Create partition")
         self.dialog({"type": "btrfs"})
 
-        self.click_card_row("Storage", name="/")
+        self.click_card_row("Storage", name="top-level")
 
         b.click(self.card_button("btrfs subvolume", "Mount"))
         self.dialog({"mount_point": tmp_mount})


### PR DESCRIPTION
Cockpit renamed the btrfs "root subvolume" to "top-level" to avoid confusion with "/".

https://github.com/cockpit-project/cockpit/pull/21127