### PR TITLE
storage: mount point mapping: fix wrapping of the custom mount points rows

### DIFF
--- a/src/components/storage/MountPointMapping.jsx
+++ b/src/components/storage/MountPointMapping.jsx
@@ -228,7 +228,7 @@ const MountPointColumn = ({ handleRequestChange, idPrefix, isRecommendedMountPoi
 
     return (
         <Flex direction={{ default: "column" }} spaceItems={{ default: "spaceItemsNone" }}>
-            <Flex spaceItems={{ default: "spaceItemsMd" }}>
+            <Flex spaceItems={{ default: "spaceItemsMd" }} flexWrap={{ default: "nowrap" }}>
                 {((isRequiredMountPoint || isRecommendedMountPoint) && !duplicatedMountPoint) || swapMountpoint
                     ? (
                         <FlexItem


### PR DESCRIPTION
Before:

![127 0 0 2_9091_cockpit_@localhost_anaconda-webui_index html](https://github.com/user-attachments/assets/9200d391-af4e-401a-916b-33c02242ceb9)

Now:

![127 0 0 2_9091_cockpit_@localhost_anaconda-webui_index html (1)](https://github.com/user-attachments/assets/4687a8fd-5165-4fe1-9b78-5aa58a6d77cc)

