### PR TITLE
Revert "Anaconda needs latest pykickstart but image refresh is currently blocked on kernel regression"

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -12,7 +12,7 @@ import sys
 BOTS_DIR = os.path.realpath(f'{__file__}/../../bots')
 sys.path.append(BOTS_DIR)
 
-missing_packages = "fedora-logos udisks2 libudisks2 udisks2-lvm2 udisks2-btrfs udisks2-iscsi python3-kickstart"
+missing_packages = "fedora-logos udisks2 libudisks2 udisks2-lvm2 udisks2-btrfs udisks2-iscsi"
 
 from machine.machine_core import machine_virtual
 


### PR DESCRIPTION
This reverts commit b6702ead655b8290ff766d8949c148b6c1bc0bc1.