### PR TITLE
build: Introduce node_modules/ as submodule

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,82 @@
+name: update node_modules
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+
+jobs:
+  dependabot:
+    environment: npm-update
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 5
+    # 22.04's podman has issues with piping and causes tar errors
+    runs-on: ubuntu-20.04
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'node_modules') }}
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+
+      - name: Clear node_modules label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'node_modules'
+              });
+            } catch (e) {
+              if (e.name == 'HttpError' && e.status == 404) {
+                /* expected: 404 if label is unset */
+              } else {
+                throw e;
+              }
+            }
+
+      - name: Update node_modules for package.json changes
+        run: |
+          make tools/node-modules
+          git config --global user.name "GitHub Workflow"
+          git config --global user.email "cockpituous@cockpit-project.org"
+          eval $(ssh-agent)
+          ssh-add - <<< '${{ secrets.NODE_CACHE_DEPLOY_KEY }}'
+          ./tools/node-modules install
+          ./tools/node-modules push
+          git add node_modules
+          ssh-add -D
+          ssh-agent -k
+
+      - name: Clear [no-test] prefix from PR title
+        if: ${{ contains(github.event.pull_request.title, '[no-test]') }}
+        uses: actions/github-script@v7
+        env:
+          TITLE: '${{ github.event.pull_request.title }}'
+        with:
+          script: |
+            const title = process.env['TITLE'].replace(/\[no-test\]\W+ /, '')
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              title,
+            });
+
+      - name: Force push node_modules update
+        run: |
+          # Dependabot prefixes the commit with [no-test] which we don't want to keep in the commit
+          title=$(git show --pretty="%s" -s | sed -E "s/\[no-test\]\W+ //")
+          body=$(git show -s --pretty="%b")
+          git commit --amend -m "${title}" -m "${body}" --no-edit node_modules
+          eval $(ssh-agent)
+          ssh-add - <<< '${{ secrets.SELF_DEPLOY_KEY }}'
+          git push --force 'git@github.com:${{ github.repository }}' '${{ github.head_ref }}'
+          ssh-add -D
+          ssh-agent -k

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,36 @@ jobs:
         uses: cockpit-project/action-release@88d994da62d1451c7073e26748c18413fcdf46e9
         with:
           filename: "anaconda-webui-${{ github.ref_name }}.tar.xz"
+
+  node-cache:
+    # doesn't depend on it, but let's make sure the build passes before we do this
+    needs: [source]
+    runs-on: ubuntu-latest
+    environment: node-cache
+    # done via deploy key, token needs no write permissions at all
+    permissions: {}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Set up git
+        run: |
+            git config user.name "GitHub Workflow"
+            git config user.email "cockpituous@cockpit-project.org"
+
+      - name: Tag node-cache
+        run: |
+          set -eux
+          # this is a shared repo, prefix with project name
+          TAG="${GITHUB_REPOSITORY#*/}-$(basename $GITHUB_REF)"
+          make tools/node-modules
+          tools/node-modules checkout
+          cd node_modules
+          git tag "$TAG"
+          git remote add cache "ssh://git@github.com/${GITHUB_REPOSITORY%/*}/node-cache"
+          eval $(ssh-agent)
+          ssh-add - <<< '${{ secrets.DEPLOY_KEY }}'
+          # make this idempotent: delete an existing tag
+          git push cache :"$TAG" || true
+          git push cache tag "$TAG"
+          ssh-add -D

--- a/.github/workflows/reposchutz.yml
+++ b/.github/workflows/reposchutz.yml
@@ -1,0 +1,66 @@
+name: repository
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  check:
+    name: Protection checks
+    # 22.04's podman has issues with piping and causes tar errors
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 5
+    env:
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+
+    steps:
+      - name: Clone target branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch PR commits
+        run: git fetch origin "${BASE_SHA}" "${HEAD_SHA}"
+
+      - name: Clear .github-changes label
+        if: ${{ !endsWith(github.event.action, 'labeled') }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: '.github-changes'
+              });
+            } catch (e) {
+              if (e.name == 'HttpError' && e.status == 404) {
+                /* expected: 404 if label is unset */
+              } else {
+                throw e;
+              }
+            }
+
+      - name: Check for .github changes
+        # We want to run this check any time the .github-changes label is not
+        # set, which needs to include the case where we just unset it above.
+        if: ${{ !endsWith(github.event.action, 'labeled') ||
+                !contains(github.event.pull_request.labels.*.name, '.github-changes') }}
+        run: |
+          set -x
+          git log --full-history --exit-code --patch "${HEAD_SHA}" --not "${BASE_SHA}" -- .github >&2
+
+      - name: Check for node_modules availability and package.json consistency
+        run: |
+          # Make tools/node-modules available
+          make tools/node-modules
+          # for each commit in the PR which modifies package.json or node_modules...
+          for commit in $(git log --reverse --full-history --format=%H \
+                              "${HEAD_SHA}" --not "${BASE_SHA}" -- package.json node_modules); do
+              # ... check that package.json and node_modules/.package.json are in sync
+              tools/node-modules verify "${commit}"
+          done

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = test/reference
 	url = https://github.com/rhinstaller/pixel-test-reference
 	branch = empty
+[submodule "node_modules"]
+	path = node_modules
+	url = https://github.com/rhinstaller/node-cache.git

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ EXTRA_DIST = dist src firefox-theme
 COCKPIT_REPO_FILES = \
 	pkg/lib \
 	test/common \
+	tools/node-modules \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git


### PR DESCRIPTION
Build and maintain the node_modules/ as a submodule, using the tools/node-modules script as it's done in the cockpit repo.

Introduce some helper workflows around it, all copied from cockpit project.