### PR TITLE
tests: double the time of the timeout when waiting for the initial page load

### DIFF
--- a/test/helpers/installer.py
+++ b/test/helpers/installer.py
@@ -176,7 +176,8 @@ class Installer():
         while step in self.steps.hidden_steps:
             step = self.steps._steps_jump[step][0]
         self.browser.open(f"/cockpit/@localhost/anaconda-webui/index.html#/{step}")
-        self.wait_current_page(step)
+        with self.browser.wait_timeout(30):
+            self.wait_current_page(step)
 
     def click_step_on_sidebar(self, step=None):
         step = step or self.get_current_page()


### PR DESCRIPTION
Especially on the initial load, and especially when the task container is on heavy load, loading the page takes more than the default 15 seconds, resulting in test flakiness. Be more generous with the time there.