### PR TITLE
infra: trigger dependabot workflow for updating node_modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,9 @@ updates:
       timezone: "Europe/Berlin"
     open-pull-requests-limit: 3
     commit-message:
-      prefix: "infra"
+      prefix: "[no-test]"
     labels:
-      - "sanity check required"
+      - "node_modules"
     groups:
       eslint:
         patterns:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Force push node_modules update
         run: |
           # Dependabot prefixes the commit with [no-test] which we don't want to keep in the commit
-          title=$(git show --pretty="%s" -s | sed -E "s/\[no-test\]\W+ //")
+          title=$(git show --pretty="%s" -s | sed -E "s/\[no-test\]\W+ /infra/")
           body=$(git show -s --pretty="%b")
           git commit --amend -m "${title}" -m "${body}" --no-edit node_modules
           eval $(ssh-agent)


### PR DESCRIPTION
The node cache must be handled when updating package.json, which is managed by our custom Dependabot GitHub workflow.
Previously, we weren't setting the [node-modules] label, so the workflow wasn't triggered. This change ensures that the workflow runs as intended.