### PR TITLE
tests: remove unnecessary class wrappers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,5 +96,7 @@ ignore_names = [
    "_testReclaimSpaceDeleteBtrfsSubvolumes_partition_disk",
    "_testReclaimSpaceOptional_partition_disk",
    "_testReclaimSpaceShrinkBtrfsSubvolumes_partition_disk",
+   "_testReclaimSpaceWindows_partition_disk",
    "_testUnusableFormats_partition_disk",
+   "_testWindows_partition_disk",
 ]

--- a/test/check-storage-basic
+++ b/test/check-storage-basic
@@ -28,7 +28,7 @@ BOTS_DIR = f'{ROOT_DIR}/bots'
 
 
 @nondestructive
-class TestStorage(VirtInstallMachineCase):
+class TestStorageBasic(VirtInstallMachineCase):
 
     def testLocalStandardDisks(self):
         """

--- a/test/check-storage-erase-all
+++ b/test/check-storage-erase-all
@@ -24,10 +24,10 @@ from testlib import nondestructive, test_main  # pylint: disable=import-error
 
 
 @nondestructive
-class TestStorageEraseAll_Fedora(VirtInstallMachineCase):
+class TestStorageEraseAll(VirtInstallMachineCase):
 
     @disk_images([("fedora-rawhide", 15)])
-    def testBasic(self):
+    def testFedora(self):
         """"
         Description:
             Test erase-all scenario with pre-existing Fedora OS
@@ -55,14 +55,11 @@ class TestStorageEraseAll_Fedora(VirtInstallMachineCase):
         r.check_deleted_system("Fedora Linux")
 
 
-@nondestructive
-class TestStorageEraseAll_Windows(VirtInstallMachineCase):
-
-    def _testBasic_partition_disk(self):
+    def _testWindows_partition_disk(self):
         WindowsOS(machine=self.machine).partition_disk()
 
     @disk_images([("", 20)])
-    def testBasic(self):
+    def testWindows(self):
         """
         Description:
             Test erase-all scenario with pre-existing Windows OS

--- a/test/check-storage-home-reuse
+++ b/test/check-storage-home-reuse
@@ -30,7 +30,7 @@ ROOT_DIR = os.path.dirname(TEST_DIR)
 BOTS_DIR = f'{ROOT_DIR}/bots'
 
 
-class TestStorageHomeReuseFedora(VirtInstallMachineCase):
+class TestStorageHomeReuse(VirtInstallMachineCase):
     def _remove_unknown_mountpoints(self, disk):
         # Remove the /var subvolume from the default btrfs layout
         # as /var/ is not default mount point in Fedora which results in

--- a/test/check-storage-reclaim
+++ b/test/check-storage-reclaim
@@ -318,8 +318,6 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
             r.check_disk_row("vda", parent=device, action="delete")
 
 
-@nondestructive
-class TestStorageReclaimSpaceLUKS(VirtInstallMachineCase):
     def _testReclaimExt4onLUKS_partition_disk(self):
         b = self.browser
         m = self.machine
@@ -365,10 +363,6 @@ class TestStorageReclaimSpaceLUKS(VirtInstallMachineCase):
         s.reclaim_check_action_button_present("vda1", "shrink", True, True)
         s.reclaim_check_action_button_present("vda1", "delete", True)
 
-
-@nondestructive
-class TestStorageReclaimExistingSystemFedora(VirtInstallMachineCase):
-
     @disk_images([("fedora-rawhide", 15)])
     def testDeletePartition(self):
         """
@@ -404,14 +398,11 @@ class TestStorageReclaimExistingSystemFedora(VirtInstallMachineCase):
         r.check_some_erased_checkbox_label()
 
 
-@nondestructive
-class TestStorageReclaimExistingSystemWindows(VirtInstallMachineCase):
-
-    def _testBasic_partition_disk(self):
+    def _testReclaimSpaceWindows_partition_disk(self):
         WindowsOS(machine=self.machine).partition_disk()
 
     @disk_images([("", 20)])
-    def testBasic(self):
+    def testReclaimSpaceWindows(self):
         """
         Description:
             Test reclaiming space from an existing Windows system by deleting partitions
@@ -437,11 +428,7 @@ class TestStorageReclaimExistingSystemWindows(VirtInstallMachineCase):
             ignore=["td[data-label=Space]", "#reclaim-space-modal-hint"],
         )
 
-
-class TestStorageReclaimExistingSystemUbuntu(VirtInstallMachineCase):
-
     @disk_images([("ubuntu-stable", 15)])
-    @nondestructive
     def testReclaimSpaceShrink(self):
         """
         Description:

--- a/test/check-users
+++ b/test/check-users
@@ -25,9 +25,6 @@ from users import CREATE_ACCOUNT_ID_PREFIX, Users, create_user
 
 @nondestructive
 class TestUsers(VirtInstallMachineCase):
-    def setUp(self):
-        super().setUp()
-
     def testBasic(self):
         """
         Description:

--- a/test/wiki-testmap.json
+++ b/test/wiki-testmap.json
@@ -28,11 +28,11 @@
                     "fedora-wiki-testcase": "QA:Testcase_partitioning_webui_guided_btrfs_preserve_home"
                 },
                 {
-                    "testname": "TestStorageEraseAll_Fedora.testBasic",
+                    "testname": "TestStorageEraseAll.testFedora",
                     "fedora-wiki-testcase": "QA:Testcase_partitioning_webui_guided_delete_all"
                 },
                 {
-                    "testname": "TestStorageReclaimExistingSystemFedora.testDeletePartition",
+                    "testname": "TestStorageReclaimSpace.testDeletePartition",
                     "fedora-wiki-testcase": "QA:Testcase_partitioning_webui_guided_delete_partial"
                 }
             ]


### PR DESCRIPTION
Since bd2b83a730c97e4a72ed62475b0b49e7dd955301, that we introduced the disk_images test method decorator instead of the class attribute for specifing disks we can just have one wrapper class per file, making the test files slightly cleaner.

Pixel test references had to be updated with the new names.