### PR TITLE
fix: enable scrolling in iframe by setting overflow-y to auto

### DIFF
--- a/src/components/storage/cockpit-storage-integration/CockpitStorageIntegration.jsx
+++ b/src/components/storage/cockpit-storage-integration/CockpitStorageIntegration.jsx
@@ -140,6 +140,9 @@ export const CockpitStorageIntegration = ({
             iframe.contentWindow.addEventListener("error", exception => {
                 onCritFail({ context: _("Storage plugin failed"), isFrontend: true })({ message: exception.error.message, stack: exception.error.stack });
             });
+            // set overflow-y to auto in order to allow scrolling if a menu gets positioned outside
+            // the bounds of the viewport
+            iframe.contentDocument.body.style["overflow-y"] = "auto";
         }
     }, [isIframeMounted, onCritFail]);
 


### PR DESCRIPTION
Allow scrolling within the storage editor when menus get positioned outside of viewport.

Resolves: INSTALLER-4272