### PR TITLE
tests: e2e: when waiting for the reboot button to appear check for possible errors

### DIFF
--- a/test/helpers/progress.py
+++ b/test/helpers/progress.py
@@ -32,10 +32,15 @@ class Progress():
     @log_step(snapshot_after=True)
     def wait_done(self, timeout=1200):
         delay = 30
-        wait(lambda: self.browser.is_present(self._reboot_selector), delay=delay, tries=timeout / delay)
-        self.browser.wait_visible(self._reboot_selector)
-        if self.browser.is_present('.pf-v5-c-alert.pf-m-danger'):
+        wait(
+            lambda: self.browser.is_present(self._reboot_selector) or self.browser.is_present("#critical-error-bz-report-modal"),
+            delay=delay,
+            tries=timeout / delay
+        )
+        if self.browser.is_present('#critical-error-bz-report-modal'):
             raise AssertionError('Error during installation')
+
+        self.browser.wait_visible(self._reboot_selector)
 
     @log_step()
     def reboot(self):


### PR DESCRIPTION
This will make tests that failed exit earlier.