### PR TITLE
cockpit-storage-integration: convert the intermediate modal to medium variant

### DIFF
--- a/src/components/storage/CockpitStorageIntegration.jsx
+++ b/src/components/storage/CockpitStorageIntegration.jsx
@@ -710,7 +710,7 @@ const CheckStorageDialog = ({
           id={idPrefix + "-check-storage-dialog"}
           onClose={() => setShowDialog(false)}
           titleIconVariant={!loading && storageRequirementsNotMet && "warning"}
-          position="top" variant="small" isOpen
+          position="top" variant="medium" isOpen
           {...modalProps}
           footer={
               !loading &&


### PR DESCRIPTION
The action buttons have rather long texts, and in some languages they do not fit into a single line in the specified modal width.