### PR TITLE
tests: temporarily mark test home reuse encrypted as desctructive

### DIFF
--- a/test/check-storage-home-reuse
+++ b/test/check-storage-home-reuse
@@ -29,7 +29,6 @@ ROOT_DIR = os.path.dirname(TEST_DIR)
 BOTS_DIR = f'{ROOT_DIR}/bots'
 
 
-@nondestructive
 class TestStorageHomeReuseFedora(VirtInstallMachineCase):
     disk_image = "fedora-rawhide"
 
@@ -50,6 +49,7 @@ class TestStorageHomeReuseFedora(VirtInstallMachineCase):
         """)
 
     @run_boot("bios", "efi")
+    @nondestructive
     def testBasic(self):
         b = self.browser
         m = self.machine
@@ -83,6 +83,7 @@ class TestStorageHomeReuseFedora(VirtInstallMachineCase):
         r.check_disk_row(dev, "/home", f"{dev}4", "12.8 GB", False, "btrfs", is_encrypted=False,
                          action="mount")
 
+    @nondestructive
     def testHidden(self):
         b = self.browser
         m = self.machine

--- a/test/check-storage-mountpoints-raid
+++ b/test/check-storage-mountpoints-raid
@@ -19,10 +19,9 @@ from anacondalib import VirtInstallMachineCase
 from installer import Installer
 from review import Review
 from storage import Storage
-from testlib import nondestructive, test_main  # pylint: disable=import-error
+from testlib import test_main  # pylint: disable=import-error
 
 
-@nondestructive
 class TestStorageMountPointsRAID(VirtInstallMachineCase):
 
     def testEncryptedUnlockRAIDonLUKS(self):


### PR DESCRIPTION
There is some cleanup missing from this.