### PR TITLE
home reuse: add check for unexpected existing mount points

### DIFF
--- a/src/components/storage/InstallationScenario.jsx
+++ b/src/components/storage/InstallationScenario.jsx
@@ -175,6 +175,7 @@ const checkHomeReuse = ({ autopartScheme, devices, originalExistingSystems, sele
         }
     }
 
+    debug(`home reuse: Default scheme is ${autopartScheme}.`);
     if (reusedOS) {
         // Check that required autopartitioning scheme matches reused OS.
         // Check just "/home". To be more generic we could check all reused devices (as the backend).

--- a/src/components/storage/InstallationScenario.jsx
+++ b/src/components/storage/InstallationScenario.jsx
@@ -26,10 +26,13 @@ import {
     Title,
 } from "@patternfly/react-core";
 
+import { getAutopartReuseDBusRequest } from "../../apis/storage_partitioning.js";
+
 import { setStorageScenarioAction } from "../../actions/storage-actions.js";
 
 import { debug } from "../../helpers/log.js";
 import {
+    bootloaderTypes,
     getDeviceAncestors,
     getLockedLUKSDevices,
 } from "../../helpers/storage.js";
@@ -154,6 +157,19 @@ const checkHomeReuse = ({ autopartScheme, devices, originalExistingSystems, sele
         return missingDisks.length === 0;
     };
 
+    const getUnknownMountPoints = (scheme, existingOS) => {
+        const reuseRequest = getAutopartReuseDBusRequest(scheme);
+        const isBootloader = (device) => bootloaderTypes.includes(devices[device].formatData.type.v);
+        const existingMountPoints = Object.entries(existingOS["mount-points"].v)
+                .map(([mountPoint, device]) => isBootloader(device) ? "bootloader" : mountPoint);
+
+        const managedMountPoints = reuseRequest["reformatted-mount-points"].v
+                .concat(reuseRequest["reused-mount-points"].v, reuseRequest["removed-mount-points"].v);
+
+        const unknownMountPoints = existingMountPoints.filter(i => !managedMountPoints.includes(i));
+        return unknownMountPoints;
+    };
+
     // Check that exactly one Linux OS is present and it is Fedora Linux
     // (Stronger check for mountpoints uniqueness is in the backend
     const linuxSystems = originalExistingSystems.filter(osdata => osdata["os-name"].v.includes("Linux"))
@@ -191,6 +207,17 @@ const checkHomeReuse = ({ autopartScheme, devices, originalExistingSystems, sele
             availability.available = false;
             availability.hidden = true;
             debug(`home reuse: No reusable existing Linux system found, reused devices must have ${requiredSchemeTypes[autopartScheme]} type`);
+        }
+    }
+
+    if (reusedOS) {
+        // Check that existing system does not have mountpoints unexpected
+        // by the required autopartitioning scheme
+        const unknownMountPoints = getUnknownMountPoints(autopartScheme, reusedOS);
+        if (unknownMountPoints.length > 0) {
+            availability.available = false;
+            availability.hidden = true;
+            console.info(`home reuse: Unknown existing mountpoints found ${unknownMountPoints}`);
         }
     }
 

--- a/src/helpers/storage.js
+++ b/src/helpers/storage.js
@@ -170,3 +170,5 @@ export const unitMultiplier = {
     GB: 1000000000,
     TB: 1000000000000,
 };
+
+export const bootloaderTypes = ["efi", "biosboot", "appleboot", "prepboot"];

--- a/test/check-storage-home-reuse
+++ b/test/check-storage-home-reuse
@@ -34,6 +34,22 @@ BOTS_DIR = f'{ROOT_DIR}/bots'
 class TestStorageHomeReuseFedora(VirtInstallMachineCase, StorageCase):
     disk_image = "fedora-rawhide"
 
+    def setUp(self):
+        super().setUp()
+
+        if self._testMethodName == "testHidden":
+            return
+
+        # Remove the /var subvolume from the default btrfs layout
+        # as /var/ is not default mount point in Fedora which results in
+        # the 'Reinstall Fedora' option to get hidden
+        self.machine.execute("""
+            mount /dev/vda4 /mnt;
+            btrfs subvolume delete /mnt/var/lib/machines;
+            btrfs subvolume delete /mnt/var;
+            umount /mnt
+        """)
+
     @run_boot("bios", "efi")
     def testBasic(self):
         b = self.browser
@@ -68,6 +84,21 @@ class TestStorageHomeReuseFedora(VirtInstallMachineCase, StorageCase):
         r.check_disk_row(dev, "/home", f"{dev}4", "12.8 GB", False, "btrfs", is_encrypted=False,
                          action="mount")
 
+    def testHidden(self):
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m, scenario="home-reuse")
+        s = Storage(b, m)
+
+        pretend_default_scheme(self, "BTRFS")
+
+        i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+        s.rescan_disks()
+
+        # The `Re-install Fedora` scenario should not be available
+        # when unexpected mount points are present
+        s.wait_scenario_visible("home-reuse", False)
 
     @skipImage("btrfs support missing on fedora-eln image", "fedora-eln-boot")
     def testMultipleRoots(self):

--- a/test/check-storage-home-reuse-e2e
+++ b/test/check-storage-home-reuse-e2e
@@ -33,6 +33,19 @@ BOTS_DIR = f'{ROOT_DIR}/bots'
 class TestStorageHomeReuse_E2E(VirtInstallMachineCase, StorageCase):
     disk_image = "fedora-rawhide"
 
+    def setUp(self):
+        super().setUp()
+
+        # Remove the /var subvolume from the default btrfs layout
+        # as /var/ is not default mount point in Fedora which results in
+        # the 'Reinstall Fedora' option to get hidden
+        self.machine.execute("""
+            mount /dev/vda4 /mnt;
+            btrfs subvolume delete /mnt/var/lib/machines;
+            btrfs subvolume delete /mnt/var;
+            umount /mnt
+        """)
+
     def install(self, needs_confirmation):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
- [x] update tests (Fedora Cloud Image / `fedora-rawhide` has separate /var therefore it fails)