### PR TITLE
components: storage: fix unselecting the only available disk

### DIFF
--- a/src/components/storage/InstallationDestination.jsx
+++ b/src/components/storage/InstallationDestination.jsx
@@ -246,12 +246,13 @@ export const InstallationDestination = ({
     const refUsableDisks = useRef();
     const { diskSelection } = useContext(StorageContext);
     const devices = useOriginalDevices();
+    const usableDisksStr = diskSelection.usableDisks.join(",");
 
     debug("DiskSelector: devices: ", JSON.stringify(Object.keys(devices)), ", diskSelection: ", JSON.stringify(diskSelection));
 
     useEffect(() => {
         refUsableDisks.current = false;
-    }, [diskSelection.usableDisks]);
+    }, [usableDisksStr]);
 
     useEffect(() => {
         // Select default disks for the partitioning on component mount

--- a/test/check-storage-basic
+++ b/test/check-storage-basic
@@ -58,6 +58,12 @@ class TestStorageBasic(VirtInstallMachineCase):
             ignore=pixel_tests_ignore,
         )
 
+        # Unselect the only available disk
+        s.select_disks([("vda", False)])
+        s.wait_no_disks()
+        # Check the next buton is disabled if no disks are selected
+        i.check_next_disabled()
+
         # This attaches a disk to the running VM
         # However, since the storage module initialization is long completed
         # the newly added disk, will not be visible in the UI,
@@ -67,6 +73,7 @@ class TestStorageBasic(VirtInstallMachineCase):
         s.rescan_disks(["vda", dev])
 
         # Check that the disk selection persists when moving next and back
+        s.select_disks([("vda", True), (dev, False)])
         s.check_disk_selected("vda", True)
         s.check_disk_selected(dev, False)
         i.next()
@@ -74,7 +81,7 @@ class TestStorageBasic(VirtInstallMachineCase):
         s.check_disk_selected("vda", True)
         s.check_disk_selected(dev, False)
 
-        # Try unselecting the single disk and expect and error
+        # Try unselecting both disks and expect and error
         s.select_disks([("vda", False), (dev, False)])
         s.wait_no_disks()
         # Check the next button is disabled if no disks are selected


### PR DESCRIPTION
Previously, unselecting the only available disk and saving would reselect it automatically. That happened because, Arrays (even with the same content) are new references on every render. Convert the array to string to avoid unwanted re-renders.