### PR TITLE
tests: when testing against a compose checkout the TAG used in the compose

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,10 +18,4 @@ jobs:
           mkdir -p ~/.config/cockpit-dev
           echo "${{ github.token }}" >> ~/.config/cockpit-dev/github-token
           export TEST_COMPOSE=$(curl -s https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/COMPOSE_ID)
-
-          # FIXME: Uncomment once bfe0973d2520fa155ff6bc673818a098f2a94154 reaches rawhide
-          # Run the tests that correspond to anaconda-webui version used in the latest compose
-          # LATEST_COMPOSE_A_PACKAGES = https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/x86_64/os/Packages/a/
-          # ANACONDA_WEBUI_TAG=$(curl -s $LATEST_COMPOSE_A_PACKAGES | grep -oP '>anaconda-webui-[0-9]+' | cut -d "-" -f3)
-          # git reset --hard $ANACONDA_WEBUI_TAG
           make test-compose

--- a/test/run
+++ b/test/run
@@ -37,6 +37,13 @@ case "${TEST_SCENARIO:=}" in
         ;;
 esac
 
+# If TEST_COMPOSE is defined checkout the git repo to the corresponding tag
+if [ -n "${TEST_COMPOSE-}" ]; then
+    COMPOSE_A_PACKAGES="https://kojipkgs.fedoraproject.org/compose/rawhide/$TEST_COMPOSE/compose/Everything/x86_64/os/Packages/a/"
+    ANACONDA_WEBUI_TAG=$(curl -s $COMPOSE_A_PACKAGES | grep -oP '>anaconda-webui-[0-9]+' | cut -d "-" -f3)
+    git checkout $ANACONDA_WEBUI_TAG
+fi
+
 # We need to know if a TEST_COMPOSE is specified before we start downloading the test images
 make create-updates.img
 

--- a/test/vm.install
+++ b/test/vm.install
@@ -61,11 +61,9 @@ def vm_install(image, compose, verbose, quick):
             anaconda_webui_pr = scenario.split("-")[-1]
             # anaconda-webui is also available in the default rawhide compose, make sure we don't pull it from there
             download_from_copr(f"packit/rhinstaller-anaconda-webui-{anaconda_webui_pr}", "anaconda-webui", machine)
-        # FIXME: Revert once bfe0973d2520fa155ff6bc673818a098f2a94154 reaches rawhide
-        # Then change the nightly action to git checkout the tag that Anaconda-webui was built from for the compose
-        # elif compose:
-        #     # If we are testing a custom compose download the anaconda-webui from the compose
-        #     machine.execute("dnf download --destdir /var/tmp/build/ anaconda-webui", stdout=sys.stdout, timeout=300)
+        elif compose:
+             # If we are testing a custom compose download the anaconda-webui from the compose
+             machine.execute("dnf download --destdir /var/tmp/build/ anaconda-webui", stdout=sys.stdout, timeout=300)
         else:
             # Build anaconda-webui from SRPM otherwise
             files_to_clean = glob.glob("anaconda-webui-*.rpm") + glob.glob("anaconda-webui-*.tar.xz") + ["anaconda-webui.spec"]


### PR DESCRIPTION
So that we are using for testing the same version of the Web UI source code (tests etc) that the anaconda-webui RPM has in the compose.