### PR TITLE
infra: add matrix strategy to test-compose workflow

### DIFF
--- a/.github/workflows/test-compose.yml
+++ b/.github/workflows/test-compose.yml
@@ -20,9 +20,9 @@ jobs:
       matrix:
         include:
           - name: 'fedora-rawhide'
-            compose_url: 'https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/COMPOSE_ID'
+            latest_compose: 'latest-Fedora-Rawhide'
           - name: 'fedora-43'
-            compose_url: 'https://kojipkgs.fedoraproject.org/compose/branched/latest-Fedora-43/COMPOSE_ID'
+            latest_compose: 'latest-Fedora-43'
       # Skip matrix if specific compose_id is provided
       fail-fast: false
     # Only run matrix when no specific compose_id is provided
@@ -31,11 +31,19 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
+      - name: Get compose ID
+        id: get-compose
+        run: |
+          # Use Python script to determine the correct path for the latest compose
+          LATEST_COMPOSE_URL=$(python3 test/helpers/compose_path.py "${{ matrix.latest_compose }}")
+          COMPOSE_ID=$(curl -s "${LATEST_COMPOSE_URL}/COMPOSE_ID")
+          echo "compose_id=$COMPOSE_ID" >> $GITHUB_OUTPUT
+
       - name: Trigger compose scenario for ${{ matrix.name }}
         run: |
           mkdir -p ~/.config/cockpit-dev
           echo "${{ github.token }}" >> ~/.config/cockpit-dev/github-token
-          export TEST_COMPOSE=$(curl -s ${{ matrix.compose_url }})
+          export TEST_COMPOSE=${{ steps.get-compose.outputs.compose_id }}
           echo "Testing against ${{ matrix.name }} compose: $TEST_COMPOSE"
           if [ "${{ github.event.inputs.staging }}" = "true" ]; then
             make test-compose-staging

--- a/.github/workflows/test-compose.yml
+++ b/.github/workflows/test-compose.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       compose_id:
-        description: 'Compose ID to test'
+        description: 'Compose ID to test (leave empty to test against matrix)'
       staging:
         description: 'Whether to test the staging wiki'
         default: 'false'
@@ -16,19 +16,50 @@ jobs:
     permissions:
       statuses: write
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: 'fedora-rawhide'
+            compose_url: 'https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/COMPOSE_ID'
+          - name: 'fedora-43'
+            compose_url: 'https://kojipkgs.fedoraproject.org/compose/branched/latest-Fedora-43/COMPOSE_ID'
+      # Skip matrix if specific compose_id is provided
+      fail-fast: false
+    # Only run matrix when no specific compose_id is provided
+    if: github.event.inputs.compose_id == '' || github.event.inputs.compose_id == null
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
 
-      - name: Trigger the latest compose scenario
+      - name: Trigger compose scenario for ${{ matrix.name }}
         run: |
           mkdir -p ~/.config/cockpit-dev
           echo "${{ github.token }}" >> ~/.config/cockpit-dev/github-token
-          if [ -z "${{ github.event.inputs.compose_id }}" ]; then
-            export TEST_COMPOSE=$(curl -s https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/COMPOSE_ID)
+          export TEST_COMPOSE=$(curl -s ${{ matrix.compose_url }})
+          echo "Testing against ${{ matrix.name }} compose: $TEST_COMPOSE"
+          if [ "${{ github.event.inputs.staging }}" = "true" ]; then
+            make test-compose-staging
           else
-            export TEST_COMPOSE=${{ github.event.inputs.compose_id }}
+            make test-compose
           fi
+
+  trigger-single:
+    environment: 'fedora-wiki'
+    permissions:
+      statuses: write
+    runs-on: ubuntu-latest
+    # Only run when specific compose_id is provided
+    if: github.event.inputs.compose_id != '' && github.event.inputs.compose_id != null
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Trigger the specified compose scenario
+        run: |
+          mkdir -p ~/.config/cockpit-dev
+          echo "${{ github.token }}" >> ~/.config/cockpit-dev/github-token
+          export TEST_COMPOSE=${{ github.event.inputs.compose_id }}
+          echo "Testing against specified compose: $TEST_COMPOSE"
           if [ "${{ github.event.inputs.staging }}" = "true" ]; then
             make test-compose-staging
           else

--- a/test/download-iso
+++ b/test/download-iso
@@ -12,13 +12,8 @@ if [ -f test/images/"$TEST_COMPOSE".iso ]; then
     exit 0
 fi
 
-# Construct ISO URL from the compose directory
-ISO_FOLDER="https://kojipkgs.fedoraproject.org/compose/${RELEASE}/${TEST_COMPOSE}/compose/Server/x86_64/iso/"
-
-if ! curl -L --silent --fail --output /dev/null --head -- "$ISO_FOLDER"; then
-    echo "Specified compose $TEST_COMPOSE does not exist"
-    exit 1
-fi
+COMPOSE_BASE_URL=$(python3 test/helpers/compose_path.py "$TEST_COMPOSE")
+ISO_FOLDER="${COMPOSE_BASE_URL}/compose/Server/x86_64/iso"
 
 ISO=$(curl -L --silent ${ISO_FOLDER} | grep -oP 'href="\K[^"]+' | grep -E '\.iso' | head -n1 | tr -d '\n')
 URL="$ISO_FOLDER/$ISO"

--- a/test/helpers/compose_path.py
+++ b/test/helpers/compose_path.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+import urllib.error
+import urllib.request
+
+
+def get_compose_url(compose_id):
+    """
+    Determine the correct compose base URL with fallback.
+
+    Args:
+        compose_id (str): The compose ID (e.g., 'Fedora-43-20250819.n.0', 'Fedora-Rawhide-20250819.n.0', 'latest-Fedora-43', 'latest-Fedora-Rawhide')
+
+    Returns:
+        str: The correct compose base URL
+    """
+    # Determine the release path based on compose ID pattern
+    release = "branched"  # Default release path
+    if re.match(r'^(latest-)Fedora-([0-9]+)$', compose_id):
+        # Fedora versioned (e.g., latest-Fedora-43) -> try branched first, then numbered
+        match = re.match(r'.*Fedora-([0-9]+)$', compose_id)
+        version = match.group(1)
+        release = "branched"
+        fallback_release = version
+    elif re.match(r'^(latest-)?Fedora-Rawhide', compose_id):
+        # Rawhide compose (with or without latest-) -> try rawhide first, then branched
+        release = "rawhide"
+
+    # For actual compose IDs, return path with /compose/ (for compose access)
+    primary_url = f"https://kojipkgs.fedoraproject.org/compose/{release}/{compose_id}"
+
+    try:
+        urllib.request.urlopen(primary_url)
+        return primary_url
+    except urllib.error.HTTPError as e:
+        if not fallback_release:
+            raise e
+
+        # Fall back to the other path
+        fallback_url = f"https://kojipkgs.fedoraproject.org/compose/{fallback_release}/{compose_id}/"
+        urllib.request.urlopen(fallback_url)
+        return fallback_url
+
+def main():
+    """Command line interface for the script."""
+    if len(sys.argv) != 2:
+        print("Usage: compose_path.py <compose_id>")
+        print("Returns: The correct compose base URL")
+        sys.exit(1)
+
+    compose_id = sys.argv[1]
+    result = get_compose_url(compose_id)
+    print(result)
+
+if __name__ == "__main__":
+    main()

--- a/test/run
+++ b/test/run
@@ -63,7 +63,8 @@ esac
 # If TEST_COMPOSE is defined checkout the git repo to the corresponding tag
 if [ -n "${TEST_COMPOSE-}" ]; then
     DIRECTORY=$(echo $TEST_OS | cut -d "-" -f2)
-    COMPOSE_A_PACKAGES="https://kojipkgs.fedoraproject.org/compose/$DIRECTORY/$TEST_COMPOSE/compose/Everything/x86_64/os/Packages/a/"
+    COMPOSE_BASE_URL=$(python3 test/helpers/compose_path.py "$TEST_COMPOSE")
+    COMPOSE_A_PACKAGES="${COMPOSE_BASE_URL}compose/Everything/x86_64/os/Packages/a/"
     ANACONDA_WEBUI_TAG=$(curl -s $COMPOSE_A_PACKAGES | grep -oP '>anaconda-webui-[0-9]+' | cut -d "-" -f3)
 
     # FIXME: Checkout only test/helpers directory and test/check-* files to the corresponding tag

--- a/test/vm.install
+++ b/test/vm.install
@@ -11,9 +11,12 @@ import sys
 
 BOTS_DIR = os.path.realpath(f'{__file__}/../../bots')
 sys.path.append(BOTS_DIR)
+TEST_HELPERS_DIR = os.path.realpath(f'{__file__}/../helpers')
+sys.path.append(TEST_HELPERS_DIR)
 
 missing_packages = "fedora-logos udisks2 libudisks2 udisks2-lvm2 udisks2-btrfs udisks2-iscsi"
 
+from compose_path import get_compose_url
 from machine.machine_core import machine_virtual
 
 
@@ -41,8 +44,8 @@ def vm_install(image, compose, verbose, quick):
         if compose:
             machine.execute("sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/*.repo")
 
-            version = image.split("-")[-1]
-            repo_url = f"https://kojipkgs.fedoraproject.org/compose/{version}/{compose}/compose/Everything/x86_64/os/"
+            compose_base_url = get_compose_url(compose)
+            repo_url = f"{compose_base_url}/compose/Everything/x86_64/os/"
             machine.execute(f"dnf -y config-manager addrepo --set=baseurl={repo_url}")
 
         # Pull cockpit dependencies from the image default compose


### PR DESCRIPTION
- Add matrix to test against both rawhide and Fedora 43 when no specific compose_id is provided
- Maintain manual runs with specific compose_id