### PR TITLE
storage: restrict access to the storage editor to the scenario selection step

### DIFF
--- a/src/components/storage/CockpitStorageIntegration.jsx
+++ b/src/components/storage/CockpitStorageIntegration.jsx
@@ -39,6 +39,7 @@ import {
     Text,
     TextContent,
     Title,
+    Tooltip,
 } from "@patternfly/react-core";
 import { ArrowLeftIcon } from "@patternfly/react-icons";
 
@@ -69,7 +70,6 @@ import { getDeviceByName, getDeviceByPath } from "../../helpers/storage.js";
 import { EmptyStatePanel } from "cockpit-components-empty-state";
 
 import { StorageContext, TargetSystemRootContext } from "../Common.jsx";
-import { getSteps } from "../steps.js";
 import {
     useDiskFreeSpace,
     useDiskTotalSpace,
@@ -647,16 +647,12 @@ export const ModifyStorage = ({ currentStepId, setShowStorage }) => {
         efi: isEfi,
         mount_point_prefix: targetSystemRoot,
     });
-    const isDisabled = useMemo(() => {
-        const steps = getSteps();
-        const currentStep = steps.find(step => step.id === currentStepId);
-        return currentStep?.isFinal;
-    }, [currentStepId]);
-
-    return (
+    // Allow to modify storage only when we are in the scenario selection page
+    const isDisabled = currentStepId !== "installation-method";
+    const item = (
         <DropdownItem
           id="modify-storage"
-          isDisabled={isDisabled}
+          isAriaDisabled={isDisabled}
           onClick={() => {
               window.sessionStorage.setItem("cockpit_anaconda", cockpitAnaconda);
               setShowStorage(true);
@@ -665,4 +661,18 @@ export const ModifyStorage = ({ currentStepId, setShowStorage }) => {
             {_("Launch storage editor")}
         </DropdownItem>
     );
+
+    if (!isDisabled) {
+        return item;
+    } else {
+        return (
+            <Tooltip
+              id="modify-storage-tooltip"
+              content={_("Storage editor is available only in the `Installation method` step.")}>
+                <span>
+                    {item}
+                </span>
+            </Tooltip>
+        );
+    }
 };

--- a/test/check-progress
+++ b/test/check-progress
@@ -63,7 +63,7 @@ class TestInstallationProgress(VirtInstallMachineCase):
 
         # Check that at this stage 'Modify Storage' is not available
         b.click("#toggle-kebab")
-        b.wait_visible("li.pf-m-disabled #modify-storage")
+        b.wait_visible("li.pf-m-aria-disabled #modify-storage")
 
         self.handleReboot()
 


### PR DESCRIPTION
Accessing the Cockpit storage editor outside the scenario selection step can cause unexpected issues during installation.  To prevent this, the dropdown item for the storage editor is now disabled when not on the storage entry page.