### PR TITLE
tests: explicitly invoke mdadm --assemble to trigger known failure on rawhide

### DIFF
--- a/test/helpers/progress.py
+++ b/test/helpers/progress.py
@@ -38,7 +38,10 @@ class Progress():
             tries=timeout / delay
         )
         if self.browser.is_present('#critical-error-bz-report-modal'):
-            raise AssertionError('Error during installation')
+            text = self.browser.text('#critical-error-bz-report-modal-details')
+            raise AssertionError(
+                f"Critical error encountered during installation: {text}"
+            )
 
         self.browser.wait_visible(self._reboot_selector)
 

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -242,6 +242,13 @@ class StorageUtils(StorageDestination):
         udevadm settle
         """, timeout=90)
         self._wait_for_mdraid_clean()
+        # Assemble the mdraid device: do this to early detect mdraid regression
+        # Remove once: https://bugzilla.redhat.com/show_bug.cgi?id=2385871 is fixed
+        self.machine.execute("""
+        set -ex
+        mdadm --assemble --scan
+        udevadm settle
+        """, timeout=30)
 
     def _wait_for_mdraid_clean(self):
         m = self.machine


### PR DESCRIPTION
This triggers the mdadm --assemble failure early in the test when running with recent rawhide kernels where the operation is currently broken.

Doing so ensures that the RAID-related tests fail consistently and can be reliably matched through a naughty in bots, since there is no other stable pattern of failure detection at this point.