### PR TITLE
Add a basic test for MBR partition table created in Cockpit Storage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ ignore_names = [
    "_testHomeReuseFedoraEncrypted_partition_disk",
    "_testLVMOnRAID_partition_disk",
    "_testLVM_partition_disk",
+   "_testMBRParttable_partition_disk",
    "_testMultipleDisks_partition_disk",
    "_testMultipleRoots_partition_disk",
    "_testNoRootMountPoint_partition_disk",

--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -656,6 +656,61 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         self.assertTrue("/mnt/sysroot/home auto noauto 0 0" in fstab)
         self.assertTrue("/mnt/sysroot auto noauto 0 0" in fstab)
 
+    @nondestructive
+    def testMBRParttable(self):
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m, scenario="use-configured-storage")
+        s = Storage(b, m)
+        r = Review(b, m)
+
+        dev = "vda"
+
+        i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+        s.wait_scenario_visible("use-configured-storage", False)
+        s.check_disk_selected(dev)
+        s.modify_storage()
+        s.confirm_entering_cockpit_storage()
+        b.wait_visible(".cockpit-storage-integration-sidebar")
+
+        frame = "iframe[name='cockpit-storage']"
+        b._wait_present(frame)
+        b.switch_to_frame("cockpit-storage")
+        b._wait_present("#storage.ct-page-fill")
+
+        self.click_dropdown(self.card_row("Storage", 1), "Create partition table")
+        self.dialog_set_val("type", "dos")
+        self.dialog_apply()
+        self.dialog_wait_close()
+
+        self.click_dropdown(self.card_row("Storage", 2), "Create partition")
+        self.dialog({"size": 1070, "type": "ext4", "mount_point": "/boot"})
+
+        self.click_dropdown(self.card_row("Storage", 3), "Create partition")
+        self.dialog({"type": "btrfs", "mount_point": "/"})
+
+        # Exit the cockpit-storage iframe
+        b.switch_to_top()
+
+        s.return_to_installation()
+        s.return_to_installation_confirm()
+
+        s.set_scenario("use-configured-storage")
+
+        i.reach(i.steps.REVIEW)
+
+        # verify review screen
+        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
+
+        r.check_disk_row(dev, "/boot", "vda1", "1.07 GB", False)
+        r.check_disk_row(dev, "/", "vda2", "15.0 GB", False)
+
+        # Check fstab
+        fstab = m.execute("cat /etc/fstab")
+        self.assertTrue("/mnt/sysroot/boot auto noauto 0 0" in fstab)
+        self.assertTrue("/mnt/sysroot auto noauto,subvol=/ 0 0" in fstab)
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/check-storage-mountpoints
+++ b/test/check-storage-mountpoints
@@ -203,7 +203,23 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         # Select only vdb disk and verify that mount point assignment is
         # not available (missing biosboot)
         s.select_disks([(dev1, False), (dev2, True)])
-        s.wait_scenario_available("mount-point-mapping", False)
+
+
+        # RHBZ 2353002 - the biosboot constraint is not required, therefore the
+        # scenario is available
+        #s.wait_scenario_available("mount-point-mapping", False)
+        s.wait_scenario_available("mount-point-mapping")
+        # Let's check that the missing biosboot is caught later by validation
+        s.select_mountpoint([(dev1, False), (dev2, True)])
+        s.select_mountpoint_row_device(1, f"{dev2}1")
+        s.check_mountpoint_row(1, "/", f"{dev2}1", True, "xfs")
+        s.remove_mountpoint_row(2, 2)
+        i.next(should_fail=True)
+        b.wait_in_text(
+            "#anaconda-screen-mount-point-mapping-step-notification",
+            "Your BIOS-based system needs a special partition to boot from a GPT disk label."
+        )
+        i.back()
 
         # Select only vda disk and verify that the partitioning request is correct
         s.select_mountpoint([(dev1, True), (dev2, False)])
@@ -365,7 +381,8 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s.confirm_entering_cockpit_storage()
         b.wait_visible(".cockpit-storage-integration-sidebar")
         s.check_constraint("/", True)
-        s.check_constraint("biosboot", True)
+        # RHBZ 2353002 - the biosboot constraint is not required
+        #s.check_constraint("biosboot", True)
         s.check_constraint("/boot", False)
 
         frame = "iframe[name='cockpit-storage']"

--- a/test/check-storage-mountpoints
+++ b/test/check-storage-mountpoints
@@ -248,6 +248,33 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
             ignore=pixel_tests_ignore,
         )
 
+    def _testMBRParttable_partition_disk(self):
+        b = self.browser
+        m = self.machine
+        s = Storage(b, m)
+
+        # Configure disk layout with MBR partition table
+        disk = "/dev/vda"
+        s.partition_disk(
+            disk,
+            [
+                ("1GB", "ext4"),
+                ("10GiB", "xfs"),
+            ],
+            is_mbr=True
+        )
+
+    def testMBRParttable(self):
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m)
+        s = Storage(b, m)
+
+        i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+
+        s.wait_scenario_available("mount-point-mapping")
+
     def _testEncryptedUnlock_partition_disk(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Resolves: rhbz#2353002

The tests and tests updates related to https://github.com/rhinstaller/anaconda/pull/6306

- [x] existing mbr parttable layout + mount point assignment
- [ ] ~? multiple disks (with mbr and gpt parttable)~
- [x] Update existing tests