### PR TITLE
tests: fix: the first argument to next() must be an iterator

### DIFF
--- a/test/wiki-report.py
+++ b/test/wiki-report.py
@@ -55,7 +55,7 @@ class WikiReport:
                 continue
 
             fedora_testcase = next(
-                [test for test in testmap if test["testname"] == testcase["test_name"]],
+                (test for test in testmap if test["testname"] == testcase["test_name"]),
                 None
             )
             fedora_wiki_testcase = fedora_testcase["fedora-wiki-testcase"]


### PR DESCRIPTION
We were passing a list comprehension