### PR TITLE
fix: resolve unnecessary re-renders and hook rule violations in scenario availability

### DIFF
--- a/src/components/storage/InstallationScenario.jsx
+++ b/src/components/storage/InstallationScenario.jsx
@@ -41,7 +41,7 @@ import {
 } from "../../hooks/Storage.jsx";
 
 import { EncryptedDevices } from "./EncryptedDevices.jsx";
-import { scenarios } from "./scenarios/index.js";
+import { scenarios, useScenariosAvailability } from "./scenarios/index.js";
 
 import "./InstallationScenario.scss";
 
@@ -68,11 +68,8 @@ const InstallationScenarioSelector = ({
     const { mountPoints } = useOriginalDeviceTree();
     const selectedDisks = diskSelection.selectedDisks;
     const { storageScenarioId } = useContext(StorageContext);
-    const scenarioAvailability = scenarios.reduce((acc, scenario) => {
-        acc[scenario.id] = scenario.getAvailability();
-        return acc;
-    }, {});
-    const scenarioAvailabilityLoading = scenarios.some(scenario => scenarioAvailability[scenario.id] === undefined);
+    const scenarioAvailability = useScenariosAvailability();
+    const scenarioAvailabilityLoading = scenarioAvailability === undefined;
 
     useEffect(() => {
         let selectedScenarioId = "";

--- a/src/components/storage/scenarios/index.js
+++ b/src/components/storage/scenarios/index.js
@@ -1,8 +1,41 @@
+import { useEffect, useState } from "react";
+
 import { scenarioEraseAll } from "./EraseAll.jsx";
 import { scenarioMountPointMapping } from "./MountPointMapping.jsx";
 import { scenarioReinstallFedora } from "./ReinstallFedora.jsx";
 import { scenarioConfiguredStorage } from "./UseConfiguredStorage.jsx";
 import { scenarioUseFreeSpace } from "./UseFreeSpace.jsx";
+
+export const useScenariosAvailability = () => {
+    const scenarioReinstallFedoraAvailability = scenarioReinstallFedora.getAvailability();
+    const scenarioUseFreeSpaceAvailability = scenarioUseFreeSpace.getAvailability();
+    const scenarioEraseAllAvailability = scenarioEraseAll.getAvailability();
+    const scenarioMountPointMappingAvailability = scenarioMountPointMapping.getAvailability();
+    const scenarioConfiguredStorageAvailability = scenarioConfiguredStorage.getAvailability();
+    const [scenarioAvailability, setScenarioAvailability] = useState();
+
+    useEffect(() => {
+        setScenarioAvailability({
+            [scenarioConfiguredStorage.id]: scenarioConfiguredStorageAvailability,
+            [scenarioEraseAll.id]: scenarioEraseAllAvailability,
+            [scenarioMountPointMapping.id]: scenarioMountPointMappingAvailability,
+            [scenarioReinstallFedora.id]: scenarioReinstallFedoraAvailability,
+            [scenarioUseFreeSpace.id]: scenarioUseFreeSpaceAvailability,
+        });
+    }, [
+        scenarioConfiguredStorageAvailability,
+        scenarioEraseAllAvailability,
+        scenarioMountPointMappingAvailability,
+        scenarioReinstallFedoraAvailability,
+        scenarioUseFreeSpaceAvailability,
+    ]);
+
+    if (Object.values(scenarioAvailability || {}).some(value => value === undefined)) {
+        return undefined;
+    }
+
+    return scenarioAvailability;
+};
 
 export const scenarios = [
     scenarioReinstallFedora,


### PR DESCRIPTION
Extracted hook calls into useScenariosAvailability to ensure React Hooks are invoked at the top level and in a consistent order. This prevents extra renders and avoids breaking the Rules of Hooks.

Resolves: INSTALLER-4202