### PR TITLE
Add debugging info to BZ template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /Test*.log*
 /Test*.png
 /Test*.xml
+/VERSION.txt
 /anaconda-webui.spec
 /bots
 /anaconda-webui-*.tar.xz

--- a/build.js
+++ b/build.js
@@ -60,6 +60,7 @@ const context = await esbuild.context({
         ".js": "jsx",
         ".py": "text",
         ".svg": "dataurl",
+        ".txt": "text",
     },
     minify: production,
     nodePaths,
@@ -73,6 +74,7 @@ const context = await esbuild.context({
                 { from: ["./images/qr-code-feedback.svg"], to: ["./qr-code-feedback.svg"] },
                 { from: ["./src/manifest.json"], to: ["./manifest.json"] },
                 { from: ["./src/index.html"], to: ["./index.html"] },
+                { from: ["./VERSION.txt"], to: ["./VERSION.txt"] },
             ]
         }),
         sassPlugin({

--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -74,6 +74,7 @@ exit 0
 %{_datadir}/cockpit/anaconda-webui/index.css.map
 %{_datadir}/cockpit/anaconda-webui/manifest.json
 %{_datadir}/cockpit/anaconda-webui/po.*.js.gz
+%{_datadir}/cockpit/anaconda-webui/VERSION.txt
 %{_libexecdir}/anaconda/cockpit-coproc-wrapper.sh
 %dir %{_datadir}/anaconda/firefox-theme
 %dir %{_datadir}/anaconda/firefox-theme/default

--- a/src/components/Error.jsx
+++ b/src/components/Error.jsx
@@ -41,7 +41,7 @@ import { DisconnectedIcon, ExternalLinkAltIcon } from "@patternfly/react-icons";
 import { createBugzillaEnterBug } from "../helpers/bugzilla.js";
 import { exitGui } from "../helpers/exit.js";
 import { error } from "../helpers/log.js";
-import { getAnacondaVersion } from "../helpers/product.js";
+import { getAnacondaUIVersion, getAnacondaVersion } from "../helpers/product.js";
 
 import { NetworkContext, OsReleaseContext, SystemTypeContext } from "../contexts/Common.jsx";
 
@@ -144,9 +144,12 @@ export const BZReportModal = ({
         getAnacondaVersion().then(setAnacondaVersion);
     }, []);
 
+    const anacondaUIVersion = getAnacondaUIVersion();
+
     const debugInfoArray = [
         ["OS", prettyName],
         ["Anaconda version", anacondaVersion],
+        ["Anaconda UI version", anacondaUIVersion],
     ];
 
     const openBZIssue = (reportURL) => {

--- a/src/components/Error.jsx
+++ b/src/components/Error.jsx
@@ -19,7 +19,7 @@ import cockpit from "cockpit";
 
 import { fmt_to_fragments as fmtToFragments } from "utils";
 
-import React, { cloneElement, useContext, useEffect, useState } from "react";
+import React, { cloneElement, useContext, useEffect } from "react";
 import {
     Alert,
     Button,
@@ -41,9 +41,8 @@ import { DisconnectedIcon, ExternalLinkAltIcon } from "@patternfly/react-icons";
 import { createBugzillaEnterBug } from "../helpers/bugzilla.js";
 import { exitGui } from "../helpers/exit.js";
 import { error } from "../helpers/log.js";
-import { getAnacondaUIVersion, getAnacondaVersion } from "../helpers/product.js";
 
-import { NetworkContext, OsReleaseContext, SystemTypeContext } from "../contexts/Common.jsx";
+import { AppVersionContext, NetworkContext, OsReleaseContext, SystemTypeContext } from "../contexts/Common.jsx";
 
 import "./Error.scss";
 
@@ -137,19 +136,12 @@ export const BZReportModal = ({
         PRETTY_NAME: prettyName,
     } = useContext(OsReleaseContext);
 
-    // anaconda version is also used on AboutModalVersions
-    // should we add it to a context?
-    const [anacondaVersion, setAnacondaVersion] = useState("");
-    useEffect(() => {
-        getAnacondaVersion().then(setAnacondaVersion);
-    }, []);
-
-    const anacondaUIVersion = getAnacondaUIVersion();
+    const appVersion = useContext(AppVersionContext);
 
     const debugInfoArray = [
         ["OS", prettyName],
-        ["Anaconda version", anacondaVersion],
-        ["Anaconda UI version", anacondaUIVersion],
+        ["Anaconda version", appVersion.backend],
+        ["Anaconda UI version", appVersion.webui],
     ];
 
     const openBZIssue = (reportURL) => {

--- a/src/components/Error.jsx
+++ b/src/components/Error.jsx
@@ -93,6 +93,15 @@ const addLogAttachmentCommentToReportURL = (reportURL) => {
     return newUrl.href;
 };
 
+const addOSPrettyNameCommentToReportURL = (reportURL, prettyName) => {
+    const newUrl = new URL(reportURL);
+    const comment = newUrl.searchParams.get("comment") || "";
+    // we don't want to translate this string. It is meant for support engineers / debugging purposes.
+    const sysInfo = cockpit.format(`---[ System & Environment Information ]---\nOS: ${prettyName}`);
+    newUrl.searchParams.set("comment", comment + "\n\n" + sysInfo + "\n\n");
+    return newUrl.href;
+};
+
 export const BZReportModal = ({
     buttons,
     description,
@@ -118,9 +127,14 @@ export const BZReportModal = ({
                 ));
     }, []);
 
+    const {
+        PRETTY_NAME: prettyName,
+    } = useContext(OsReleaseContext);
+
     const openBZIssue = (reportURL) => {
         reportURL = ensureMaximumReportURLLength(reportURL);
         reportURL = addLogAttachmentCommentToReportURL(reportURL);
+        reportURL = addOSPrettyNameCommentToReportURL(reportURL, prettyName);
 
         if (isBootIso) {
             window.open(reportURL);

--- a/src/components/HeaderKebab.jsx
+++ b/src/components/HeaderKebab.jsx
@@ -16,7 +16,7 @@
  */
 import cockpit from "cockpit";
 
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useState } from "react";
 import {
     AboutModal,
     Button,
@@ -37,9 +37,7 @@ import {
     ExternalLinkAltIcon
 } from "@patternfly/react-icons";
 
-import { getAnacondaVersion } from "../helpers/product.js";
-
-import { OsReleaseContext, SystemTypeContext } from "../contexts/Common.jsx";
+import { AppVersionContext, OsReleaseContext, SystemTypeContext } from "../contexts/Common.jsx";
 
 import { UserIssue } from "./Error.jsx";
 import { CockpitStorageIntegration, ModifyStorage } from "./storage/cockpit-storage-integration/CockpitStorageIntegration.jsx";
@@ -49,11 +47,7 @@ import "./HeaderKebab.scss";
 const _ = cockpit.gettext;
 
 const AboutModalVersions = () => {
-    const [anacondaVersion, setAnacondaVersion] = useState("");
-
-    useEffect(() => {
-        getAnacondaVersion().then(content => setAnacondaVersion(content));
-    }, []);
+    const { backend: anacondaVersion } = useContext(AppVersionContext);
 
     return (
         <DescriptionList isHorizontal id="about-modal-versions">

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -27,6 +27,7 @@ import { initialState, reducer, useReducerWithThunk } from "../reducer.js";
 
 import { readConf } from "../helpers/conf.js";
 import { debug } from "../helpers/log.js";
+import { getAnacondaUIVersion, getAnacondaVersion } from "../helpers/product.js";
 
 import { MainContextWrapper } from "../contexts/Common.jsx";
 
@@ -165,6 +166,18 @@ const useAddress = () => {
     return address;
 };
 
+const useAppVersion = () => {
+    const initialState = {
+        webui: getAnacondaUIVersion(),
+    };
+    const [appVersion, setAppVersion] = useState(initialState);
+
+    useEffect(() => {
+        getAnacondaVersion().then(value => setAppVersion(obj => ({ ...obj, backend: value })));
+    }, []);
+    return appVersion;
+};
+
 export const ApplicationWithErrorBoundary = () => {
     const [showStorage, setShowStorage] = useState(false);
     const [state, dispatch] = useReducerWithThunk(reducer, initialState);
@@ -175,13 +188,14 @@ export const ApplicationWithErrorBoundary = () => {
     );
     const conf = useConf({ onCritFail });
     const osRelease = useOsRelease({ onCritFail });
+    const appVersion = useAppVersion();
 
     if (!conf || !osRelease) {
         return <ApplicationLoading />;
     }
 
     return (
-        <MainContextWrapper state={state} osRelease={osRelease} conf={conf}>
+        <MainContextWrapper state={state} osRelease={osRelease} conf={conf} appVersion={appVersion}>
             <Page className="no-masthead-sidebar" data-debug={conf.Anaconda.debug}>
                 <ErrorBoundary
                   backendException={errorBeforeBoundary}

--- a/src/contexts/Common.jsx
+++ b/src/contexts/Common.jsx
@@ -35,6 +35,7 @@ export const UserInterfaceContext = createContext(null);
 export const NetworkContext = createContext(null);
 export const TimezoneContext = createContext(null);
 export const DialogsContext = createContext(null);
+export const AppVersionContext = createContext(null);
 
 export const FormGroupHelpPopover = ({ helpContent }) => {
     return (
@@ -71,7 +72,7 @@ const ModuleContextWrapper = ({ children, state }) => {
     );
 };
 
-const SystemInfoContextWrapper = ({ children, conf, osRelease }) => {
+const SystemInfoContextWrapper = ({ appVersion, children, conf, osRelease }) => {
     const [desktopVariant, setDesktopVariant] = useState();
 
     useEffect(() => {
@@ -93,7 +94,9 @@ const SystemInfoContextWrapper = ({ children, conf, osRelease }) => {
                 <StorageDefaultsContext.Provider value={{ defaultScheme }}>
                     <TargetSystemRootContext.Provider value={conf["Installation Target"].system_root}>
                         <UserInterfaceContext.Provider value={conf["User Interface"]}>
-                            {children}
+                            <AppVersionContext.Provider value={appVersion}>
+                                {children}
+                            </AppVersionContext.Provider>
                         </UserInterfaceContext.Provider>
                     </TargetSystemRootContext.Provider>
                 </StorageDefaultsContext.Provider>
@@ -102,10 +105,10 @@ const SystemInfoContextWrapper = ({ children, conf, osRelease }) => {
     );
 };
 
-export const MainContextWrapper = ({ children, conf, osRelease, state }) => {
+export const MainContextWrapper = ({ appVersion, children, conf, osRelease, state }) => {
     return (
         <ModuleContextWrapper state={state}>
-            <SystemInfoContextWrapper osRelease={osRelease} conf={conf}>
+            <SystemInfoContextWrapper osRelease={osRelease} conf={conf} appVersion={appVersion}>
                 <WithDialogs>
                     {children}
                 </WithDialogs>

--- a/src/helpers/product.js
+++ b/src/helpers/product.js
@@ -16,8 +16,14 @@
  */
 import cockpit from "cockpit";
 
+import VERSION from "../../VERSION.txt";
+
 export const getAnacondaVersion = () => {
     return cockpit
             .spawn(["anaconda", "--version"])
             .then((content) => content.split(" ").slice(-1)[0].replace("\n", ""));
+};
+
+export const getAnacondaUIVersion = () => {
+    return VERSION.trim().replace("\n", "");
 };


### PR DESCRIPTION
Adds os-release PRETTY_NAME, Anaconda version and Anaconda UI version to Bugzilla template. This enhancement improves the context provided in error reports, making it easier to identify the environment in which issues occur.

Also, now that version information is being used in more than one place, the way it is collected/used was refactored to have that cached on a proper Context. This had a side effect on the "about" modal which now loads the version information instantly.

## Screenshots
<img width="1071" height="470" alt="image" src="https://github.com/user-attachments/assets/80bef5be-0c24-48e6-bf4e-ca4010e19805" />

## Screen recordings
### "About" modal before these changes
[before-context.webm](https://github.com/user-attachments/assets/6890a1d0-485e-4096-8a87-05370cd19b97)

### "About" modal after changes
[after-context.webm](https://github.com/user-attachments/assets/c3b11596-f87d-4daa-b941-290b8ae7a0a4)



