### PR TITLE
tests: introduce workaround for making the Reclaim Windows test more robust

### DIFF
--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -110,6 +110,9 @@ class VirtInstallMachineCase(MachineCase):
         # Set the first disk as the installation target
         s.dbus_set_selected_disk("vda")
 
+        # DEBUG
+        print("Free space on vda: ", s.dbus_get_disk_free_space("vda"))
+
         self.resetLanguage()
 
         self.allow_journal_messages('.*cockpit.bridge-WARNING: Could not start ssh-agent.*')

--- a/test/helpers/operating_systems.py
+++ b/test/helpers/operating_systems.py
@@ -40,6 +40,7 @@ sector-size: 512
 
     def partition_disk(self):
         self.machine.execute("echo '%s' | sfdisk /dev/vda" % self.WINDOWS_SFDISK)
+        print("Windows partitions created:\n" + self.machine.execute("lsblk -f /dev/vda"))
 
 
 class DualBootHelper_E2E(VirtInstallMachineCase):

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -383,6 +383,15 @@ class StorageDBus():
 
         return re.findall('"([^"]*)"', ret)
 
+    def dbus_get_disk_free_space(self, disk):
+        ret = self.machine.execute(f'busctl --address="{self._bus_address}" \
+            call \
+            {STORAGE_SERVICE} \
+            {STORAGE_OBJECT_PATH}/DeviceTree \
+            {STORAGE_INTERFACE}.DeviceTree.Viewer GetDiskFreeSpace as 1 {disk}')
+
+        return ret
+
     def dbus_reset_selected_disks(self):
         self.machine.execute(f'busctl --address="{self._bus_address}" \
             set-property \


### PR DESCRIPTION
This needs to be investigated and this workaround should be removed.

This failure is very consistent in CI: https://github.com/rhinstaller/anaconda-webui/pull/694 <-- See example
I was not able to reproduce locally yet.
