### PR TITLE
tests: add e2e check for RAID1 on disks and remove existing which is not longer applicable

### DIFF
--- a/src/components/storage/StorageConfiguration.jsx
+++ b/src/components/storage/StorageConfiguration.jsx
@@ -97,6 +97,10 @@ const usePageInit = () => {
     // This is a workaround, as reseting the partitioning just before the 'applyStorage'
     // call results in a deadlock.
     const needsReset = appliedPartitioning && appliedPartitioning !== partitioning.path;
+    console.info("usePageInit, StorageConfiguration.jsx");
+    console.info("needsReset", needsReset);
+    console.info("appliedPartitioning", appliedPartitioning);
+    console.info("partitioning.path", partitioning.path);
 
     useEffect(() => {
         const _resetPartitioning = async () => {

--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -269,7 +269,7 @@ class VirtInstallMachineCase(MachineCase):
 
         # FIXME: https://bugzilla.redhat.com/show_bug.cgi?id=2325707
         # This should be removed from the test
-        if self.is_efi:
+        if self.is_efi and button_text != "Erase data and install":
             # Add efibootmgr entry for the second OS
             distro_name = self.disk_images[0][0].split("-")[0]
             m.execute(f"efibootmgr -c -d /dev/vda -p 15 -L {distro_name} -l '/EFI/{distro_name}/shimx64.efi'")

--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -468,47 +468,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
     @nondestructive
     @disk_images([("", 15), ("", 15), ("", 15)])
-    def testRAIDUnsupportedMetadataCheck(self):
-        b = self.browser
-        m = self.machine
-        i = Installer(b, m)
-        s = Storage(b, m)
-
-        self.addCleanup(m.execute, "mdadm --zero-superblock /dev/vda /dev/vdb /dev/vdc")
-        self.addCleanup(m.execute, "mdadm --stop /dev/md/SOMERAID")
-
-        i.open()
-        i.reach(i.steps.INSTALLATION_METHOD)
-        s.select_disks([("vdb", True), ("vda", True), ("vdc", True)])
-
-        s.modify_storage()
-        s.confirm_entering_cockpit_storage()
-        b.switch_to_frame("cockpit-storage")
-
-        # Create RAID device on vda, vdb, and vdc
-        self.click_dropdown(self.card_header("Storage"), "Create MDRAID device")
-        self.dialog_wait_open()
-        self.dialog_set_val("level", "raid0")
-        self.dialog_set_val("disks", {"vda": True, "vdb": True, "vdc": True})
-        self.dialog_set_val("name", "SOMERAID")
-        self.dialog_apply()
-        self.dialog_wait_close()
-
-        # Exit the cockpit-storage iframe and return to installation
-        b.switch_to_top()
-        s.return_to_installation()
-        s.return_to_installation_confirm()
-
-        s.check_scenario_selected("erase-all")
-        i.reach(i.steps.STORAGE_CONFIGURATION)
-        i.next(should_fail=True)
-        b.wait_in_text(
-            "#anaconda-screen-storage-configuration-step-notification",
-            "Failed to find a suitable stage1 device"
-        )
-
-    @nondestructive
-    @disk_images([("", 15), ("", 15), ("", 15)])
     def testCalculateSelectedDisksRAID(self):
         """ Verify that the disk selection changes when creating a RAID device """
 

--- a/test/check-storage-cockpit-e2e
+++ b/test/check-storage-cockpit-e2e
@@ -202,5 +202,58 @@ class TestStorageCockpitIntegration_E2E(VirtInstallMachineCase, StorageCase):
         self.assertEqual(raid_part["size"], "30G")
 
 
+    @disk_images([("", 15), ("", 15), ("", 15)])
+    @run_boot("bios", "efi")
+    def testRAID1onDisks(self):
+        """
+        Test scenario with three disks:
+        - A RAID 1 array is created using 'vda', 'vdb', and 'vdc'.
+        - The bootloader, '/boot' and the root filesystem ('/') are placed on the RAID 1 device.
+        """
+
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m)
+        s = Storage(b, m)
+
+        i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+        s.select_disks([("vdb", True), ("vda", True), ("vdc", True)])
+
+        s.modify_storage()
+        s.confirm_entering_cockpit_storage()
+        b.switch_to_frame("cockpit-storage")
+
+        # Create RAID device on vda, vdb, and vdc
+        self.click_dropdown(self.card_header("Storage"), "Create MDRAID device")
+        self.dialog_wait_open()
+        self.dialog_set_val("level", "raid1")
+        self.dialog_set_val("disks", {"vda": True, "vdb": True, "vdc": True})
+        self.dialog_set_val("name", "SOMERAID")
+        self.dialog_apply()
+        self.dialog_wait_close()
+
+        # Exit the cockpit-storage iframe and return to installation
+        b.switch_to_top()
+        s.return_to_installation()
+        s.return_to_installation_confirm()
+
+        s.check_scenario_selected("erase-all")
+        i.reach(i.steps.REVIEW)
+
+        # verify review screen
+        self.install(needs_confirmation=False, button_text="Erase data and install")
+
+        # Check that the expected partition layout is created and spans all the target devices
+        lsblk = s.get_lsblk_json()
+        block_devs = lsblk["blockdevices"]
+        vda = next(dev for dev in block_devs if dev["name"] == "vda")
+        raid_dev = next(part for part in vda["children"] if part["type"] == "raid1")
+        raid_dev_boot = next(part for part in raid_dev["children"] if part["type"] == "part" and part["name"] == "md127p2")
+        self.assertEqual(raid_dev_boot["mountpoints"], ["/boot"])
+        raid_dev_root = next(part for part in raid_dev["children"] if part["type"] == "part" and part["name"] == "md127p3")
+        self.assertEqual(raid_dev_root["children"][0]["mountpoints"], ["/"])
+
+
 if __name__ == '__main__':
     test_main()

--- a/test/vm.install
+++ b/test/vm.install
@@ -53,7 +53,12 @@ def vm_install(image, compose, verbose, quick):
             # cockpit-storaged is also available in the default rawhide compose, make sure we don't pull it from there
             download_from_copr(f"packit/cockpit-project-cockpit-{cockpit_pr}", "cockpit-storaged", machine)
         else:
-            packages_to_download += " cockpit-storaged"
+            # FIXME: test unreleased cockpit-storaged till cockpit-336 is in the gated ISO
+            # packages_to_download += " cockpit-storaged"
+            if image.startswith("fedora-42"):
+                machine.execute("curl -o /var/tmp/build/cockpit-storaged-336-1.fc42.noarch.rpm https://kojipkgs.fedoraproject.org//packages/cockpit/336/1.fc42/noarch/cockpit-storaged-336-1.fc42.noarch.rpm")
+            else:
+                machine.execute("curl -o /var/tmp/build/cockpit-storaged-336-1.fc43.noarch.rpm https://kojipkgs.fedoraproject.org//packages/cockpit/336/1.fc43/noarch/cockpit-storaged-336-1.fc43.noarch.rpm")
 
         if scenario and scenario.startswith("anaconda-webui-pr-"):
             # If we are testing a anaconda-webui PR scenario from a different repository


### PR DESCRIPTION
This needs new cockpit-storage which by default set 1.0 metadata version for MDRAID.
The existing check for invalid default metadata version is not longer applicable.

Relevant to: rhbz#2352953