### PR TITLE
cockpit-storage-integration: prevent entering the storage editor without selected disks

### DIFF
--- a/src/components/storage/CockpitStorageIntegration.jsx
+++ b/src/components/storage/CockpitStorageIntegration.jsx
@@ -890,7 +890,7 @@ export const ModifyStorage = ({ currentStepId, setShowStorage }) => {
         mount_point_prefix: targetSystemRoot,
     });
     // Allow to modify storage only when we are in the scenario selection page
-    const isDisabled = currentStepId !== "anaconda-screen-method";
+    const isDisabled = currentStepId !== "anaconda-screen-method" || diskSelection.selectedDisks.length === 0;
     const item = (
         <DropdownItem
           id="modify-storage"
@@ -907,10 +907,16 @@ export const ModifyStorage = ({ currentStepId, setShowStorage }) => {
     if (!isDisabled) {
         return item;
     } else {
+        let tooltipContent;
+        if (currentStepId !== "anaconda-screen-method") {
+            tooltipContent = _("Storage editor is available only in the `Installation method` step.")
+        } else if (diskSelection.selectedDisks.length === 0) {
+            tooltipContent = _("Select at least one disk to enable the storage editor.");
+        }
         return (
             <Tooltip
               id="modify-storage-tooltip"
-              content={_("Storage editor is available only in the `Installation method` step.")}>
+              content={tooltipContent}>
                 <span>
                     {item}
                 </span>


### PR DESCRIPTION
Disks must be selected before entering the storage editor. Currently, entering without a selection leads to unexpected behavior and warnings, as this case isn't properly handled.