### PR TITLE
Require cockpit-selinux to suppress SELinux warnings in live environment

### DIFF
--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -26,6 +26,7 @@ BuildRequires: systemd-rpm-macros
 Requires: cockpit-storaged
 Requires: cockpit-bridge >= %{cockpitver}
 Requires: cockpit-ws >= %{cockpitver}
+Requires: cockpit-selinux
 Requires: anaconda-core  >= %{anacondacorever}
 # Firefox dependency needs to be specified there as cockpit web-view does not have a hard dependency on Firefox as
 # it can often fall back to a diferent browser. This does not work in the limited installer


### PR DESCRIPTION
Although the live ISO runs with SELinux in permissive mode, Cockpit components used by anaconda-webui (e.g. cockpit-ws, cockpit-bridge) still trigger SELinux AVC warnings.

These warnings clutter logs and even UI by pop up alerts.

This commit adds a dependency on cockpit-selinux, so these accesses are recognized as valid even in permissive mode.