### PR TITLE
test: make the win "Basic data partition" leave a bit more space

### DIFF
--- a/test/helpers/operating_systems.py
+++ b/test/helpers/operating_systems.py
@@ -31,7 +31,7 @@ sector-size: 512
 
 /dev/vda1 : start=        2048, size=      204800, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B, uuid=FA98D08B-128A-42AB-AB26-1B10D24F18FD, name="EFI system partition", attrs="GUID:63"
 /dev/vda2 : start=      206848, size=       32768, type=E3C9E316-0B5C-4DB8-817D-F92DF00215AE, uuid=E37855A3-07F9-4C2B-909B-EE2D92BC8D39, name="Microsoft reserved partition", attrs="GUID:63"
-/dev/vda3 : start=      239616, size=    26031793, type=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7, uuid=9431458E-065F-418F-92F5-30F52A746DC9, name="Basic data partition"
+/dev/vda3 : start=      239616, size=    24031793, type=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7, uuid=9431458E-065F-418F-92F5-30F52A746DC9, name="Basic data partition"
 /dev/vda4 : start=    30367744, size=     1085440, type=DE94BBA4-06D1-4D40-A16A-BFD50179D6AC, uuid=CC7E5418-AF67-472F-9BF4-FAD27A94A082, attrs="RequiredPartition GUID:63"
 """
 


### PR DESCRIPTION
So that it is sufficient for the "Use free space" scenario.  If the test TestStorageReclaimExistingSystemWindows.testBasic
followed TestStorageReclaimExistingSystemFedora.testDeletePartition the space was not sufficient by a fraction of GB.