### PR TITLE
tests: the Fedora boot entry is not the 2nd entry

### DIFF
--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -271,7 +271,7 @@ class VirtInstallMachineCase(MachineCase):
             distro_name = self.disk_images[0][0].split("-")[0]
             m.execute(f"efibootmgr -c -d /dev/vda -p 15 -L {distro_name} -l '/EFI/{distro_name}/shimx64.efi'")
             # Select the Fedora grub entry for first boot
-            m.execute("efibootmgr -n 0001")
+            m.execute("efibootmgr -n 0002")
 
         self.handleReboot()
 


### PR DESCRIPTION
0000 is bootManagerApp, 0001 is EFI firmware setup.

This will resolve this failure: https://cockpit-logs.us-east-1.linodeobjects.com/pull-887-3ca4dfde-20250623-111827-fedora-rawhide-boot-efi/log.html 

It now looks like this:
![Screen Shot 2025-06-23 at 14 46 09](https://github.com/user-attachments/assets/2e8484d4-9ada-4548-81d1-86f4e4a9c405)
