### PR TITLE
components: cockpit-storage-integration: fix warning banner not taking full width

### DIFF
--- a/src/components/storage/cockpit-storage-integration/CockpitStorageIntegration.jsx
+++ b/src/components/storage/cockpit-storage-integration/CockpitStorageIntegration.jsx
@@ -33,7 +33,7 @@ import {
     PageSection,
     Tooltip
 } from "@patternfly/react-core";
-import { ArrowLeftIcon, ExclamationTriangleIcon } from "@patternfly/react-icons";
+import { ArrowLeftIcon, ExclamationTriangleIcon, TimesIcon } from "@patternfly/react-icons";
 
 import {
     getDeviceAncestors
@@ -164,7 +164,6 @@ export const CockpitStorageIntegration = ({
               aria-label={_("Configure storage")}
               className={backdropClass + " " + idPrefix + "-modal-page-section"}
               isOpen={isConfirmed}
-              onClose={() => setShowDialog(true)}
               showClose={false}
               variant={ModalVariant.large}>
                 <Banner screenReaderText="Warning banner" status="warning">
@@ -176,6 +175,9 @@ export const CockpitStorageIntegration = ({
                             }
                         </FlexItem>
                     </Flex>
+                    <Button variant="plain" aria-label={_("Close storage editor")} onClick={() => setShowStorage(false)}>
+                        <TimesIcon />
+                    </Button>
                 </Banner>
                 <div className={idPrefix + "-page-section-cockpit-storage"}>
                     <PageSection hasBodyWrapper={false}>

--- a/src/components/storage/cockpit-storage-integration/CockpitStorageIntegration.scss
+++ b/src/components/storage/cockpit-storage-integration/CockpitStorageIntegration.scss
@@ -9,6 +9,12 @@
       /* Provide "breathing room" to make the banner more obvious */
       --pf-v6-c-banner--PaddingBlockStart: var(--pf-t--global--spacer--md);
       --pf-v6-c-banner--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+
+      /* Create flex container to align the 'x' button */
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
     }
 }
 


### PR DESCRIPTION
Possibly when we ported the modals to Patternfly 6 this broke. Fix the button alignment and missing background by using a custom 'Close' button for the modal, to have full control over it.

Resolves: rhbz#2386742