### PR TITLE
build: pin down cockpit-storaged version because of Patternfly 6 changes

### DIFF
--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -20,11 +20,12 @@ BuildRequires: systemd-rpm-macros
 %endif
 
 %global cockpitver 275
-%global cockpitstorver 311
+%global cockpitstorver 336.2
 
 %define _unitdir /usr/lib/systemd/system
 
-Requires: cockpit-storaged >= %{cockpitstorver}
+# Unpin cockpit-storaged when anaconda-webui get's migrated to Patternfly 6
+Requires: cockpit-storaged <= %{cockpitstorver}
 Requires: cockpit-bridge >= %{cockpitver}
 Requires: cockpit-ws >= %{cockpitver}
 Requires: anaconda-core  >= %{anacondacorever}


### PR DESCRIPTION
Unpin when we are also ready with Patternfly 6 migration.