### PR TITLE
tests: kill rsync process in case it's keeping a mount busy

### DIFF
--- a/test/check-storage-home-reuse
+++ b/test/check-storage-home-reuse
@@ -29,6 +29,7 @@ ROOT_DIR = os.path.dirname(TEST_DIR)
 BOTS_DIR = f'{ROOT_DIR}/bots'
 
 
+@nondestructive
 class TestStorageHomeReuseFedora(VirtInstallMachineCase):
     def _remove_unknown_mountpoints(self):
         # Remove the /var subvolume from the default btrfs layout
@@ -46,7 +47,6 @@ class TestStorageHomeReuseFedora(VirtInstallMachineCase):
 
     @run_boot("bios", "efi")
     @disk_images([("fedora-rawhide", 15)])
-    @nondestructive
     def testBasic(self):
         b = self.browser
         m = self.machine
@@ -80,7 +80,6 @@ class TestStorageHomeReuseFedora(VirtInstallMachineCase):
                          action="mount")
 
     @disk_images([("fedora-rawhide", 15)])
-    @nondestructive
     def testHidden(self):
         b = self.browser
         m = self.machine
@@ -110,6 +109,7 @@ class TestStorageHomeReuseFedora(VirtInstallMachineCase):
         # Create standard encrypted btrfs layout in the empty disk and copy the data from the fedora
         # disk to emulate the Fedora encrypted layout
         # Then eject the fedora disk
+        self.addCleanup(m.execute, "killall -9 rsync || true")
         self.machine.execute(f"""
         set -xe
 
@@ -193,7 +193,6 @@ class TestStorageHomeReuseFedora(VirtInstallMachineCase):
 
     @disk_images([("fedora-rawhide", 15), ("fedora-41", 15), ("ubuntu-stable", 15)])
     @skipImage("btrfs support missing on fedora-eln image", "fedora-eln-boot")
-    @nondestructive
     def testMultipleRoots(self):
         b = self.browser
         m = self.machine

--- a/test/check-storage-mountpoints
+++ b/test/check-storage-mountpoints
@@ -278,6 +278,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         # Create standard btrfs layout in the empty disk and copy the data from the fedora
         # disk to emulate the installation on MBR disk.
         # Then eject the fedora disk
+        self.addCleanup(m.execute, "killall -9 rsync || true")
         self.machine.execute(f"""
         set -xe
 


### PR DESCRIPTION
This was keeping devices busy after test teardown generating a series of test failures.