### PR TITLE
Fix tests after adding Welcome screen

### DIFF
--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -37,6 +37,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         pretend_live_iso(self, i, m)
 
         i.open()
+        i.next()
         s.check_disk_selected("vda")
         s.modify_storage()
         s.confirm_entering_cockpit_storage()


### PR DESCRIPTION
Tests are now failing because pixel tests do not contain images with the Welcome screen.