### PR TITLE
storage: adjust scenario display order and default scenario selection

### DIFF
--- a/src/apis/storage.js
+++ b/src/apis/storage.js
@@ -21,13 +21,10 @@ import {
     getDiskSelectionAction,
     getPartitioningDataAction,
     setAppliedPartitioningAction,
-    setStorageScenarioAction,
 } from "../actions/storage-actions.js";
 
 import { debug } from "../helpers/log.js";
 import { _callClient, _getProperty } from "./helpers.js";
-
-import { getDefaultScenario } from "../components/storage/InstallationScenario.jsx";
 
 const INTERFACE_NAME = "org.fedoraproject.Anaconda.Modules.Storage";
 const OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Storage";
@@ -96,8 +93,6 @@ export class StorageClient {
     }
 
     async initData () {
-        this.dispatch(setStorageScenarioAction(window.sessionStorage.getItem("storage-scenario-id") || getDefaultScenario().id));
-
         const partitioning = await getProperty("CreatedPartitioning");
         if (partitioning.length !== 0) {
             const lastPartitioning = partitioning[partitioning.length - 1];

--- a/src/components/storage/InstallationScenario.jsx
+++ b/src/components/storage/InstallationScenario.jsx
@@ -27,7 +27,6 @@ import {
 
 import { setStorageScenarioAction } from "../../actions/storage-actions.js";
 
-import { debug } from "../../helpers/log.js";
 import {
     getLockedLUKSDevices,
 } from "../../helpers/storage.js";
@@ -65,10 +64,6 @@ export const useScenario = () => {
     }, [storageScenarioId]);
 
     return scenario;
-};
-
-export const getDefaultScenario = () => {
-    return scenarios.filter(s => s.default)[0];
 };
 
 const InstallationScenarioSelector = ({
@@ -135,7 +130,6 @@ const InstallationScenarioSelector = ({
 
     useEffect(() => {
         let selectedScenarioId = "";
-        let availableScenarioExists = false;
 
         // Don't mess up with the scenarios while cockpit storage mode is active
         if (showStorage) {
@@ -153,25 +147,19 @@ const InstallationScenarioSelector = ({
             return;
         }
 
-        for (const scenario of scenarios) {
-            const availability = scenarioAvailability[scenario.id];
-            if (!availability.hidden && availability.available) {
-                availableScenarioExists = true;
-                if (scenario.id === storageScenarioId) {
-                    debug(`Selecting backend scenario ${scenario.id}`);
-                    selectedScenarioId = scenario.id;
-                }
-                if (!selectedScenarioId && scenario.default) {
-                    debug(`Selecting default scenario ${scenario.id}`);
-                    selectedScenarioId = scenario.id;
-                }
-            }
+        if (storageScenarioId && !scenarioAvailability[storageScenarioId].hidden && scenarioAvailability[storageScenarioId].available) {
+            selectedScenarioId = storageScenarioId;
+        } else {
+            selectedScenarioId = scenarios.find(scenario => (
+                scenarioAvailability[scenario.id].available &&
+                !scenarioAvailability[scenario.id].hidden
+            ))?.id;
         }
 
-        if (availableScenarioExists) {
+        if (selectedScenarioId) {
             dispatch(setStorageScenarioAction(selectedScenarioId));
         }
-        setIsFormValid(availableScenarioExists);
+        setIsFormValid(!!selectedScenarioId);
     }, [dispatch, mountPoints, scenarioAvailability, setIsFormValid, showStorage, storageScenarioId]);
 
     const onScenarioToggled = (scenarioId) => {

--- a/src/components/storage/scenarios/EraseAll.jsx
+++ b/src/components/storage/scenarios/EraseAll.jsx
@@ -45,7 +45,6 @@ export const scenarioEraseAll = {
     buttonLabel: _("Erase data and install"),
     buttonVariant: "danger",
     check: checkEraseAll,
-    default: true,
     detail: helpEraseAll,
     id: "erase-all",
     // CLEAR_PARTITIONS_ALL = 1

--- a/src/components/storage/scenarios/MountPointMapping.jsx
+++ b/src/components/storage/scenarios/MountPointMapping.jsx
@@ -61,7 +61,6 @@ export const scenarioMountPointMapping = {
     buttonLabel: _("Apply mount point assignment and install"),
     buttonVariant: "danger",
     check: checkMountPointMapping,
-    default: false,
     detail: helpMountPointMapping,
     id: "mount-point-mapping",
     // CLEAR_PARTITIONS_NONE = 0

--- a/src/components/storage/scenarios/ReinstallFedora.jsx
+++ b/src/components/storage/scenarios/ReinstallFedora.jsx
@@ -119,7 +119,6 @@ export const scenarioReinstallFedora = {
     buttonLabel: _("Reinstall Fedora"),
     buttonVariant: "danger",
     check: checkHomeReuse,
-    default: false,
     detail: helpHomeReuse,
     id: "home-reuse",
     // CLEAR_PARTITIONS_NONE = 0

--- a/src/components/storage/scenarios/UseConfiguredStorage.jsx
+++ b/src/components/storage/scenarios/UseConfiguredStorage.jsx
@@ -88,7 +88,6 @@ export const scenarioConfiguredStorage = {
     buttonLabel: _("Install"),
     buttonVariant: "danger",
     check: checkConfiguredStorage,
-    default: false,
     detail: helpConfiguredStorage,
     id: "use-configured-storage",
     // CLEAR_PARTITIONS_NONE = 0

--- a/src/components/storage/scenarios/UseFreeSpace.jsx
+++ b/src/components/storage/scenarios/UseFreeSpace.jsx
@@ -77,7 +77,6 @@ export const scenarioUseFreeSpace = {
     buttonVariant: "primary",
     canReclaimSpace: true,
     check: checkUseFreeSpace,
-    default: false,
     detail: helpUseFreeSpace,
     id: "use-free-space",
     // CLEAR_PARTITIONS_NONE = 0

--- a/src/components/storage/scenarios/index.js
+++ b/src/components/storage/scenarios/index.js
@@ -6,8 +6,8 @@ import { scenarioUseFreeSpace } from "./UseFreeSpace.jsx";
 
 export const scenarios = [
     scenarioReinstallFedora,
-    scenarioEraseAll,
     scenarioUseFreeSpace,
+    scenarioEraseAll,
     scenarioMountPointMapping,
     scenarioConfiguredStorage,
 ];

--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -195,7 +195,7 @@ class VirtInstallMachineCase(MachineCase):
         s = Storage(b, m)
 
         self.removeAllDisks()
-        s.dbus_reset_partitioning()
+        s.dbus_reset_scenario()
         # Create an AUTOMATIC partitioning because MANUAL partitioning tests might take the last created
         s.dbus_create_partitioning("AUTOMATIC")
         s.dbus_reset_selected_disks()

--- a/test/check-storage-basic
+++ b/test/check-storage-basic
@@ -91,7 +91,7 @@ class TestStorage(VirtInstallMachineCase):
         i.reach(i.steps.INSTALLATION_METHOD)
 
         # Check the default mode
-        s.check_partitioning_selected("erase-all")
+        s.check_scenario_selected("erase-all")
 
         # Check that when an unpartitioned disk is selected the "Use free space" scenario is hidden
         s.wait_scenario_visible("use-free-space", False)
@@ -104,10 +104,10 @@ class TestStorage(VirtInstallMachineCase):
         # The choice is preserved (stored in the backend).
         # The choice is available only if the partitioning was reset
         # (there is enough free space)
-        s.set_partitioning("use-free-space")
+        s.set_scenario("use-free-space")
         i.next()
         i.back()
-        s.check_partitioning_selected("use-free-space")
+        s.check_scenario_selected("use-free-space")
 
     def testPartitioningObject(self):
         # Test which partitioning object ends up being the AppliedPartitioning

--- a/test/check-storage-basic
+++ b/test/check-storage-basic
@@ -208,8 +208,11 @@ class TestStorage(VirtInstallMachineCase):
         b = self.browser
         m = self.machine
         i = Installer(b, m)
+        s = Storage(b, m)
 
         i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+        s.set_scenario("erase-all")
         i.reach(i.steps.STORAGE_CONFIGURATION)
         i.next(should_fail=True)
         b.wait_in_text(

--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -564,7 +564,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         s.return_to_installation()
         s.return_to_installation_confirm()
 
-        s.check_partitioning_selected("erase-all")
+        s.check_scenario_selected("erase-all")
         i.reach(i.steps.REVIEW)
 
         disk = "MDRAID-SOMERAID"

--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -88,14 +88,14 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         s.return_to_installation()
         s.return_to_installation_confirm()
 
-        s.check_partitioning_selected("use-configured-storage")
+        s.check_scenario_selected("use-configured-storage")
 
         # Check that choosing another storage scenario without diving into that,
         # preserves the visibility of "Use configured storage"
-        s.set_partitioning("erase-all")
+        s.set_scenario("erase-all")
         s.wait_scenario_available("use-configured-storage")
 
-        s.set_partitioning("use-configured-storage")
+        s.set_scenario("use-configured-storage")
 
         i.reach(i.steps.REVIEW)
 
@@ -183,7 +183,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         )
         s.return_to_installation_confirm()
 
-        s.set_partitioning("use-configured-storage")
+        s.set_scenario("use-configured-storage")
 
         i.reach(i.steps.REVIEW)
 
@@ -226,7 +226,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         s.return_to_installation()
         s.return_to_installation_confirm()
 
-        s.set_partitioning("use-configured-storage")
+        s.set_scenario("use-configured-storage")
 
         i.reach(i.steps.REVIEW)
 
@@ -299,7 +299,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         s.return_to_installation()
         s.return_to_installation_confirm()
 
-        s.set_partitioning("use-configured-storage")
+        s.set_scenario("use-configured-storage")
 
         i.reach(i.steps.REVIEW)
 
@@ -373,7 +373,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         s.return_to_installation()
         s.return_to_installation_confirm()
 
-        s.set_partitioning("mount-point-mapping")
+        s.set_scenario("mount-point-mapping")
 
         i.next(next_page=i.steps.CUSTOM_MOUNT_POINT)
 
@@ -517,7 +517,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         s.return_to_installation_confirm()
 
-        s.set_partitioning("use-configured-storage")
+        s.set_scenario("use-configured-storage")
 
         i.reach(i.steps.REVIEW)
 

--- a/test/check-storage-encryption
+++ b/test/check-storage-encryption
@@ -41,7 +41,7 @@ class TestStorageEncryption(VirtInstallMachineCase):
         i.reach(i.steps.INSTALLATION_METHOD)
 
         # Check the default mode
-        s.check_partitioning_selected("erase-all")
+        s.check_scenario_selected("erase-all")
 
         i.next()
         # Disk Encryption

--- a/test/check-storage-erase-all
+++ b/test/check-storage-erase-all
@@ -19,6 +19,7 @@ from anacondalib import VirtInstallMachineCase, disk_images
 from installer import Installer
 from operating_systems import WindowsOS
 from review import Review
+from storage import Storage
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 
 
@@ -32,8 +33,12 @@ class TestStorageEraseAll_Fedora(VirtInstallMachineCase):
 
         i = Installer(b, m)
         r = Review(b, m)
+        s = Storage(b, m)
 
         i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+        s.check_scenario_index("erase-all", 2)
+        s.set_scenario("erase-all")
         i.reach(i.steps.REVIEW)
 
         for device in ["vda1", "vda2", "vda3", "vda4"]:
@@ -54,8 +59,11 @@ class TestStorageEraseAll_Windows(VirtInstallMachineCase):
         m = self.machine
         i = Installer(b, m)
         r = Review(b, m)
+        s = Storage(b, m)
 
         i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+        s.set_scenario("erase-all")
         i.reach(i.steps.REVIEW)
 
         for device in ["vda1", "vda2", "vda3", "vda4"]:

--- a/test/check-storage-erase-all-e2e
+++ b/test/check-storage-erase-all-e2e
@@ -44,7 +44,7 @@ class TestStorageEraseAll_E2E(VirtInstallMachineCase):
         i.reach(i.steps.INSTALLATION_METHOD)
 
         # Check the default mode
-        s.check_partitioning_selected("erase-all")
+        s.check_scenario_selected("erase-all")
 
         i.next()
         # Disk Encryption

--- a/test/check-storage-home-reuse
+++ b/test/check-storage-home-reuse
@@ -60,7 +60,8 @@ class TestStorageHomeReuseFedora(VirtInstallMachineCase):
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
 
-        s.set_scenario("home-reuse")
+        s.check_scenario_selected("home-reuse")
+        s.check_scenario_index("home-reuse", 1)
         i.reach(i.steps.REVIEW)
 
         # check selected disks are shown

--- a/test/check-storage-home-reuse
+++ b/test/check-storage-home-reuse
@@ -60,7 +60,7 @@ class TestStorageHomeReuseFedora(VirtInstallMachineCase):
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
 
-        s.set_partitioning("home-reuse")
+        s.set_scenario("home-reuse")
         i.reach(i.steps.REVIEW)
 
         # check selected disks are shown
@@ -175,7 +175,7 @@ class TestStorageHomeReuseFedora(VirtInstallMachineCase):
 
         s.unlock_all_encrypted()
         s.unlock_device("einszwei", ["vda4"], ["vda4"])
-        s.set_partitioning("home-reuse")
+        s.set_scenario("home-reuse")
         i.reach(i.steps.REVIEW)
 
         # check selected disks are shown
@@ -226,7 +226,7 @@ class TestStorageHomeReuseFedora(VirtInstallMachineCase):
         s.wait_scenario_visible("home-reuse", True)
         s.wait_scenario_available("home-reuse", True)
 
-        s.set_partitioning("home-reuse")
+        s.set_scenario("home-reuse")
         i.reach(i.steps.REVIEW)
 
         # check selected disks are shown

--- a/test/check-storage-home-reuse-e2e
+++ b/test/check-storage-home-reuse-e2e
@@ -107,7 +107,7 @@ class TestStorageHomeReuse_E2E(VirtInstallMachineCase):
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
 
-        s.set_partitioning("home-reuse")
+        s.set_scenario("home-reuse")
         i.reach(i.steps.REVIEW)
 
         self.install(needs_confirmation=True)

--- a/test/check-storage-reclaim
+++ b/test/check-storage-reclaim
@@ -72,7 +72,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
 
-        s.set_partitioning("use-free-space")
+        s.set_scenario("use-free-space")
         s.reclaim_check_checkbox(False, False)
 
         s.reclaim_set_checkbox(True)
@@ -111,7 +111,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
 
-        s.set_partitioning("use-free-space")
+        s.set_scenario("use-free-space")
         s.reclaim_check_checkbox(True, True)
         i.next(True)
 
@@ -181,7 +181,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
 
-        s.set_partitioning("use-free-space")
+        s.set_scenario("use-free-space")
         i.next(True)
 
         s.reclaim_check_available_space("1.03 MB")
@@ -258,7 +258,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
 
-        s.set_partitioning("use-free-space")
+        s.set_scenario("use-free-space")
         s.reclaim_set_checkbox(True)
         i.next(True)
 
@@ -319,7 +319,7 @@ class TestStorageReclaimSpaceLUKS(VirtInstallMachineCase):
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
 
-        s.set_partitioning("use-free-space")
+        s.set_scenario("use-free-space")
         s.reclaim_set_checkbox(True)
         i.next(True)
 
@@ -347,7 +347,7 @@ class TestStorageReclaimExistingSystemFedora(VirtInstallMachineCase):
 
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
-        s.set_partitioning("use-free-space")
+        s.set_scenario("use-free-space")
         s.reclaim_set_checkbox(True)
         i.next(True)
 
@@ -380,7 +380,7 @@ class TestStorageReclaimExistingSystemWindows(VirtInstallMachineCase):
 
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
-        s.set_partitioning("use-free-space")
+        s.set_scenario("use-free-space")
         s.reclaim_set_checkbox(True)
         i.next(True)
 
@@ -404,7 +404,7 @@ class TestStorageReclaimExistingSystemUbuntu(VirtInstallMachineCase):
 
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
-        s.set_partitioning("use-free-space")
+        s.set_scenario("use-free-space")
         s.reclaim_set_checkbox(True)
         i.next(True)
 

--- a/test/check-storage-reclaim-e2e
+++ b/test/check-storage-reclaim-e2e
@@ -36,7 +36,7 @@ class TestStorageReclaim_E2E(DualBootHelper_E2E, VirtInstallMachineCase):
 
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
-        s.set_partitioning("use-free-space")
+        s.set_scenario("use-free-space")
         s.reclaim_set_checkbox(True)
         i.next(True)
 

--- a/test/check-storage-use-free-space-e2e
+++ b/test/check-storage-use-free-space-e2e
@@ -36,7 +36,7 @@ class TestStorageUseFreeSpace_E2E(DualBootHelper_E2E, VirtInstallMachineCase):
 
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
-        s.set_partitioning("use-free-space")
+        s.check_scenario_selected("use-free-space")
         i.next()
         s.check_encryption_selected(False)
         i.reach(i.steps.REVIEW)

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -397,7 +397,7 @@ class StorageDBus():
             {STORAGE_OBJECT_PATH}/DiskSelection \
             {STORAGE_INTERFACE}.DiskSelection SelectedDisks as 1 {disk}')
 
-    def dbus_reset_partitioning(self):
+    def dbus_reset_scenario(self):
         self.machine.execute(f'busctl --address="{self._bus_address}" \
             call \
             {STORAGE_SERVICE} \
@@ -451,29 +451,29 @@ class StorageScenario():
         self.machine = machine
         self.browser = browser
 
-    def _partitioning_selector(self, scenario):
+    def _scenario_selector(self, scenario):
         return f"#{INSTALLATION_METHOD}-scenario-" + scenario
 
     def wait_scenario_visible(self, scenario, visible=True):
         if visible:
-            self.browser.wait_visible(self._partitioning_selector(scenario))
+            self.browser.wait_visible(self._scenario_selector(scenario))
         else:
-            self.browser.wait_not_present(self._partitioning_selector(scenario))
+            self.browser.wait_not_present(self._scenario_selector(scenario))
 
     def wait_scenario_available(self, scenario, available=True):
         if available:
-            self.browser.wait_visible(f"{self._partitioning_selector(scenario)}:not([disabled])")
+            self.browser.wait_visible(f"{self._scenario_selector(scenario)}:not([disabled])")
         else:
-            self.browser.wait_visible(f"{self._partitioning_selector(scenario)}:disabled")
+            self.browser.wait_visible(f"{self._scenario_selector(scenario)}:disabled")
 
     @log_step(snapshot_before=True)
-    def check_partitioning_selected(self, scenario):
-        self.browser.wait_visible(self._partitioning_selector(scenario) + ":checked")
+    def check_scenario_selected(self, scenario):
+        self.browser.wait_visible(self._scenario_selector(scenario) + ":checked")
 
     @log_step(snapshot_before=True)
-    def set_partitioning(self, scenario):
-        self.browser.click(self._partitioning_selector(scenario))
-        self.browser.wait_visible(self._partitioning_selector(scenario) + ":checked")
+    def set_scenario(self, scenario):
+        self.browser.click(self._scenario_selector(scenario))
+        self.browser.wait_visible(self._scenario_selector(scenario) + ":checked")
         self.browser.wait_visible(f"div[data-scenario='{scenario}']")
 
 
@@ -622,7 +622,7 @@ class StorageMountPointMapping(StorageDBus, StorageDestination):
     def select_mountpoint(self, disks):
         self.select_disks(disks)
 
-        self.set_partitioning("mount-point-mapping")
+        self.set_scenario("mount-point-mapping")
 
         self.browser.click("button:contains(Next)")
         self.browser.wait_js_cond(f'window.location.hash === "#/{CUSTOM_MOUNT_POINT}"')

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -470,6 +470,9 @@ class StorageScenario():
     def check_scenario_selected(self, scenario):
         self.browser.wait_visible(self._scenario_selector(scenario) + ":checked")
 
+    def check_scenario_index(self, scenario, index):
+        self.browser.wait_visible(f".anaconda-screen-method-scenario:nth-child({index}) > {self._scenario_selector(scenario)}")
+
     @log_step(snapshot_before=True)
     def set_scenario(self, scenario):
         self.browser.click(self._scenario_selector(scenario))


### PR DESCRIPTION
Scenarios are now presented with the following order:
* Re-install Fedora
* Use Free Space
* Mount Point Mapping
* Erase All
* Use Configured storage

Resolves: rhbz#2347151
