### PR TITLE
tests: increase timeout for when exiting cockpit-storage

### DIFF
--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -166,8 +166,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         def checkStorageReview(prefix=""):
             disk = "vda"
-            with b.wait_timeout(30):
-                r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
+            r.check_disk(disk, "16.1 GB vda (Virtio Block Device)", prefix=prefix)
             r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False, prefix=prefix)
             r.check_disk_row(disk, "/", "vda3, LVM", "6.01 GB", False, prefix=prefix)
             r.check_disk_row(disk, "/home", "vda3, LVM", "8.12 GB", False, prefix=prefix)

--- a/test/helpers/review.py
+++ b/test/helpers/review.py
@@ -52,8 +52,8 @@ class Review(NetworkDBus, StorageDBus):
     def check_storage_config(self, scenario):
         self.browser.wait_in_text(f"#{self._step}-target-system-mode > .pf-v5-c-description-list__text", scenario)
 
-    def check_disk(self, disk, text):
-        self.browser.wait_text(f"#disk-{disk}", text)
+    def check_disk(self, disk, text, prefix=""):
+        self.browser.wait_text(f"{prefix} #disk-{disk}", text)
 
     def check_disk_row(
         self,

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -84,8 +84,13 @@ class StorageDestination():
 
     def return_to_installation(self, error=None):
         self.browser.click("#cockpit-storage-integration-return-to-installation-button")
-        if error:
-            self.browser.wait_in_text("#cockpit-storage-integration-check-storage-dialog", error)
+        # FIXME: https://github.com/rhinstaller/anaconda/pull/6234
+        # On Fedora-42 re-scanning takes long when there are LVM devices
+        # This extra timeout can be removed once the above PR is merged
+        with self.browser.wait_timeout(90):
+            if error:
+                self.browser.wait_in_text("#cockpit-storage-integration-check-storage-dialog", error)
+            self.browser.wait_visible("#cockpit-storage-integration-check-storage-dialog-continue:not([disabled])")
 
     def return_to_installation_confirm(self):
         # FIXME: testBtrfsTopLevelVolume fails sometimes on CI without this workaround


### PR DESCRIPTION
This is needed because of an LVM2 bug which causes re-scanning to take forever.

The anaconda fix for rawhide is merged and released: https://github.com/rhinstaller/anaconda/pull/6140
For fedora-42 we need a workaround in the tests as PR is still not merged: https://github.com/rhinstaller/anaconda/pull/6234.