### PR TITLE
tests: fix nightly action for testing latest compose

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,4 +18,10 @@ jobs:
           mkdir -p ~/.config/cockpit-dev
           echo "${{ github.token }}" >> ~/.config/cockpit-dev/github-token
           export TEST_COMPOSE=$(curl -s https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/COMPOSE_ID)
+
+          # FIXME: Uncomment once bfe0973d2520fa155ff6bc673818a098f2a94154 reaches rawhide
+          # Run the tests that correspond to anaconda-webui version used in the latest compose
+          # LATEST_COMPOSE_A_PACKAGES = https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/x86_64/os/Packages/a/
+          # ANACONDA_WEBUI_TAG=$(curl -s $LATEST_COMPOSE_A_PACKAGES | grep -oP '>anaconda-webui-[0-9]+' | cut -d "-" -f3)
+          # git reset --hard $ANACONDA_WEBUI_TAG
           make test-compose

--- a/test/download-iso
+++ b/test/download-iso
@@ -14,7 +14,7 @@ if [ -f test/images/"$TEST_COMPOSE".iso ]; then
 fi
 
 # Construct ISO URL from the compose directory
-ISO_FOLDER="https://kojipkgs.fedoraproject.org/compose/${RELEASE}/${TEST_COMPOSE}/compose/Everything/x86_64/iso/"
+ISO_FOLDER="https://kojipkgs.fedoraproject.org/compose/${RELEASE}/${TEST_COMPOSE}/compose/Server/x86_64/iso/"
 
 if ! curl -L --silent --fail --output /dev/null --head -- "$ISO_FOLDER"; then
     echo "Specified compose $TEST_COMPOSE does not exist"

--- a/test/run
+++ b/test/run
@@ -13,7 +13,7 @@
 set -eux
 
 make codecheck
-make create-updates.img
+make bots
 
 RUN_OPTS=""
 ALL_TESTS="$(test/common/run-tests --test-dir test -l)"
@@ -36,6 +36,9 @@ case "${TEST_SCENARIO:=}" in
         RUN_OPTS="$ALL_TESTS"
         ;;
 esac
+
+# We need to know if a TEST_COMPOSE is specified before we start downloading the test images
+make create-updates.img
 
 # test runs in kernel_t context and triggers massive amounts of SELinux
 # denials; SELinux gets disabled, but would still trigger unexpected messages

--- a/test/vm.install
+++ b/test/vm.install
@@ -61,9 +61,11 @@ def vm_install(image, compose, verbose, quick):
             anaconda_webui_pr = scenario.split("-")[-1]
             # anaconda-webui is also available in the default rawhide compose, make sure we don't pull it from there
             download_from_copr(f"packit/rhinstaller-anaconda-webui-{anaconda_webui_pr}", "anaconda-webui", machine)
-        elif compose:
-            # If we are testing a custom compose download the anaconda-webui from the compose
-            machine.execute("dnf download --destdir /var/tmp/build/ anaconda-webui", stdout=sys.stdout, timeout=300)
+        # FIXME: Revert once bfe0973d2520fa155ff6bc673818a098f2a94154 reaches rawhide
+        # Then change the nightly action to git checkout the tag that Anaconda-webui was built from for the compose
+        # elif compose:
+        #     # If we are testing a custom compose download the anaconda-webui from the compose
+        #     machine.execute("dnf download --destdir /var/tmp/build/ anaconda-webui", stdout=sys.stdout, timeout=300)
         else:
             # Build anaconda-webui from SRPM otherwise
             files_to_clean = glob.glob("anaconda-webui-*.rpm") + glob.glob("anaconda-webui-*.tar.xz") + ["anaconda-webui.spec"]


### PR DESCRIPTION
We want to test the compose untouched, that means anaconda-webui package that is inside the compose. That means we also need to checkout the anaconda-webui repository, before running the tests to the tag used in the compose.
This is problematic, because our support for testing composes did not yet land in rawhide, therefore no tag contains that currently.

Let's test against anaconda-webui from main branch, temporarily.