### PR TITLE
Remove `installation-` prefix from all selectors

### DIFF
--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -140,7 +140,7 @@ export const AnacondaWizard = ({ currentStepId, dispatch, isFetching, onCritFail
                 setIsFormValid,
             }}>
                 <Wizard
-                  id="installation-wizard"
+                  id="wizard"
                   isVisitRequired
                   startIndex={startIndex}
                   footer={<AnacondaWizardFooter {...footerProps} />}

--- a/src/components/AnacondaWizardFooter.jsx
+++ b/src/components/AnacondaWizardFooter.jsx
@@ -83,21 +83,21 @@ export const AnacondaWizardFooter = ({
                 {footerHelperText}
                 <ActionList>
                     <Button
-                      id="installation-back-btn"
+                      id="back-btn"
                       variant="secondary"
                       isDisabled={isFirstScreen || isFormDisabled}
                       onClick={() => onBack()}>
                         {_("Back")}
                     </Button>
                     <Button
-                      id="installation-next-btn"
+                      id="next-btn"
                       variant={nextButtonVariant || "primary"}
                       isDisabled={!isFormValid || isFormDisabled}
                       onClick={onNextButtonClicked}>
                         {nextButtonText || _("Next")}
                     </Button>
                     <Button
-                      id="installation-quit-btn"
+                      id="quit-btn"
                       isDisabled={isFormDisabled}
                       style={{ marginLeft: "var(--pf-v5-c-wizard__footer-cancel--MarginLeft)" }}
                       variant="link"
@@ -118,10 +118,10 @@ export const QuitInstallationConfirmModal = ({ exitGui, setQuitWaitsConfirmation
 
     return (
         <Modal
-          id="installation-quit-confirm-dialog"
+          id="quit-confirm-dialog"
           actions={[
               <Button
-                id="installation-quit-confirm-btn"
+                id="quit-confirm-btn"
                 key="confirm"
                 onClick={() => {
                     exitGui();
@@ -131,7 +131,7 @@ export const QuitInstallationConfirmModal = ({ exitGui, setQuitWaitsConfirmation
                   {isBootIso ? _("Reboot") : _("Quit")}
               </Button>,
               <Button
-                id="installation-quit-confirm-cancel-btn"
+                id="quit-confirm-cancel-btn"
                 key="cancel"
                 onClick={() => setQuitWaitsConfirmation(false)}
                 variant="secondary">

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -14,11 +14,11 @@ html:not(.index-page) body {
   }
 }
 
-#installation-wizard .pf-v5-c-wizard__main {
+#wizard .pf-v5-c-wizard__main {
   display: flex;
 }
 
-#installation-wizard .pf-v5-c-wizard__main-body {
+#wizard .pf-v5-c-wizard__main-body {
   flex: 1 1 auto;
 }
 

--- a/src/components/installation/InstallationProgress.jsx
+++ b/src/components/installation/InstallationProgress.jsx
@@ -45,27 +45,27 @@ import "./InstallationProgress.scss";
 
 const _ = cockpit.gettext;
 const N_ = cockpit.noop;
-const idPrefix = "installation-progress";
+const idPrefix = "progress";
 
 const progressSteps = [
     {
         description: _("Storage configuration: Storage is currently being configured."),
-        id: "installation-progress-step-storage",
+        id: "progress-step-storage",
         title: _("Storage configuration"),
     },
     {
         description: _("Software installation: Storage configuration complete. The software is now being installed onto your device."),
-        id: "installation-progress-step-payload",
+        id: "progress-step-payload",
         title: _("Software installation"),
     },
     {
         description: _("System configuration: Software installation complete. The system is now being configured."),
-        id: "installation-progress-step-configuration",
+        id: "progress-step-configuration",
         title: _("System configuration"),
     },
     {
         description: _("Finalizing: The system configuration is complete. Finalizing installation may take a few moments."),
-        id: "installation-progress-step-boot-loader",
+        id: "progress-step-boot-loader",
         title: _("Finalization"),
     },
 ];
@@ -239,7 +239,7 @@ const InstallationProgress = ({ onCritFail }) => {
 export class Page {
     constructor () {
         this.component = InstallationProgress;
-        this.id = "installation-progress";
+        this.id = "progress";
         this.isFinal = true;
     }
 }

--- a/src/components/installation/InstallationProgress.scss
+++ b/src/components/installation/InstallationProgress.scss
@@ -2,7 +2,7 @@
     width: 100%;
 }
 
-.installation-progress-status {
+.progress-status {
     &-success .pf-v5-c-empty-state__icon {
         color: var(--pf-v5-global--success-color--100);
     }

--- a/src/components/localization/InstallationLanguage.jsx
+++ b/src/components/localization/InstallationLanguage.jsx
@@ -256,7 +256,7 @@ class LanguageSelector extends React.Component {
 
         return (
             <>
-                <TextInputGroup className="installation-language-search">
+                <TextInputGroup className={this.props.idPrefix + "-search"}>
                     <TextInputGroupMain
                       icon={<SearchIcon />}
                       value={this.state.search}
@@ -276,8 +276,8 @@ class LanguageSelector extends React.Component {
                     )}
                 </TextInputGroup>
                 <Menu
-                  className="installation-language-menu"
-                  id={this.props.idPrefix + "-language-menu"}
+                  className={this.props.idPrefix + "-menu"}
+                  id={this.props.idPrefix + "-menu"}
                   isScrollable
                   isPlain
                   onSelect={handleOnSelect}
@@ -334,7 +334,7 @@ const PageTitle = () => {
 export class Page {
     constructor (isBootIso) {
         this.component = InstallationLanguage;
-        this.id = "installation-language";
+        this.id = "language";
         this.isHidden = !isBootIso;
         this.label = _("Welcome");
         this.title = <PageTitle />;

--- a/src/components/localization/InstallationLanguage.scss
+++ b/src/components/localization/InstallationLanguage.scss
@@ -1,16 +1,16 @@
-.installation-language-menu.pf-v5-c-menu.pf-m-scrollable {
+.language-menu.pf-v5-c-menu.pf-m-scrollable {
     max-width: 400px;
     // heading: 84, footer: 44, content (about from header): 158, necessary padding underneath: 8px,
     // 50px magic number
     --pf-v5-c-menu__content--MaxHeight: calc(100vh - 84px - 44px - 158px - 8px - 50px);
 }
 
-.installation-language-search {
+.language-search {
     margin-bottom: var(--pf-v5-global--spacer--sm);
     max-width: 400px;
 }
 
-.installation-language-menu {
+.language-menu {
     border: var(--pf-v5-global--BorderWidth--sm) solid var(--pf-v5-global--BorderColor--100);
 }
 
@@ -21,7 +21,7 @@ to prevent surprises elsewhere. However, if we use the widget elsewhere,
 it would also need this fix, so this is definitely a fix for PF
 overrides, not a local fix.
 */
-#installation-language-language-menu {
+#language-menu {
   // Oddly, the spacing here isn't consistent with the reference on the website;
   // it should be balanced on the top and bottom, not all just on the top
   .pf-v5-c-menu__group-title {

--- a/src/components/review/Hostname.jsx
+++ b/src/components/review/Hostname.jsx
@@ -38,7 +38,7 @@ import { setHostname } from "../../apis/network.js";
 import { NetworkContext } from "../Common.jsx";
 
 const _ = cockpit.gettext;
-const idPrefix = "installation-review";
+const idPrefix = "review";
 
 const ChangeHostname = ({ initHostname }) => {
     const [currentHostname, setCurrentHostname] = useState(initHostname);

--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -38,7 +38,7 @@ import { StorageReview, StorageReviewNote } from "./StorageReview.jsx";
 import "./ReviewConfiguration.scss";
 
 const _ = cockpit.gettext;
-const idPrefix = "installation-review";
+const idPrefix = "review";
 
 const ReviewDescriptionList = ({ children }) => {
     return (
@@ -211,7 +211,7 @@ const CustomFooter = ({ setIsFormValid }) => {
           footerHelperText={confirmationCheckbox}
           nextButtonText={buttonLabel}
           nextButtonVariant={!installationIsClean ? "warning" : "primary"}
-          onNext={() => cockpit.location.go(["installation-progress"])}
+          onNext={() => cockpit.location.go(["progress"])}
         />
     );
 };

--- a/src/components/review/StorageReview.jsx
+++ b/src/components/review/StorageReview.jsx
@@ -344,7 +344,7 @@ export const StorageReviewNote = () => {
 
     return (
         <ReviewDescriptionListItem
-          id="installation-review-target-storage-note"
+          id="review-target-storage-note"
           term={_("Note")}
           description={description}
         />

--- a/src/components/storage/CockpitStorageIntegration.jsx
+++ b/src/components/storage/CockpitStorageIntegration.jsx
@@ -87,7 +87,7 @@ const idPrefix = "cockpit-storage-integration";
 const ReturnToInstallationButton = ({ onAction }) => (
     <Button
       icon={<ArrowLeftIcon />}
-      id={idPrefix + "-return-to-installation-button"}
+      id={idPrefix + "-return-to-button"}
       variant="secondary"
       onClick={onAction}>
         {_("Return to installation")}
@@ -651,7 +651,7 @@ export const ModifyStorage = ({ currentStepId, setShowStorage }) => {
         mount_point_prefix: targetSystemRoot,
     });
     // Allow to modify storage only when we are in the scenario selection page
-    const isDisabled = currentStepId !== "installation-method";
+    const isDisabled = currentStepId !== "method";
     const item = (
         <DropdownItem
           id="modify-storage"

--- a/src/components/storage/DiskEncryption.jsx
+++ b/src/components/storage/DiskEncryption.jsx
@@ -53,7 +53,7 @@ const ruleAscii = {
 };
 
 const CheckDisksSpinner = (
-    <EmptyState id="installation-destination-next-spinner">
+    <EmptyState id="destination-next-spinner">
         <EmptyStateHeader titleText={<>{_("Checking storage configuration")}</>} icon={<EmptyStateIcon icon={Spinner} />} headingLevel="h4" />
         <EmptyStateFooter>
             <TextContent>

--- a/src/components/storage/InstallationDestination.scss
+++ b/src/components/storage/InstallationDestination.scss
@@ -1,5 +1,5 @@
-.installation-method-selector {
-  .installation-method-disk-selector {
+.method-selector {
+  .method-disk-selector {
     width: 50%;
   }
 
@@ -8,17 +8,17 @@
   }
 }
 
-.installation-method-target-disk-size,
-.installation-method-target-disk-existing-os {
+.method-target-disk-size,
+.method-target-disk-existing-os {
   color: var(--pf-v5-global--Color--200);
   font-size: var(--pf-v5-global--FontSize--sm);
 }
 
 // Add some border to the disk selection menu
-.installation-method-disk-selection-stack {
+.method-disk-selection-stack {
   border: var(--pf-v5-global--BorderWidth--sm) solid var(--pf-v5-global--BorderColor--100);
 
-  .installation-method-disk-selection-rescan {
+  .method-disk-selection-rescan {
     margin-top: var(--pf-v5-global--spacer--md);
     margin-bottom: var(--pf-v5-global--spacer--md);
     align-self: center;

--- a/src/components/storage/InstallationMethod.jsx
+++ b/src/components/storage/InstallationMethod.jsx
@@ -228,7 +228,7 @@ const PageTitle = () => {
 export class Page {
     constructor (isBootIso) {
         this.component = InstallationMethod;
-        this.id = "installation-method";
+        this.id = "method";
         this.label = _("Installation method");
         this.title = !isBootIso ? <PageTitle /> : null;
         this.usePageInit = usePageInit;

--- a/src/components/storage/InstallationScenario.scss
+++ b/src/components/storage/InstallationScenario.scss
@@ -1,20 +1,20 @@
-.installation-method-scenario {
+.method-scenario {
   .pf-v5-c-radio__body {
     margin-top: 0;
     font-size: var(--pf-v5-global--FontSize--sm);
 
-    .installation-method-scenario-disabled-reason {
+    .method-scenario-disabled-reason {
       font-weight: var(--pf-v5-global--FontWeight--bold);
       margin-inline-end: var(--pf-v5-global--spacer--xs);
     }
 
-    .installation-method-scenario-review {
+    .method-scenario-review {
         color: var(--pf-v5-c-radio__description--Color);
     }
   }
 }
 
 // Increase the standard radio button spacing
-.installation-method-scenario-group .pf-v5-c-form__group-control {
+.method-scenario-group .pf-v5-c-form__group-control {
   gap: var(--pf-v5-global--spacer--md);
 }

--- a/test/check-basic
+++ b/test/check-basic
@@ -98,7 +98,7 @@ class TestBasic(VirtInstallMachineCase):
         i.reach(i.steps.INSTALLATION_METHOD)
 
         # Back button should be disabled on the first screen
-        b.wait_visible("#installation-back-btn[aria-disabled=true]")
+        b.wait_visible("#back-btn[aria-disabled=true]")
 
         # For live media in the review screen language details should still be displayed
         i.reach(i.steps.REVIEW)

--- a/test/helpers/installer.py
+++ b/test/helpers/installer.py
@@ -21,13 +21,13 @@ from users import create_user
 
 
 class InstallerSteps(UserDict):
-    WELCOME = "installation-language"
-    INSTALLATION_METHOD = "installation-method"
+    WELCOME = "language"
+    INSTALLATION_METHOD = "method"
     CUSTOM_MOUNT_POINT = "mount-point-mapping"
     STORAGE_CONFIGURATION = "storage-configuration"
     ACCOUNTS = "accounts"
-    REVIEW = "installation-review"
-    PROGRESS = "installation-progress"
+    REVIEW = "review"
+    PROGRESS = "progress"
 
     def __init__(self, hidden_steps=None, scenario=None):
         super().__init__()
@@ -89,12 +89,12 @@ class Installer():
         current_page = self.get_current_page()
 
         if needs_confirmation:
-            self.browser.wait_visible("#installation-next-btn[aria-disabled=true]")
+            self.browser.wait_visible("#next-btn[aria-disabled=true]")
             self.browser.click(f"#{self.steps.REVIEW}-next-confirmation-checkbox")
-            self.browser.wait_visible("#installation-next-btn[aria-disabled=false]")
+            self.browser.wait_visible("#next-btn[aria-disabled=false]")
 
-        self.browser.wait_text("#installation-next-btn", button_text)
-        self.browser.click("#installation-next-btn")
+        self.browser.wait_text("#next-btn", button_text)
+        self.browser.click("#next-btn")
 
         if should_fail:
             self.wait_current_page(current_page)
@@ -135,7 +135,7 @@ class Installer():
         if current_page == self.steps.INSTALLATION_METHOD:
             sleep(2)
 
-        self.browser.click("#installation-next-btn")
+        self.browser.click("#next-btn")
         expected_page = current_page if should_fail else next_page
         self.wait_current_page(expected_page)
         return expected_page
@@ -148,7 +148,7 @@ class Installer():
         :type disabled: bool, optional
         """
         value = "false" if disabled else "true"
-        self.browser.wait_visible(f"#installation-next-btn:not([aria-disabled={value}]")
+        self.browser.wait_visible(f"#next-btn:not([aria-disabled={value}]")
 
     def check_sidebar_step_disabled(self, step, disabled=True):
         """Check if a sidebar step is disabled.
@@ -199,7 +199,7 @@ class Installer():
 
     @log_step(snapshot_after=True)
     def wait_current_page(self, page):
-        self.browser.wait_not_present("#installation-destination-next-spinner")
+        self.browser.wait_not_present("#destination-next-spinner")
         self.browser.wait_js_cond(f'window.location.hash === "#/{page}"')
 
         if page == self.steps.PROGRESS:

--- a/test/helpers/progress.py
+++ b/test/helpers/progress.py
@@ -28,7 +28,7 @@ class Progress():
     def __init__(self, browser):
         self.browser = browser
         self.steps = InstallerSteps()
-        self._reboot_selector = ".installation-progress-status-success button:contains('Reboot')"
+        self._reboot_selector = ".progress-status-success button:contains('Reboot')"
 
     @log_step(snapshot_after=True)
     def wait_done(self, timeout=1200):

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -30,12 +30,12 @@ DISK_INITIALIZATION_INTERFACE = "org.fedoraproject.Anaconda.Modules.Storage.Disk
 STORAGE_OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Storage"
 DISK_INITIALIZATION_OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Storage/DiskInitialization"
 
-id_prefix = "installation-method"
+id_prefix = "method"
 
 
 class StorageDestination():
     def __init__(self, browser, machine):
-        self._step = "installation-method"
+        self._step = id_prefix
         self.browser = browser
         self.machine = machine
 
@@ -80,7 +80,7 @@ class StorageDestination():
         self.browser.click("#cockpit-storage-integration-enter-storage-confirm")
 
     def return_to_installation(self):
-        self.browser.click("#cockpit-storage-integration-return-to-installation-button")
+        self.browser.click("#cockpit-storage-integration-return-to-button")
 
     def return_to_installation_confirm(self):
         with self.browser.wait_timeout(30):
@@ -161,7 +161,7 @@ class StorageEncryption():
             b.wait_in_text("#unlock-device-dialog .pf-v5-c-helper-text", fail_text)
 
     def unlock_all_encrypted(self):
-        self.browser.click("#installation-method-unlock-devices-btn")
+        self.browser.click(f"#{id_prefix}-unlock-devices-btn")
 
 
 class StorageUtils(StorageDestination):


### PR DESCRIPTION
Do this because not we are exposing the selector IDs for use by anaconda.conf, for hidden_pages option.

Since this is part of an API now, we need to be consistent with the naming of the page IDs, and also not include the redundant 'installation' substring.