### PR TITLE
systemd: run cockpit-bridge with coproc to fix SELinux denials in Live ISOs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ install: $(DIST_TEST) po/LINGUAS
 	mkdir -p $(DESTDIR)/usr/libexec/anaconda
 	cp webui-desktop $(DESTDIR)/usr/libexec/anaconda
 	cp browser-ext $(DESTDIR)/usr/libexec/anaconda
+	cp src/scripts/cockpit-coproc-wrapper.sh $(DESTDIR)/usr/libexec/anaconda/
 	ln -sTfr $(DESTDIR)/usr/share/pixmaps/fedora-logo-sprite.svg $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)/logo.svg
 	mkdir -p $(DESTDIR)/usr/lib/systemd/system/
 	cp src/systemd/webui-cockpit-ws.service $(DESTDIR)/usr/lib/systemd/system/

--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -74,6 +74,7 @@ exit 0
 %{_datadir}/cockpit/anaconda-webui/index.css.map
 %{_datadir}/cockpit/anaconda-webui/manifest.json
 %{_datadir}/cockpit/anaconda-webui/po.*.js.gz
+%{_libexecdir}/anaconda/cockpit-coproc-wrapper.sh
 %dir %{_datadir}/anaconda/firefox-theme
 %dir %{_datadir}/anaconda/firefox-theme/default
 %dir %{_datadir}/anaconda/firefox-theme/default/chrome

--- a/src/scripts/cockpit-coproc-wrapper.sh
+++ b/src/scripts/cockpit-coproc-wrapper.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu
+
+# This script implements the coproc approach for the systemd service
+# to avoid SELinux denials while keeping the service manageable with systemctl
+WEBUI_ADDRESS=$1
+
+# Start cockpit-bridge in unconfined context via su using coproc
+coproc BRIDGE { cockpit-bridge; }
+
+# Start cockpit-ws connected to the coproc
+exec /usr/libexec/cockpit-ws -p 80 -a "$WEBUI_ADDRESS" --no-tls --local-session=- <&${BRIDGE[0]} >&${BRIDGE[1]}

--- a/src/systemd/webui-cockpit-ws.service
+++ b/src/systemd/webui-cockpit-ws.service
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 EnvironmentFile=/tmp/webui-cockpit-ws.env
 Environment="COCKPIT_SUPERUSER=pkexec"
-ExecStart=/usr/libexec/cockpit-ws -p 80 -a "$WEBUI_ADDRESS" --no-tls --local-session=cockpit-bridge
+ExecStart=/usr/libexec/anaconda/cockpit-coproc-wrapper.sh $WEBUI_ADDRESS
 Restart=on-failure
 RestartSec=5s
 


### PR DESCRIPTION
Fixes SELinux denials from cockpit-bridge when running anaconda-webui in Live ISOs. The issue was that cockpit-ws was running in cockpit_ws_t context instead of unconfined_t, causing permission issues.

Suggested by cockpit maintainer pitti.