### PR TITLE
Parse hidden_webui_pages option from anaconda.conf

### DIFF
--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -66,7 +66,7 @@ const ReviewConfiguration = ({ setIsFormValid }) => {
     const accounts = useContext(UsersContext);
     const { label: scenarioLabel } = useScenario();
     const userInterfaceConfig = useContext(UserInterfaceContext);
-    const hiddenScreens = userInterfaceConfig.hidden_screens || [];
+    const hiddenScreens = userInterfaceConfig.hidden_webui_pages || [];
     const isBootIso = useContext(SystemTypeContext) === "BOOT_ISO";
 
     // Display custom footer

--- a/src/components/steps.js
+++ b/src/components/steps.js
@@ -14,7 +14,7 @@ const _ = cockpit.gettext;
 
 export const getSteps = (userInterfaceConfig, ...args) => {
     const mountPointMappingStep = new PageMountPointMapping(...args);
-    const hiddenScreens = userInterfaceConfig.hidden_screens || [];
+    const hiddenScreens = userInterfaceConfig.hidden_webui_pages || [];
     const stepsOrder = [
         new PageInstallationLanguage(...args),
         new PageInstallationMethod(...args),
@@ -33,7 +33,7 @@ export const getSteps = (userInterfaceConfig, ...args) => {
     /* Screens can be hidden in two ways:
      * 1. Dynamically: Controlled by the 'Page.isHidden' method in individual components,
      *    e.g., see 'MountPointMapping.jsx'.
-     * 2. Statically: Configured via the 'hidden_screens' key in the 'anaconda.conf'
+     * 2. Statically: Configured via the 'hidden_webui_pages' key in the 'anaconda.conf'
      *    For example, the 'Account Creation' screen is hidden in the 'Workstation' ISO
      *    because this step is handled by the 'Gnome Initial Setup' tool during the first boot.
      */

--- a/test/helpers/utils.py
+++ b/test/helpers/utils.py
@@ -30,7 +30,7 @@ def pretend_live_iso(test, installer):
     installer.steps.hidden_steps.extend([installer.steps.ACCOUNTS, installer.steps.LANGUAGE])
     test.restore_file('/run/anaconda/anaconda.conf')
     test.machine.execute("sed -i 's/type = BOOT_ISO/type = LIVE_OS/g' /run/anaconda/anaconda.conf")
-    test.machine.execute("sed -i '/[anaconda]/a hidden_screens = anaconda-screen-language anaconda-screen-accounts' /run/anaconda/anaconda.conf")
+    test.machine.execute("sed -i '/[anaconda]/a hidden_webui_pages = anaconda-screen-language anaconda-screen-accounts' /run/anaconda/anaconda.conf")
 
 def pretend_default_scheme(test, scheme):
     test.restore_file('/run/anaconda/anaconda.conf')


### PR DESCRIPTION
There was mismatch in the option name between front-end and back-end.