### PR TITLE
cockpit-storage-integration: Prevent crash when deleting an encrypted device

### DIFF
--- a/src/components/storage/CockpitStorageIntegration.jsx
+++ b/src/components/storage/CockpitStorageIntegration.jsx
@@ -421,6 +421,10 @@ const CheckStorageDialog = ({
                         });
                     }))
                 .filter(({ device }) => {
+                    if (!device) {
+                        return false;
+                    }
+
                     return (
                         devices[device].formatData.type.v === "luks" &&
                             devices[device].formatData.attrs.v.has_key !== "True"

--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -101,6 +101,21 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         r.check_disk_row(dev, "/", "vda3", "15.0 GB", False, None, True)
 
+        # Do not crash if encrypted device got deleted
+        i.reach_on_sidebar(i.steps.INSTALLATION_METHOD)
+        s.modify_storage()
+        s.confirm_entering_cockpit_storage()
+        b.switch_to_frame("cockpit-storage")
+
+        self.click_dropdown(self.card_row("Storage", 4), "Delete")
+        b.set_checked("#dialog-confirm", val=True)
+        self.dialog_apply()
+        b.wait_not_present(self.card_row("Storage", name="vda3"))
+
+        b.switch_to_top()
+        s.return_to_installation()
+        s.return_to_installation_confirm()
+
     @nondestructive
     def testLVM(self):
         b = self.browser


### PR DESCRIPTION
Avoid a crash when an encrypted device is deleted after being created in cockpit-storage.

Here is the reproducer:
* An encrypted device is created in cockpit-storage.
* The user exits cockpit-storage, passing the device password from Cockpit to Anaconda.
* The user re-enters cockpit-storage and deletes the device.
* The user exits the cockpit-storage screen again, triggering the crash.

This fix ensures that such a sequence no longer leads to a crash.