### PR TITLE
packit: Enable downstream automation

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -37,3 +37,11 @@ jobs:
     trigger: release
     dist_git_branches:
       - fedora-development
+
+  - job: koji_build
+    trigger: commit
+    sidetag_group: anaconda-releases
+    dependents:
+      - anaconda
+    dist_git_branches:
+      - fedora-development


### PR DESCRIPTION
This commit adds a `koji_build` job configured to build in a sidetag. `anaconda` is set as a dependent, which means that a successful Koji build will trigger `bodhi_update` job configured there and if builds of both `anaconda` and `anaconda-webui` are in the sidetag, Bodhi update will be automatically created from it.
In case you want to release only `anaconda-webui`, you will have to tag the latest stable build of `anaconda` into the sidetag by commenting `/packit koji-tag` in any `anaconda` dist-git PR (that will satisfy the dependency but only the not-yet-released build of `anaconda-webui` will be added to the update).

This PR complements https://github.com/rhinstaller/anaconda/pull/6166.

See also: https://packit.dev/docs/fedora-releases-guide/releasing-multiple-packages

Note: the cross-package automation will not work properly until Packit configuration is updated in dist-git repos of both packages.

@KKoukiou please have a look.