### PR TITLE
tests: wait for the root enable checkbox to get checked before continuing

### DIFF
--- a/test/helpers/users.py
+++ b/test/helpers/users.py
@@ -102,6 +102,7 @@ class Users(UsersDBus):
     def enable_root_account(self, enable):
         sel = f"#{ACCOUNTS_SCREEN}-root-account-enable-root-account"
         self.browser.set_checked(sel, enable)
+        self.browser.wait_visible(f"{sel}:checked" if enable else f"{sel}:not(:checked)")
 
     def set_valid_root_password(self, valid=True):
         p = Password(self.browser, ROOT_ACCOUNT_ID_PREFIX)


### PR DESCRIPTION

Hopefully will prevent flakes of this kind:
https://cockpit-logs.us-east-1.linodeobjects.com/pull-6432-23afdae5-20250714-070134-fedora-rawhide-boot-anaconda-pr-6432-rhinstaller-anaconda-webui/log.html