### PR TITLE
storage: avoid rendering wizard pages while Cockpit Storage is active

### DIFF
--- a/src/components/AnacondaPage.jsx
+++ b/src/components/AnacondaPage.jsx
@@ -28,6 +28,7 @@ export const AnacondaPage = ({
     isFirstScreen,
     isFormDisabled,
     setIsFormDisabled,
+    showStorage,
     step,
     title,
     usePageInit,
@@ -53,7 +54,9 @@ export const AnacondaPage = ({
         }
     }, [isFormDisabled]);
 
-    if (!showPage) {
+    // Don't try to render anything while cockpit storage mode is active
+    // as background API calls might cause UnknownDeviceError
+    if (!showPage || showStorage) {
         return null;
     }
 

--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -50,7 +50,6 @@ export const AnacondaWizard = ({ currentStepId, dispatch, isFetching, onCritFail
         onCritFail,
         setIsFormDisabled,
         setIsFormValid,
-        showStorage,
     };
 
     const stepsOrder = getSteps(userInterfaceConfig, isBootIso, storageScenarioId);
@@ -87,6 +86,7 @@ export const AnacondaWizard = ({ currentStepId, dispatch, isFetching, onCritFail
                           step={s.id}
                           title={s.title}
                           isFirstScreen={s.isFirstScreen}
+                          showStorage={showStorage}
                           usePageInit={s.usePageInit}>
                             <s.component {...componentProps} isFirstScreen={s.isFirstScreen} />
                         </AnacondaPage>

--- a/src/components/storage/InstallationMethod.jsx
+++ b/src/components/storage/InstallationMethod.jsx
@@ -57,7 +57,6 @@ const InstallationMethod = ({
     setIsFormDisabled,
     setIsFormValid,
     setStepNotification,
-    showStorage,
 }) => {
     const [isReclaimSpaceCheckboxChecked, setIsReclaimSpaceCheckboxChecked] = useState();
 
@@ -95,7 +94,6 @@ const InstallationMethod = ({
                   isFormDisabled={isFormDisabled}
                   onCritFail={onCritFail}
                   setIsFormValid={setIsFormValid}
-                  showStorage={showStorage}
                 />
             </DialogsContext.Provider>
         </Form>

--- a/src/components/storage/InstallationScenario.jsx
+++ b/src/components/storage/InstallationScenario.jsx
@@ -71,7 +71,6 @@ const InstallationScenarioSelector = ({
     idPrefix,
     isFormDisabled,
     setIsFormValid,
-    showStorage,
 }) => {
     const { appliedPartitioning, diskSelection, partitioning } = useContext(StorageContext);
     const { devices, mountPoints } = useOriginalDeviceTree();
@@ -131,11 +130,6 @@ const InstallationScenarioSelector = ({
     useEffect(() => {
         let selectedScenarioId = "";
 
-        // Don't mess up with the scenarios while cockpit storage mode is active
-        if (showStorage) {
-            return;
-        }
-
         if (storageScenarioId && scenarioAvailability[storageScenarioId].available === undefined) {
             return;
         }
@@ -160,7 +154,7 @@ const InstallationScenarioSelector = ({
             dispatch(setStorageScenarioAction(selectedScenarioId));
         }
         setIsFormValid(!!selectedScenarioId);
-    }, [dispatch, mountPoints, scenarioAvailability, setIsFormValid, showStorage, storageScenarioId]);
+    }, [dispatch, mountPoints, scenarioAvailability, setIsFormValid, storageScenarioId]);
 
     const onScenarioToggled = (scenarioId) => {
         dispatch(setStorageScenarioAction(scenarioId));
@@ -200,7 +194,6 @@ export const InstallationScenario = ({
     isFirstScreen,
     isFormDisabled,
     setIsFormValid,
-    showStorage,
 }) => {
     const headingLevel = isFirstScreen ? "h3" : "h2";
     const { diskSelection, storageScenarioId } = useContext(StorageContext);
@@ -231,7 +224,6 @@ export const InstallationScenario = ({
                   idPrefix={idPrefix}
                   isFormDisabled={isFormDisabled}
                   setIsFormValid={setIsFormValid}
-                  showStorage={showStorage}
                 />
             </FormGroup>
         </FormSection>


### PR DESCRIPTION
Rendering wizard pages in the background can trigger API calls to devices that may no longer exist, leading to errors.
We currently work around this by handling and silencing these errors [1] as a hotfix for Fedora 42, due to limited time to implement a proper fix.

This change takes first steps to a more robust approach by preventing the rendering of wizard pages entirely while cockpit-storage mode is active, avoiding invalid device accesses altogether.

[1] https://github.com/rhinstaller/anaconda-webui/commit/53f2ff