### PR TITLE
tests: add e2e check for RAID1 on disks and remove existing which is not longer applicable

### DIFF
--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -468,47 +468,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
     @nondestructive
     @disk_images([("", 15), ("", 15), ("", 15)])
-    def testRAIDUnsupportedMetadataCheck(self):
-        b = self.browser
-        m = self.machine
-        i = Installer(b, m)
-        s = Storage(b, m)
-
-        self.addCleanup(m.execute, "mdadm --zero-superblock /dev/vda /dev/vdb /dev/vdc")
-        self.addCleanup(m.execute, "mdadm --stop /dev/md/SOMERAID")
-
-        i.open()
-        i.reach(i.steps.INSTALLATION_METHOD)
-        s.select_disks([("vdb", True), ("vda", True), ("vdc", True)])
-
-        s.modify_storage()
-        s.confirm_entering_cockpit_storage()
-        b.switch_to_frame("cockpit-storage")
-
-        # Create RAID device on vda, vdb, and vdc
-        self.click_dropdown(self.card_header("Storage"), "Create MDRAID device")
-        self.dialog_wait_open()
-        self.dialog_set_val("level", "raid0")
-        self.dialog_set_val("disks", {"vda": True, "vdb": True, "vdc": True})
-        self.dialog_set_val("name", "SOMERAID")
-        self.dialog_apply()
-        self.dialog_wait_close()
-
-        # Exit the cockpit-storage iframe and return to installation
-        b.switch_to_top()
-        s.return_to_installation()
-        s.return_to_installation_confirm()
-
-        s.check_scenario_selected("erase-all")
-        i.reach(i.steps.STORAGE_CONFIGURATION)
-        i.next(should_fail=True)
-        b.wait_in_text(
-            "#anaconda-screen-storage-configuration-step-notification",
-            "Failed to find a suitable stage1 device"
-        )
-
-    @nondestructive
-    @disk_images([("", 15), ("", 15), ("", 15)])
     def testCalculateSelectedDisksRAID(self):
         """ Verify that the disk selection changes when creating a RAID device """
 

--- a/test/check-storage-cockpit-e2e
+++ b/test/check-storage-cockpit-e2e
@@ -202,5 +202,99 @@ class TestStorageCockpitIntegration_E2E(VirtInstallMachineCase, StorageCase):
         self.assertEqual(raid_part["size"], "30G")
 
 
+    @disk_images([("", 15), ("", 15)])
+    def testRAID1onDisksManual(self):
+        """
+        Test scenario with three disks:
+        - A RAID 1 array is created using 'vda', 'vdb'
+        - The bootloader, '/boot' and the root filesystem ('/') are placed manually on the RAID 1 device.
+        """
+
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m, scenario="use-configured-storage")
+        s = Storage(b, m)
+        r = Review(b, m)
+
+        i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+        s.select_disks([("vdb", True), ("vda", True)])
+
+        s.modify_storage()
+        s.confirm_entering_cockpit_storage()
+        b.switch_to_frame("cockpit-storage")
+
+        def createRAID_Manual(raid_level="raid1"):
+            # Create RAID device on vda, vdb
+            self.click_dropdown(self.card_header("Storage"), "Create MDRAID device")
+            self.dialog_wait_open()
+            self.dialog_set_val("level", raid_level)
+            self.dialog_set_val("disks", {"vda": True, "vdb": True})
+            self.dialog_set_val("name", f"SOMERAID-{raid_level}")
+            self.dialog_apply()
+            self.dialog_wait_close()
+
+            # Create biosboot and /boot partitions on vda
+            self.click_dropdown(self.card_row("Storage", 3), "Create partition table")
+            self.dialog({"type": "gpt"})
+            b.wait_in_text(self.card_row("Storage", name=f"md/SOMERAID-{raid_level}"), "GPT")
+            self.click_dropdown(self.card_row("Storage", 4), "Create partition")
+            self.dialog({"size": 1, "type": "biosboot"})
+            self.click_dropdown(self.card_row("Storage", 5), "Create partition")
+            self.dialog({"size": 1070, "type": "ext4", "mount_point": "/boot"})
+            self.click_dropdown(self.card_row("Storage", 6), "Create partition")
+            self.dialog({"type": "ext4", "mount_point": "/"})
+
+        # RAID0 should not be allowed for the bootloaders
+        createRAID_Manual("raid0")
+
+        # Exit the cockpit-storage iframe and return to installation
+        b.switch_to_top()
+        s.return_to_installation("Failed to find a suitable stage1 device")
+        s.return_to_installation_cancel()
+        b.switch_to_frame("cockpit-storage")
+
+        self.click_dropdown(self.card_row("Storage", 3), "Delete")
+        self.dialog_apply()
+        b.wait_not_present(self.card_row("Storage", name="md/SOMERAID-raid0"))
+
+        # Create biosboot and /boot partitions on vda
+        self.click_dropdown(self.card_row("Storage", 1), "Create partition table")
+        self.dialog({"type": "empty"})
+        b.wait_not_present(self.card_row("Storage", name="Free space"))
+
+        createRAID_Manual("raid1")
+
+        # Exit the cockpit-storage iframe and return to installation
+        b.switch_to_top()
+        s.return_to_installation()
+
+        def checkStorageReview(prefix=""):
+            with b.wait_timeout(30):
+                disk = "MDRAID-SOMERAID-raid1"
+                r.check_disk(disk, f"16.1 GB {disk} (MDRAID set (mirror))", prefix=prefix)
+
+        # verify review screen
+        checkStorageReview(prefix="#cockpit-storage-integration-check-storage-dialog")
+        s.return_to_installation_confirm()
+
+        i.reach(i.steps.REVIEW)
+
+        # verify review screen
+        checkStorageReview()
+        self.install(needs_confirmation=False)
+
+        # Check that the expected partition layout is created and spans all the target devices
+        lsblk = s.get_lsblk_json()
+        block_devs = lsblk["blockdevices"]
+
+        vda = next(dev for dev in block_devs if dev["name"] == "vda")
+        raid_dev = next(part for part in vda["children"] if part["type"] == "raid1")
+        raid_boot = next(part for part in raid_dev["children"] if part["name"] == "md127p2")
+        raid_root = next(part for part in raid_dev["children"] if part["name"] == "md127p3")
+        self.assertEqual(raid_boot["mountpoints"], ["/boot"])
+        self.assertEqual(raid_root["mountpoints"], ["/"])
+
+
 if __name__ == '__main__':
     test_main()

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -103,6 +103,10 @@ class StorageDestination():
             self.browser.click("#cockpit-storage-integration-check-storage-dialog-continue")
             self.browser.wait_not_present("#cockpit-storage-integration-check-storage-dialog")
 
+    def return_to_installation_cancel(self):
+        self.browser.click("#cockpit-storage-integration-check-storage-dialog-return")
+        self.browser.wait_not_present("#cockpit-storage-integration-check-storage-dialog")
+
     def modify_storage(self):
         self.browser.click("#toggle-kebab")
         self.browser.click("#modify-storage")

--- a/test/vm.install
+++ b/test/vm.install
@@ -13,6 +13,9 @@ BOTS_DIR = os.path.realpath(f'{__file__}/../../bots')
 sys.path.append(BOTS_DIR)
 
 missing_packages = "cockpit-ws cockpit-bridge fedora-logos udisks2 libudisks2 udisks2-lvm2 udisks2-btrfs udisks2-iscsi"
+# We need stat binary from coreutils for cockpit-storage
+# https://github.com/weldr/lorax/commit/51d8501a6ea208a9914bc58b4131285c495e18f7
+missing_packages += " coreutils"
 
 from machine.machine_core import machine_virtual
 
@@ -53,7 +56,12 @@ def vm_install(image, compose, verbose, quick):
             # cockpit-storaged is also available in the default rawhide compose, make sure we don't pull it from there
             download_from_copr(f"packit/cockpit-project-cockpit-{cockpit_pr}", "cockpit-storaged", machine)
         else:
-            packages_to_download += " cockpit-storaged"
+            # FIXME: test unreleased cockpit-storaged till cockpit-336 is in the gated ISO
+            # packages_to_download += " cockpit-storaged"
+            if image.startswith("fedora-42"):
+                machine.execute("curl -o /var/tmp/build/cockpit-storaged-336.1-1.fc42.noarch.rpm https://kojipkgs.fedoraproject.org//packages/cockpit/336.1/1.fc42/noarch/cockpit-storaged-336.1-1.fc42.noarch.rpm")
+            else:
+                machine.execute("curl -o /var/tmp/build/cockpit-storaged-336.1-1.fc43.noarch.rpm https://kojipkgs.fedoraproject.org//packages/cockpit/336.1/1.fc43/noarch/cockpit-storaged-336.1-1.fc43.noarch.rpm")
 
         if scenario and scenario.startswith("anaconda-webui-pr-"):
             # If we are testing a anaconda-webui PR scenario from a different repository


### PR DESCRIPTION
This needs new cockpit-storage which by default set 1.0 metadata version for MDRAID.
The existing check for invalid default metadata version is not longer applicable.

Relevant to: rhbz#2352953
Relevant to: rhbz#2354798