### PR TITLE
fix: can't click outside of header dropdown to close it

### DIFF
--- a/src/components/HeaderKebab.jsx
+++ b/src/components/HeaderKebab.jsx
@@ -147,6 +147,7 @@ export const HeaderKebab = ({ currentStepId, dispatch, isConnected, onCritFail, 
               isOpen={isOpen}
               onSelect={onSelect}
               popperProps={{ position: "right" }}
+              onOpenChange={setIsOpen}
               toggle={toggleRef =>
                   <MenuToggle
                     className="pf-m-align-right"


### PR DESCRIPTION
Just reinstalled fedora 41 and found a minor bug with the installer: you can't click outside the of the kebab dropdown menu to close it. 

This PR fixes that issue