### PR TITLE
Revert "tests: unlock root account and start sshd in interactive defaults"

### DIFF
--- a/test/machine_install.py
+++ b/test/machine_install.py
@@ -85,17 +85,7 @@ class VirtInstallMachine(VirtMachine):
 
     def _write_interactive_defaults_ks(self, updates_image, updates_image_edited):
         payload_cached_name, http_payload_port = self._serve_payload()
-        content = f"""
-        liveimg --url="http://10.0.2.2:{http_payload_port}/{payload_cached_name}"
-        %pre
-        # root account is by default locked
-        # See: https://src.fedoraproject.org/rpms/setup/c/7ced36d60b67c9e74f7951123225200597e3d2fa
-        # unlock the root account to allow ssh login
-        sed -i 's/^root:!unprovisioned:/root::/' /etc/shadow
-        # start sshd service
-        systemctl start sshd
-        %end
-        """
+        content = f'liveimg --url="http://10.0.2.2:{http_payload_port}/{payload_cached_name}"'
         defaults_path = "usr/share/anaconda/"
         print("Adding interactive defaults to updates.img")
         with TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
This reverts commit f51078b012384e75ae331f45001565530c573216.

This was fixed in lorax by: https://bodhi.fedoraproject.org/updates/FEDORA-2025-2d0f741832
See: https://bugzilla.redhat.com/show_bug.cgi?id=2364082