### PR TITLE
storage: cockpit: fix UI flickering when exiting cockpit storage

### DIFF
--- a/src/components/storage/CockpitStorageIntegration.jsx
+++ b/src/components/storage/CockpitStorageIntegration.jsx
@@ -354,11 +354,7 @@ const CheckStorageDialog = ({
         const mode = useConfiguredStorage ? "use-configured-storage" : "use-free-space";
 
         dispatch(setStorageScenarioAction(mode));
-
-        if (!useConfiguredStorage && checkStep === "prepare-partitioning") {
-            setCheckStep();
-        }
-    }, [useConfiguredStorage, checkStep, dispatch]);
+    }, [useConfiguredStorage, dispatch]);
 
     useEffect(() => {
         if (checkStep !== "luks") {
@@ -408,6 +404,12 @@ const CheckStorageDialog = ({
         // If the required devices needed for manual partitioning are set up,
         // and prepare the partitioning
         if (checkStep !== "prepare-partitioning") {
+            return;
+        }
+
+        // If "Use configured storage" is not available, skip Manual partitioning creation
+        if (!useConfiguredStorage) {
+            setCheckStep();
             return;
         }
 


### PR DESCRIPTION
Previously we were resetting the checkStep prematurely, therefore causing a UI flicker between success and error mode in the cockpit storage integration exiting dialog.

Moving the checkStep reset before the 'prepare partitioning' step solves this issue.

