### PR TITLE
test: adjust windows test to use /dev/vdb

### DIFF
--- a/test/check-storage-reclaim
+++ b/test/check-storage-reclaim
@@ -369,9 +369,9 @@ class TestStorageReclaimExistingSystemFedora(VirtInstallMachineCase):
 class TestStorageReclaimExistingSystemWindows(VirtInstallMachineCase):
 
     def _testBasic_partition_disk(self):
-        WindowsOS(machine=self.machine).partition_disk()
+        WindowsOS(machine=self.machine).partition_disk("vdb")
 
-    @disk_images([("", 20)])
+    @disk_images([("", 15), ("", 20)])
     def testBasic(self):
         b = self.browser
         m = self.machine
@@ -380,6 +380,7 @@ class TestStorageReclaimExistingSystemWindows(VirtInstallMachineCase):
 
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
+        s.select_disks([("vda", False), ("vdb", True)])
         s.set_scenario("use-free-space")
         s.reclaim_set_checkbox(True)
         i.next(True)

--- a/test/helpers/operating_systems.py
+++ b/test/helpers/operating_systems.py
@@ -23,23 +23,23 @@ class WindowsOS:
     WINDOWS_SFDISK = """
 label: gpt
 label-id: DB12B2A4-5E98-4F12-97A2-424EFC6869C1
-device: /dev/vda
+device: /dev/{dev}
 unit: sectors
 first-lba: 34
 last-lba: 31457246
 sector-size: 512
 
-/dev/vda1 : start=        2048, size=      204800, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B, uuid=FA98D08B-128A-42AB-AB26-1B10D24F18FD, name="EFI system partition", attrs="GUID:63"
-/dev/vda2 : start=      206848, size=       32768, type=E3C9E316-0B5C-4DB8-817D-F92DF00215AE, uuid=E37855A3-07F9-4C2B-909B-EE2D92BC8D39, name="Microsoft reserved partition", attrs="GUID:63"
-/dev/vda3 : start=      239616, size=    26031793, type=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7, uuid=9431458E-065F-418F-92F5-30F52A746DC9, name="Basic data partition"
-/dev/vda4 : start=    30367744, size=     1085440, type=DE94BBA4-06D1-4D40-A16A-BFD50179D6AC, uuid=CC7E5418-AF67-472F-9BF4-FAD27A94A082, attrs="RequiredPartition GUID:63"
+/dev/{dev}1 : start=        2048, size=      204800, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B, uuid=FA98D08B-128A-42AB-AB26-1B10D24F18FD, name="EFI system partition", attrs="GUID:63"
+/dev/{dev}2 : start=      206848, size=       32768, type=E3C9E316-0B5C-4DB8-817D-F92DF00215AE, uuid=E37855A3-07F9-4C2B-909B-EE2D92BC8D39, name="Microsoft reserved partition", attrs="GUID:63"
+/dev/{dev}3 : start=      239616, size=    26031793, type=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7, uuid=9431458E-065F-418F-92F5-30F52A746DC9, name="Basic data partition"
+/dev/{dev}4 : start=    30367744, size=     1085440, type=DE94BBA4-06D1-4D40-A16A-BFD50179D6AC, uuid=CC7E5418-AF67-472F-9BF4-FAD27A94A082, attrs="RequiredPartition GUID:63"
 """
 
     def __init__(self, machine):
         self.machine = machine
 
-    def partition_disk(self):
-        self.machine.execute("echo '%s' | sfdisk /dev/vda" % self.WINDOWS_SFDISK)
+    def partition_disk(self, dev="vda"):
+        self.machine.execute(f"echo '%s' | sfdisk /dev/{dev}" % self.WINDOWS_SFDISK.format(dev=dev))
 
 
 class DualBootHelper_E2E(VirtInstallMachineCase):


### PR DESCRIPTION
There is some problematic dependency between the following two tests: TestStorageReclaimExistingSystemFedora.testDeletePartition TestStorageReclaimExistingSystemWindows.testBasic

When they are run against the same VM in the above order, the Windows test fails to detect correctly the free space.
There is some race condition in the backend, causing the Storage module to not refresh even after re-scanning.

I am not able to resolve this so let's use a differently named disk for the Windows test, to prevent confusing the Storage module.