### PR TITLE
Anaconda needs latest pykickstart but image refresh is currently blocked on kernel regression

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -12,7 +12,7 @@ import sys
 BOTS_DIR = os.path.realpath(f'{__file__}/../../bots')
 sys.path.append(BOTS_DIR)
 
-missing_packages = "cockpit-ws cockpit-bridge fedora-logos udisks2 libudisks2 udisks2-lvm2 udisks2-btrfs udisks2-iscsi"
+missing_packages = "cockpit-ws cockpit-bridge fedora-logos udisks2 libudisks2 udisks2-lvm2 udisks2-btrfs udisks2-iscsi python3-kickstart"
 
 from machine.machine_core import machine_virtual
 


### PR DESCRIPTION
This should be reverted ASAP.