### PR TITLE
tests: generate report.json for TEST_SCENARIO=compose-XYZ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 /test/common/
 /test/images
 /test/ks*.cfg
+/test/report.json

--- a/test/prepare-report
+++ b/test/prepare-report
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -eu
+
+# This script creates the report.json which will be used by the CI run to report the test results to OpenQA.
+# Here is only fills in the metadata section. The tests section will be filled by the test run.
+#
+# Structure of report.json
+# {
+#   "metadata": {
+#     "compose": "rawhide/Fedora-Rawhide-20250117.n.0",
+#     "test_env": "qemu-x86_64",
+#   },
+#   "tests": [
+#     {
+#       "test_name": "TestClassX1.test_example_feature",
+#       "firmware": "uefi",
+#       "openqa_test": "https://fedoraproject.org/wiki/QA:Testcase_webui_partitioning_guided_multi_select",
+#       "status": "pass",
+#     },
+#     {
+#       "test_name": "TestClassX2.test_another_feature",
+#       "firmware": "bios",
+#       "openqa_test": "https://fedoraproject.org/wiki/QA:Testcase_webui_partitioning_guided_free_space",
+#       "status": "fail",
+#     }
+#   ],
+#   "timestamp": "2025-01-17T10:30:00Z"
+# }
+
+COMPOSE=$TEST_COMPOSE
+TEST_ENV="qemu-x86_64"
+
+cat <<EOF > ./test/report.json
+{
+  "metadata": {
+    "compose": "$COMPOSE",
+    "test_env": "$TEST_ENV"
+  },
+  "tests": [],
+  "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+}
+EOF

--- a/test/run
+++ b/test/run
@@ -40,6 +40,11 @@ esac
 # We need to know if a TEST_COMPOSE is specified before we start downloading the test images
 make create-updates.img
 
+# If TEST_COMPOSE is defined prepare the test report
+if [ -n "${TEST_COMPOSE-}" ]; then
+  test/prepare-report
+fi
+
 # test runs in kernel_t context and triggers massive amounts of SELinux
 # denials; SELinux gets disabled, but would still trigger unexpected messages
 # we create huge VMs, so we need to reduce parallelism on CI


### PR DESCRIPTION
This can be parsed from OpenQA tools, for writing our test results into Fedora Test Wiki.