### PR TITLE
tests: pre-create images pool otherwise parallel VM spawn might race on creating it

### DIFF
--- a/test/run
+++ b/test/run
@@ -92,6 +92,9 @@ if [ -z "${TEST_OS-}" ]; then
   TEST_OS=fedora-rawhide-boot
 fi
 
+# Avoid error: could not define storage pool: operation failed: pool 'images' already exists with uuid ...
+virsh pool-define-as --name images --type dir --target $(pwd)/bots/images
+
 # Allow wiki-reporting even if test suite partially failed
 set +e
 


### PR DESCRIPTION
This avoids the following error:
ERROR    Validating install media '...' failed: Could not define storage pool: operation failed: \n
pool 'images' already exists with uuid ...