### PR TITLE
Revert "build: stop requiring cockpit-storaged with Patternfly 5"

### DIFF
--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -23,7 +23,7 @@ BuildRequires: systemd-rpm-macros
 
 %define _unitdir /usr/lib/systemd/system
 
-# Unpin cockpit-storaged when anaconda-webui get's migrated to Patternfly 6
+Requires: cockpit-storaged
 Requires: cockpit-bridge >= %{cockpitver}
 Requires: cockpit-ws >= %{cockpitver}
 Requires: anaconda-core  >= %{anacondacorever}


### PR DESCRIPTION
This reverts commit 5dd43fe92509004b4e5fcfcaa6b7361eb4c9314d.

We need cockpit-storaged, we should just not pin down the version.