### PR TITLE
Override globally modals min-width to stretch according to the contents

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -42,3 +42,6 @@ html:not(.index-page) body {
 .ct-table .pf-v5-c-table__expandable-row-content {
   padding: 0;
 }
+
+// FIXME: Remove when fixed: https://github.com/patternfly/patternfly/issues/7440
+.pf-v5-c-modal-box { min-width: min-content; }


### PR DESCRIPTION
Resolves: rhbz#2357172