### PR TITLE
test: avoid test failures because pool has been defined

### DIFF
--- a/test/run
+++ b/test/run
@@ -98,6 +98,15 @@ fi
 # Allow wiki-reporting even if test suite partially failed
 set +e
 
+# Create tmp storage pool to avoid parallel test runs to conflict
+echo "<pool type='dir'>
+  <name>tmp</name>
+  <target>
+    <path>/var/tmp/</path>
+  </target>
+</pool>" > /tmp/storage-pool.xml
+virsh pool-define --file /tmp/storage-pool.xml
+
 export TEST_JOBS TEST_OS
 J=$(($TEST_JOBS/4)); [ $J -ge 1 ] || J=1; TEST_AUDIT_NO_SELINUX=1 test/common/run-tests --test-dir test/ --jobs $J $RUN_OPTS
 exit_code=$?


### PR DESCRIPTION
Avoid errors with the following pattern:

ERROR    Error: --disk /var/tmp/*.qcow2,format=qcow2,target=vda: Could
not define storage pool: operation failed: pool 'tmp' already exists
with uuid *

subprocess.CalledProcessError: Command '['virt-xml', '-c', 'qemu:///session', 'fedora-rawhide-boot-127.0.0.2-2201', '--update', '--add-device', '--disk', '/var/tmp/*.qcow2,format=qcow2,target=vda']' returned non-zero exit status 1.