### PR TITLE
Use process inspection to detect GNOME instead of XDG_CURRENT_DESKTOP

### DIFF
--- a/src/contexts/Common.jsx
+++ b/src/contexts/Common.jsx
@@ -72,8 +72,12 @@ const SystemInfoContextWrapper = ({ children, conf, osRelease }) => {
     const [desktopVariant, setDesktopVariant] = useState();
 
     useEffect(() => {
-        cockpit.spawn(["/bin/sh", "-c", "echo $XDG_CURRENT_DESKTOP"]).then(res => {
-            setDesktopVariant(res.trim());
+        cockpit.spawn(["ps", "-eo", "comm"]).then(res => {
+            if (res.includes("gnome-shell")) {
+                setDesktopVariant("GNOME");
+            } else {
+                setDesktopVariant("UNKNOWN");
+            }
         });
     }, []);
 


### PR DESCRIPTION
Cockpit's spawn environment does not expose XDG_CURRENT_DESKTOP, so desktop detection via that variable was unreliable. This change uses `ps` to check for the presence of `gnome-shell` to infer if GNOME is running. Falls back to "UNKNOWN" otherwise.