### PR TITLE
Allow Anaconda to override Firefox shortcuts

### DIFF
--- a/firefox-theme/live/user.js
+++ b/firefox-theme/live/user.js
@@ -46,3 +46,6 @@ user_pref("dom.disable_open_during_load", false);
 
 // Disable built in Password Manager / Password Generation
 user_pref("signon.generation.enabled", false);
+
+// Allow overriding Firefox shortcuts from page JS
+user_pref("permissions.default.shortcuts", "1");


### PR DESCRIPTION
This tells Firefox to allow us to override its built in shortcuts, so we could rewrite what ctrl-w, ctrl-q, ctrl-t, and the rest do from within Anaconda.

(It might or might not still work in current Firefox; the docs I saw about it are years old.)