### PR TITLE
metainfo: Use the correct AppStream ID

### DIFF
--- a/org.cockpit-project.anaconda-webui.metainfo.xml
+++ b/org.cockpit-project.anaconda-webui.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-  <id>org.cockpit_project.starter_kit</id>
+  <id>org.cockpit_project.anaconda_webui</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Anaconda</name>
   <summary>Anaconda installer</summary>


### PR DESCRIPTION
This ensures software centers and Cockpit do not get confused by the template ID named "Anaconda".