### PR TITLE
test: wiki-report: fix up for 8c64a6

### DIFF
--- a/test/wiki-report.py
+++ b/test/wiki-report.py
@@ -136,4 +136,4 @@ if __name__ == "__main__":
     parser.add_argument("--staging", action="store_true", help="Operate on the staging wiki (for testing)")
     args = parser.parse_args()
 
-    report = WikiReport(args.report, staging=args.staging)
+    report = WikiReport(args.report, staging=args.staging).run()


### PR DESCRIPTION
By mistake the above commit removed the run method execution.