### PR TITLE
tests: ignore timezone in review screen as this is autodetected

### DIFF
--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -36,7 +36,7 @@ from testlib import MachineCase, wait  # pylint: disable=import-error
 from users import Users
 from utils import add_public_key
 
-pixel_tests_ignore = [".logo", "#betanag-icon"]
+pixel_tests_ignore = [".logo", "#betanag-icon", "#anaconda-screen-review-target-system-timezone"]
 
 
 class VirtInstallMachineCase(MachineCase):


### PR DESCRIPTION
And test runners do not always exist in the same data center.

Example failure: https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-6549-a888a48b-20250812-071735-fedora-rawhide-boot-anaconda-pr-6549-rhinstaller-anaconda-webui/TestStorageMountPoints-testMultipleDisks-review-multiple-disks-delta.png