### PR TITLE
components: storage: fix disabled radio buttons

### DIFF
--- a/src/components/storage/InstallationScenario.jsx
+++ b/src/components/storage/InstallationScenario.jsx
@@ -174,7 +174,7 @@ const InstallationScenarioSelector = ({
           value={scenario.id}
           name={idPrefix + "-scenario"}
           label={scenario.getLabel()}
-          isAriaDisabled={!scenarioAvailability[scenario.id].available || isFormDisabled}
+          isDisabled={!scenarioAvailability[scenario.id].available || isFormDisabled}
           isChecked={storageScenarioId === scenario.id}
           onChange={() => onScenarioToggled(scenario.id)}
           description={scenario.getDetail()}


### PR DESCRIPTION
Patternfly 6 does not expose isAriaDisabled property on radio buttons. https://www.patternfly.org/components/forms/radio/