### PR TITLE
test: fedora-wiki: remove hardcoded release when reporting to Fedora Wiki

### DIFF
--- a/test/fedora-wiki/wiki-report.py
+++ b/test/fedora-wiki/wiki-report.py
@@ -76,7 +76,6 @@ class WikiReport:
                         compose=self.compose,
                         dist="Fedora",
                         env=fedora_testcase['environment'] if 'environment' in fedora_testcase else f"{testcase['arch']} {testcase['firmware']}",
-                        release="42",
                         user="anaconda-bot",
                         section=section,
                         status="pass",


### PR DESCRIPTION
ResTuple can obtain release information from the compose ID.

Tested with manual report:  `test/fedora-wiki/wiki-report.py ./test/report.json`

```
kkoukiou@easy:~/repos/anaconda-webui$ cat ./test/report.json 
{
    "metadata": {
        "compose": "Fedora-43-20250821.n.0",
        "test_env": "qemu-x86_64"
    },
    "tests": [
        {
            "arch": "x86_64",
            "test_name": "TestStorageCockpitIntegration.testBtrfsSubvolumes",
            "firmware": "BIOS",
            "status": "pass",
            "error": null
        }
    ]
}
```
which was indeed reported here: 
https://fedoraproject.org/wiki/Test_Results:Fedora_43_Branched_20250821.n.0_Installation