### PR TITLE
Fix scripts/makeupdates root detection

### DIFF
--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -50,7 +50,7 @@ def usage(cmd):
 def main(argv):
     prog = os.path.basename(argv[0])
     cwd = os.getcwd()
-    spec = os.path.realpath(cwd + '/anaconda-webui.spec')
+    metainfo = os.path.realpath(cwd + '/org.cockpit-project.anaconda-webui.metainfo.xml')
     updates = cwd + '/updates'
     show_help, unknown = False, False
     opts = []
@@ -77,7 +77,7 @@ def main(argv):
         sys.stderr.write("Try `%s --help' for more information." % (prog,))
         sys.exit(1)
 
-    if not os.path.isfile(spec):
+    if not os.path.isfile(metainfo):
         sys.stderr.write("You must be at the top level of the repository source tree.\n")
         sys.exit(1)
 


### PR DESCRIPTION
It currently only works if you have run certain `make` targets - anaconda-webui.spec is not part of the version-controlled repo, it's generated. It seems safer to look for a file under version control.

I'm not sure the script is much use for anaconda-webui anyway - I don't think there's a mechanism to apply changes to the jsx files, for e.g. - but it doesn't hurt to improve this.