### PR TITLE
Revert "tests: do not update the anaconda packages till the wayland work reaches rawhide"

### DIFF
--- a/test/check-review
+++ b/test/check-review
@@ -46,7 +46,7 @@ class TestReview(VirtInstallMachineCase):
         r.check_language("English (United States)")
 
         # check selected disks are shown
-        r.check_disk("vda", "16.1 GB vda (0x1af4)")
+        r.check_disk("vda", "16.1 GB vda (Virtio Block Device)")
         r.check_disk_row("vda", "/boot", "vda2", "1.07 GB", True, "xfs")
         r.check_disk_row("vda", "/", "vda3, LVM", "15.0 GB", True, "xfs")
 
@@ -71,7 +71,7 @@ class TestReview(VirtInstallMachineCase):
         i.reach(i.steps.REVIEW)
 
         # check selected disks are shown
-        r.check_disk("vda", "16.1 GB vda (0x1af4)")
+        r.check_disk("vda", "16.1 GB vda (Virtio Block Device)")
         r.check_disk_row("vda", "/boot", "vda2", "1.07 GB", True, "xfs", is_encrypted=False)
         r.check_disk_row("vda", "/", "vda3, LVM", "15.0 GB", True, "xfs", is_encrypted=True)
 

--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -148,7 +148,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         def checkStorageReview(prefix=""):
             disk = "vda"
-            r.check_disk(disk, "16.1 GB vda (0x1af4)")
+            r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
             r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False, prefix=prefix)
             r.check_disk_row(disk, "/", "vda3, LVM", "6.01 GB", False, prefix=prefix)
             r.check_disk_row(disk, "/home", "vda3, LVM", "8.12 GB", False, prefix=prefix)
@@ -233,7 +233,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         # verify review screen
         dev = "vda"
-        r.check_disk(dev, "16.1 GB vda (0x1af4)")
+        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False)
         r.check_disk_row(dev, "/", "vda3", "15.0 GB", False, None, False, 3)
@@ -322,7 +322,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         # verify review screen
         dev = "vda"
-        r.check_disk(dev, "16.1 GB vda (0x1af4)")
+        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "ext4")
         r.check_disk_row(dev, "/", "vda3", "15.0 GB", True, "btrfs")

--- a/test/check-storage-home-reuse
+++ b/test/check-storage-home-reuse
@@ -56,7 +56,7 @@ class TestHomeReuseFedora(VirtInstallMachineCase, StorageCase):
 
 
         # check selected disks are shown
-        r.check_disk(dev, f"16.1 GB {dev} (0x1af4)")
+        r.check_disk(dev, f"16.1 GB {dev} (Virtio Block Device)")
         r.check_disk_row(dev, parent=f"{dev}3", action="delete")
         r.check_disk_row(dev, parent=f"{dev}1", action="delete")
         r.check_disk_row(dev, "/boot", f"{dev}3", "1.07 GB", True, "xfs", is_encrypted=False)
@@ -108,7 +108,7 @@ class TestHomeReuseFedora(VirtInstallMachineCase, StorageCase):
         i.reach(i.steps.REVIEW)
 
         # check selected disks are shown
-        r.check_disk(dev_fedora1, f"16.1 GB {dev_fedora1} (0x1af4)")
+        r.check_disk(dev_fedora1, f"16.1 GB {dev_fedora1} (Virtio Block Device)")
         r.check_disk_row(dev_fedora1, parent=f"{dev_fedora1}3", action="delete")
         r.check_disk_row(dev_fedora1, parent=f"{dev_fedora1}1", action="delete")
         r.check_disk_row(dev_fedora1, "/boot", f"{dev_fedora1}3", "1.07 GB", True, "xfs", is_encrypted=False)
@@ -142,7 +142,7 @@ class TestHomeReuseFedoraEFI(VirtInstallMachineCase, StorageCase):
         # check selected disks are shown
         r.check_disk_row(dev, parent=f"{dev}2", action="delete")
         r.check_disk_row(dev, parent=f"{dev}3", action="delete")
-        r.check_disk(dev, f"16.1 GB {dev} (0x1af4)")
+        r.check_disk(dev, f"16.1 GB {dev} (Virtio Block Device)")
         r.check_disk_row(dev, "/boot", f"{dev}3", "1.07 GB", True, "xfs", is_encrypted=False)
         r.check_disk_row(dev, "/boot/efi", f"{dev}2", "629 MB", True, "efi", is_encrypted=False)
         r.check_disk_row(dev, "/", f"{dev}4", "12.8 GB", True, "btrfs", is_encrypted=False)

--- a/test/check-storage-mountpoints
+++ b/test/check-storage-mountpoints
@@ -77,7 +77,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         i.reach(i.steps.REVIEW)
 
         # verify review screen
-        r.check_disk(dev, "16.1 GB vda (0x1af4)")
+        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "ext4")
         r.check_disk_row(dev, "/", "vda3", "10.7 GB", True, "btrfs")
@@ -210,12 +210,12 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
 
         # verify review screen
         disk = "vda"
-        r.check_disk(disk, "16.1 GB vda (0x1af4)")
+        r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
         r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False)
         r.check_disk_row(disk, "/", "vda3", "15.0 GB", True, "xfs")
 
         disk = "vdb"
-        r.check_disk(disk, "10.7 GB vdb (0x1af4)")
+        r.check_disk(disk, "10.7 GB vdb (Virtio Block Device)")
         r.check_disk_row(disk, "/home", "vdb1", "10.7 GB", False)
 
         b.assert_pixels(
@@ -415,7 +415,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
 
         # verify review screen
         disk = "vda"
-        r.check_disk(disk, "16.1 GB vda (0x1af4)")
+        r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
 
         r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False)
         r.check_disk_row(disk, "/", "vda3", "5.37 GB", True, "btrfs")
@@ -483,7 +483,7 @@ class TestStorageMountPointsEFI(VirtInstallMachineCase):
         i.reach(i.steps.REVIEW)
 
         # verify review screen
-        r.check_disk(dev, "16.1 GB vda (0x1af4)")
+        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
         r.check_disk_row(dev, "/boot/efi", "vda1", "524 MB", False)
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False)

--- a/test/check-storage-mountpoints-btrfs
+++ b/test/check-storage-mountpoints-btrfs
@@ -82,7 +82,7 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase, StorageCase):
         i.reach(i.steps.REVIEW)
 
         # verify review screen
-        r.check_disk(dev, "16.1 GB vda (0x1af4)")
+        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
         r.check_disk_row(dev, "/boot", "vda2",  "1.07 GB", True, "ext4")
         r.check_disk_row(dev, "/", "vda3", "15.0 GB", True, "btrfs")

--- a/test/check-storage-mountpoints-lvm
+++ b/test/check-storage-mountpoints-lvm
@@ -83,7 +83,7 @@ class TestStorageMountPointsLVM(VirtInstallMachineCase, StorageCase):
 
         # verify review screen
         disk = "vda"
-        r.check_disk(disk, "16.1 GB vda (0x1af4)")
+        r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
 
         r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", True, "ext4")
         r.check_disk_row(disk, "/", "vda3, LVM", "6.01 GB", True, "ext4")
@@ -102,7 +102,7 @@ class TestStorageMountPointsLVM(VirtInstallMachineCase, StorageCase):
 
         # verify review screen
         disk = "vda"
-        r.check_disk(disk, "16.1 GB vda (0x1af4)")
+        r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
 
         r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False)
         r.check_disk_row(disk, "/", "vda3, LVM", "6.01 GB", True, "ext4")

--- a/test/check-storage-mountpoints-raid
+++ b/test/check-storage-mountpoints-raid
@@ -69,7 +69,7 @@ class TestStorageMountPointsRAID(VirtInstallMachineCase, StorageCase):
 
         i.reach(i.steps.REVIEW)
 
-        r.check_disk(dev, "16.1 GB vda (0x1af4)")
+        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "xfs")
         r.check_disk_row(dev, "/", "vda3, vda4, RAID", "5.35 GB", True, "xfs", True)
@@ -121,7 +121,7 @@ class TestStorageMountPointsRAID(VirtInstallMachineCase, StorageCase):
 
         i.reach(i.steps.REVIEW)
 
-        r.check_disk(dev, "16.1 GB vda (0x1af4)")
+        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
         r.check_disk_row(dev, "/", "vda3, vda4, RAID", "5.35 GB",  True, "xfs", True)
 
 

--- a/test/check-storage-reclaim
+++ b/test/check-storage-reclaim
@@ -114,21 +114,21 @@ class TestReclaim(VirtInstallMachineCase, StorageCase):
         s.reclaim_check_available_space("1.03 MB")
 
         # Check that all partitions are present
-        s.reclaim_check_device_row("vda (0x", "", "disk", "16.1 GB")
+        s.reclaim_check_device_row("vda (Virtio", "", "disk", "16.1 GB")
         s.reclaim_check_device_row("vda1", "", "biosboot", "1.05 MB")
         s.reclaim_check_device_row("vda2", "", "ext4", "4.29 GB")
         s.reclaim_check_device_row("vda3", "", "btrfs", "5.37 GB")
         s.reclaim_check_device_row("vda4", "", "btrfs", "6.44 GB")
 
         # Check that deleting a disk will delete all contained partitions
-        s.reclaim_remove_device("vda (0x")
+        s.reclaim_remove_device("vda (Virtio")
         for device in ["vda1", "vda2", "vda3"]:
             s.reclaim_check_action_present(device, "delete")
 
         s.reclaim_check_available_space("16.1 GB")
 
         # Undo disk device deletion
-        s.reclaim_undo_action("vda (0x")
+        s.reclaim_undo_action("vda (Virtio")
         for device in ["vda1", "vda2", "vda3"]:
             s.reclaim_check_action_present(device, "delete", False)
 
@@ -136,7 +136,7 @@ class TestReclaim(VirtInstallMachineCase, StorageCase):
 
         # Check that actions for devices whose parents are marked for deletion are not sent to blivet
         s.reclaim_remove_device("vda4")
-        s.reclaim_remove_device("vda (0x")
+        s.reclaim_remove_device("vda (Virtio")
         s.reclaim_modal_submit()
 
         i.back()
@@ -150,9 +150,9 @@ class TestReclaim(VirtInstallMachineCase, StorageCase):
 
         # Check that deleting a parent disk which contains partitions marked for deletion
         # correctly calculates the available space
-        s.reclaim_remove_device("vda (0x")
+        s.reclaim_remove_device("vda (Virtio")
         s.reclaim_check_available_space("16.1 GB")
-        s.reclaim_undo_action("vda (0x")
+        s.reclaim_undo_action("vda (Virtio")
         s.reclaim_check_available_space("6.44 GB")
 
         s.reclaim_modal_submit()
@@ -175,7 +175,7 @@ class TestReclaim(VirtInstallMachineCase, StorageCase):
         s.reclaim_check_available_space("1.03 MB")
 
         # Check that shrinking action is only available for partitions
-        s.reclaim_check_action_button_present("vda (0x", "shrink", False)
+        s.reclaim_check_action_button_present("vda (Virtio", "shrink", False)
         for device in ["vda2"]:
             s.reclaim_check_action_button_present(device, "shrink", True)
 

--- a/test/vm.install
+++ b/test/vm.install
@@ -70,10 +70,7 @@ def vm_install(image, verbose, quick):
         # unless we are testing a PR on rhinstaller/anaconda, then pull it from the PR COPR repo
         if not scenario or not scenario.startswith("anaconda-pr-"):
             # anaconda-core is also available in the default rawhide compose, make sure we don't pull it from there
-            # download_from_copr("@rhinstaller/Anaconda", "anaconda-core anaconda-tui", machine)
-            # FIXME: don't get latest anaconda-[core, tui] packages through updates.img till the wayland
-            # migration patches are in the rawhide boot.iso
-            pass
+            download_from_copr("@rhinstaller/Anaconda", "anaconda-core anaconda-tui", machine)
         else:
             anaconda_pr = scenario.split("-")[-1]
             # anaconda-core is also available in the default rawhide compose, make sure we don't pull it from there


### PR DESCRIPTION
Fix tests on main Anaconda repository by unblocking Anaconda RPMs from PR testing. Also adapt for a new disk label of virtio block devices.

This reverts commit 9f59b69ea4a3d0aa10d89c9065c183ab73c5e118.