### PR TITLE
tests: users: wait for password to be focused before starting typing

### DIFF
--- a/test/helpers/password.py
+++ b/test/helpers/password.py
@@ -27,6 +27,10 @@ class Password():
         self.browser = browser
         self.id_prefix = id_prefix
 
+    def check_pw_focused(self):
+        sel = f"#{self.id_prefix}-password-field"
+        self.browser.wait_visible(f"{sel}:focus")
+
     @log_step(snapshot_before=True)
     def check_pw_rule(self, rule, value):
         sel = f"#{self.id_prefix}-password-rule-{rule}"

--- a/test/helpers/users.py
+++ b/test/helpers/users.py
@@ -104,6 +104,11 @@ class Users(UsersDBus):
         self.browser.set_checked(sel, enable)
         self.browser.wait_visible(f"{sel}:checked" if enable else f"{sel}:not(:checked)")
 
+        if enable:
+            # Wait that the root password field is visible and focused
+            p = Password(self.browser, ROOT_ACCOUNT_ID_PREFIX)
+            p.check_pw_focused()
+
     def set_valid_root_password(self, valid=True):
         p = Password(self.browser, ROOT_ACCOUNT_ID_PREFIX)
         password = "password"

--- a/test/helpers/users.py
+++ b/test/helpers/users.py
@@ -16,6 +16,8 @@
 import os
 import sys
 
+from testlib import Error  # pylint: disable=import-error
+
 HELPERS_DIR = os.path.dirname(__file__)
 sys.path.append(HELPERS_DIR)
 
@@ -101,8 +103,15 @@ class Users(UsersDBus):
     @log_step(snapshot_before=True)
     def enable_root_account(self, enable):
         sel = f"#{ACCOUNTS_SCREEN}-root-account-enable-root-account"
-        self.browser.set_checked(sel, enable)
-        self.browser.wait_visible(f"{sel}:checked" if enable else f"{sel}:not(:checked)")
+        # FIXME:
+        # Tests are sometimes failing to enable the root account for unknown reasons.
+        # Let's be resilient and try to set the checkbox twice.
+        try:
+            self.browser.set_checked(sel, enable)
+            self.browser.wait_visible(f"{sel}:checked" if enable else f"{sel}:not(:checked)")
+        except Error:
+            self.browser.set_checked(sel, enable)
+            self.browser.wait_visible(f"{sel}:checked" if enable else f"{sel}:not(:checked)")
 
         if enable:
             # Wait that the root password field is visible and focused


### PR DESCRIPTION
This commit c66f51f2cf38380a1008a644b3ea7313e6247abd introduces a autofocus logic in the code for the Root Password field, after the user enables root account creation. This was causing some flakiness in the tests which type super fact, as it would regain focus on the first password field, when the test would be already filling the second password field.

Fix this by waiting for the focus before starting typing.