### PR TITLE
tests: increase timeout for dialog to load when exiting cockpit-storage

### DIFF
--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -166,7 +166,8 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         def checkStorageReview(prefix=""):
             disk = "vda"
-            r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
+            with b.wait_timeout(30):
+                r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
             r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False, prefix=prefix)
             r.check_disk_row(disk, "/", "vda3, LVM", "6.01 GB", False, prefix=prefix)
             r.check_disk_row(disk, "/home", "vda3, LVM", "8.12 GB", False, prefix=prefix)

--- a/test/helpers/installer.py
+++ b/test/helpers/installer.py
@@ -176,7 +176,7 @@ class Installer():
         while step in self.steps.hidden_steps:
             step = self.steps._steps_jump[step][0]
         self.browser.open(f"/cockpit/@localhost/anaconda-webui/index.html#/{step}")
-        with self.browser.wait_timeout(30):
+        with self.browser.wait_timeout(60):
             self.wait_current_page(step)
 
     def click_step_on_sidebar(self, step=None):

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -64,7 +64,7 @@ class StorageDestination():
         b.click(f"#{INSTALLATION_METHOD}-rescan-disks")
         b.wait_visible(f"#{INSTALLATION_METHOD}-rescan-disks.pf-m-disabled")
         # Default 15 seconds is not always enough for re-scanning disks
-        with b.wait_timeout(30):
+        with b.wait_timeout(60):
             b.wait_not_present(f"#{INSTALLATION_METHOD}-rescan-disks.pf-m-disabled")
 
         for disk in expected_disks or []:


### PR DESCRIPTION
Exiting the cockpit-storage page, does heavy operations, like creating partitioning, re-scanning disks etc.
Give it a bit more time as on heavy CI load this sometimes fails to load in time.