### PR TITLE
tests: fix language switching case by bringing desired locale is in viewport

### DIFF
--- a/test/check-language
+++ b/test/check-language
@@ -138,13 +138,13 @@ class TestLanguage(VirtInstallMachineCase):
         self.assertIn('string "de_DE.UTF-8"', language_new)
 
         # Expect language direction to be set to RTL for selected languages
-        l.select_locale("he_IL", False)
+        l.select_locale("he_IL", is_common=False)
         l.check_selected_locale("he_IL", is_common=False)
         b.wait_attr("html", "dir", "rtl")
 
         # Expect language direction to be set to LTR when switching to EN_US from RTL language
         # as this has special handling
-        l.select_locale("en_US")
+        l.select_locale("en_US", locale_name="English (United States)")
         l.check_selected_locale("en_US")
         b.wait_attr("html", "dir", "ltr")
 

--- a/test/helpers/language.py
+++ b/test/helpers/language.py
@@ -39,10 +39,14 @@ class Language():
         self._bus_address = self.machine.execute("cat /run/anaconda/bus.address")
 
     @log_step()
-    def select_locale(self, locale, is_common=True):
+    def select_locale(self, locale, locale_name=None, is_common=True):
         common_prefix = "common" if is_common else "alpha"
         if self.browser.val(f".{self._step}-search .pf-v5-c-text-input-group__text-input") != "":
             self.input_locale_search("")
+
+        if locale_name:
+            self.input_locale_search(locale_name)
+
         self.browser.click(f"#{self._step}-option-{common_prefix}-{locale}")
 
     @log_step()


### PR DESCRIPTION
This fixes the following error that appears often in CI: testlib.Error: move target out of bounds: Cannot move beyond viewport (x: 1306, y: -2028)