### PR TITLE
tests: Map some non-E2E test cases to the wiki test map

### DIFF
--- a/test/wiki-testmap.json
+++ b/test/wiki-testmap.json
@@ -22,6 +22,10 @@
                 {
                     "testname": "TestStorageHomeReuse_E2E.testBasic",
                     "fedora-wiki-testcase": "QA:Testcase_partitioning_webui_guided_btrfs_preserve_home"
+                },
+                {
+                    "testname": "TestStorageEraseAll_Fedora.testBasic",
+                    "fedora-wiki-testcase": "QA:Testcase_partitioning_webui_guided_delete_all"
                 }
             ]
     },
@@ -43,6 +47,14 @@
                 {
                     "testname": "TestStorageCockpitIntegration_E2E.testRAIDonPartitions",
                     "fedora-wiki-testcase": "QA:Testcase_partitioning_webui_custom_software_RAID"
+                },
+                {
+                    "testname": "TestStorageCockpitIntegration.testBtrfsSubvolumes",
+                    "fedora-wiki-testcase": "QA:Testcase_partitioning_webui_custom_btrfs"
+                },
+                {
+                    "testname": "TestStorageCockpitIntegration.testLVM",
+                    "fedora-wiki-testcase": "QA:Testcase_partitioning_webui_custom_lvm_ext4"
                 }
             ]
     }


### PR DESCRIPTION
Non-E2E tests validate all expected checks without rebooting into the installed system, avoiding resource overhead. Instead, they verify the `fstab` file and the UI indicating partition changes (removal/resizing), providing assurance that the created storage layout aligns with expectations.