### PR TITLE
storage: fix selected disk handling when replacing an MD RAID device

### DIFF
--- a/src/components/storage/CockpitStorageIntegration.jsx
+++ b/src/components/storage/CockpitStorageIntegration.jsx
@@ -331,25 +331,30 @@ const handleMDRAID = ({ devices, onFail, refDevices, setNextCheckStep }) => {
     // for the new mdarrays to be handled as such.
     const setNewSelectedDisks = async () => {
         const selectedDisks = await getSelectedDisks();
-        const newSelectedDisks = selectedDisks.reduce((acc, disk) => {
-            if (!devices[disk]) {
-                if (refDevices.current[disk]?.parents.v) {
-                    debug("cockpit-storage-integration: re-scan finished: Device got removed, adding parent disks to selected disks", disk);
-                    return [...acc, ...refDevices.current[disk].parents.v];
-                } else {
-                    debug("cockpit-storage-integration: re-scan finished: Device got removed, removing from selected disks", disk);
-                    return acc;
-                }
-            }
-            const mdArray = devices[disk].children.v.filter(child => mdArrays.includes(child));
-            if (mdArray.length > 0) {
-                debug("cockpit-storage-integration: re-scan finished: MD array found, replacing disk with mdarray", disk, mdArray);
-                return [...acc, mdArray[0]];
-            } else {
-                debug("cockpit-storage-integration: re-scan finished: Keeping disk", disk);
-                return [...acc, disk];
-            }
-        }, []).filter((disk, index, disks) => disks.indexOf(disk) === index);
+        const newSelectedDisks = selectedDisks
+                .reduce((acc, disk) => {
+                    if (!devices[disk]) {
+                        if (refDevices.current[disk]?.parents.v) {
+                            debug("cockpit-storage-integration: re-scan finished: Device got removed, adding parent disks to selected disks", disk);
+                            return [...acc, ...refDevices.current[disk].parents.v];
+                        } else {
+                            debug("cockpit-storage-integration: re-scan finished: Device got removed, removing from selected disks", disk);
+                            return acc;
+                        }
+                    }
+                    return [...acc, disk];
+                }, [])
+                .reduce((acc, disk) => {
+                    const mdArray = devices[disk].children.v.filter(child => mdArrays.includes(child));
+                    if (mdArray.length > 0) {
+                        debug("cockpit-storage-integration: re-scan finished: MD array found, replacing disk with mdarray", disk, mdArray);
+                        return [...acc, mdArray[0]];
+                    } else {
+                        debug("cockpit-storage-integration: re-scan finished: Keeping disk", disk);
+                        return [...acc, disk];
+                    }
+                }, [])
+                .filter((disk, index, disks) => disks.indexOf(disk) === index);
 
         if (!checkIfArraysAreEqual(selectedDisks, newSelectedDisks)) {
             setSelectedDisks({ drives: newSelectedDisks });

--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -538,6 +538,32 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
             f"'{bootloaderType}' partition on MDRAID device SOMERAID found. Bootloader partitions on MDRAID devices are not supported."
         )
 
+    def _createRAID(self, disks, level, name):
+        """ Create a RAID device with the given disks, level and name """
+
+        b = self.browser
+
+        self.click_dropdown(self.card_header("Storage"), "Create MDRAID device")
+        self.dialog_wait_open()
+        self.dialog_set_val("level", level)
+        self.dialog_set_val("disks", disks)
+        self.dialog_set_val("name", name)
+        self.dialog_apply()
+        self.dialog_wait_close()
+
+        b.wait_visible(self.card_row("Storage", name=f"md/{name}"))
+
+    def _delete_storage(self, index):
+        """ Delete the storage device with the given index """
+
+        b = self.browser
+
+        self.click_dropdown(self.card_row("Storage", index), "Delete")
+        self.dialog_apply()
+        self.dialog_wait_close()
+
+        b.wait_not_present(self.card_row("Storage", index))
+
     @nondestructive
     @disk_images([("", 15), ("", 15), ("", 15)])
     def testCalculateSelectedDisksRAID(self):
@@ -557,13 +583,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         b.switch_to_frame("cockpit-storage")
 
         # Create RAID device on vda, vdb, and vdc
-        self.click_dropdown(self.card_header("Storage"), "Create MDRAID device")
-        self.dialog_wait_open()
-        self.dialog_set_val("level", "raid0")
-        self.dialog_set_val("disks", {"vda": True, "vdb": True, "vdc": True})
-        self.dialog_set_val("name", "SOMERAID")
-        self.dialog_apply()
-        self.dialog_wait_close()
+        self._createRAID({"vda": True, "vdb": True, "vdc": True}, "raid0", "SOMERAID")
 
         # Exit the cockpit-storage iframe and return to installation
         b.switch_to_top()
@@ -577,9 +597,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         b.switch_to_frame("cockpit-storage")
 
         # Delete RAID device and expect the disk selection to be set back to the parent disks
-        self.click_dropdown(self.card_row("Storage", 4), "Delete")
-        self.dialog_apply()
-        self.dialog_wait_close()
+        self._delete_storage(4)
 
         # Exit the cockpit-storage iframe and return to installation
         b.switch_to_top()
@@ -595,13 +613,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         b.switch_to_frame("cockpit-storage")
 
         # Create RAID device on vda, vdb
-        self.click_dropdown(self.card_header("Storage"), "Create MDRAID device")
-        self.dialog_wait_open()
-        self.dialog_set_val("level", "raid0")
-        self.dialog_set_val("disks", {"vda": True, "vdb": True})
-        self.dialog_set_val("name", "SOMERAID")
-        self.dialog_apply()
-        self.dialog_wait_close()
+        self._createRAID({"vda": True, "vdb": True}, "raid0", "SOMERAID")
 
         # Exit the cockpit-storage iframe and return to installation
         b.switch_to_top()
@@ -616,9 +628,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         s.confirm_entering_cockpit_storage()
         b.switch_to_frame("cockpit-storage")
 
-        self.click_dropdown(self.card_row("Storage", 4), "Delete")
-        self.dialog_apply()
-        b.wait_not_present(self.card_row("Storage", 4))
+        self._delete_storage(4)
 
         # Exit the cockpit-storage iframe and return to installation
         b.switch_to_top()
@@ -627,6 +637,37 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         for disk in ["vda", "vdb", "vdc"]:
             s.check_disk_selected(disk)
+
+        s.modify_storage()
+        s.confirm_entering_cockpit_storage()
+        b.switch_to_frame("cockpit-storage")
+
+        # Create RAID device on vda, vdb, and vdc, then delete it and create a new one with another name
+        # before returning to installation
+        self._createRAID({"vda": True, "vdb": True, "vdc": True}, "raid0", "SOMERAID")
+
+        b.switch_to_top()
+        s.return_to_installation()
+        s.return_to_installation_cancel()
+
+        b.switch_to_frame("cockpit-storage")
+        self._delete_storage(4)
+
+        self._createRAID({"vda": True, "vdb": True, "vdc": True}, "raid0", "SOMERAID2")
+
+        # Exit the cockpit-storage iframe and return to installation
+        b.switch_to_top()
+        s.return_to_installation()
+        s.return_to_installation_confirm()
+        s.check_disk_selected("MDRAID-SOMERAID2")
+
+        s.modify_storage()
+        s.confirm_entering_cockpit_storage()
+        b.switch_to_frame("cockpit-storage")
+
+        # Delete it for the test cleanup
+        self._delete_storage(4)
+
 
     @disk_images([("", 15), ("", 15)])
     @nondestructive

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -103,6 +103,10 @@ class StorageDestination():
             self.browser.click("#cockpit-storage-integration-check-storage-dialog-continue")
             self.browser.wait_not_present("#cockpit-storage-integration-check-storage-dialog")
 
+    def return_to_installation_cancel(self):
+        self.browser.click("#cockpit-storage-integration-check-storage-dialog-return")
+        self.browser.wait_not_present("#cockpit-storage-integration-check-storage-dialog")
+
     def modify_storage(self):
         self.browser.click("#toggle-kebab")
         self.browser.click("#modify-storage")


### PR DESCRIPTION
When an MD RAID device is deleted and a new one is immediately created using the same disks, the selected disks list will temporarily not include the parent disks. To handle this correctly, we first re-add the parent disks to the selection, then determine whether the new MD RAID device should replace them in the selected set.

Resolves: rhbz#2354798