### PR TITLE
users: disallow proceeding from users page when neither root or user is configured

### DIFF
--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -71,9 +71,7 @@ const ReviewDescriptionList = ({ children }) => {
 const AccountsDescription = () => {
     const accounts = useContext(UsersContext);
 
-    if (accounts.skipAccountCreation && !accounts.isRootEnabled) {
-        return _("No user or root account has been configured");
-    } else if (accounts.skipAccountCreation && accounts.isRootEnabled) {
+    if (accounts.skipAccountCreation && accounts.isRootEnabled) {
         return _("Root account is enabled, but no user account has been configured");
     } else if (!accounts.skipAccountCreation && !accounts.isRootEnabled) {
         return accounts.fullName ? `${accounts.fullName} (${accounts.userName})` : accounts.userName;

--- a/src/components/users/Accounts.jsx
+++ b/src/components/users/Accounts.jsx
@@ -338,11 +338,25 @@ export const Accounts = ({
 }) => {
     const [isUserValid, setIsUserValid] = useState();
     const [isRootValid, setIsRootValid] = useState();
+    const accounts = useContext(UsersContext);
     const setAccounts = useMemo(() => args => dispatch(setUsersAction(args)), [dispatch]);
 
     useEffect(() => {
-        setIsFormValid(isUserValid && isRootValid);
-    }, [setIsFormValid, isUserValid, isRootValid]);
+        const skipRootCreation = !accounts.isRootEnabled;
+        const skipAccountCreation = accounts.skipAccountCreation;
+
+        setIsFormValid(
+            (skipAccountCreation || isUserValid) &&
+            (skipRootCreation || isRootValid) &&
+            !(skipRootCreation && skipAccountCreation)
+        );
+    }, [
+        accounts.isRootEnabled,
+        accounts.skipAccountCreation,
+        isRootValid,
+        isUserValid,
+        setIsFormValid,
+    ]);
 
     // Display custom footer
     const getFooter = useMemo(() => <CustomFooter />, []);
@@ -376,7 +390,7 @@ const CustomFooter = () => {
 
     return (
         <AnacondaWizardFooter
-          footerHelperText={(!accounts.isRootEnabled && !accounts.userName) ? _("Skipping account creation during installation. It will happen on first boot instead.") : null}
+          footerHelperText={(!accounts.isRootEnabled && accounts.skipAccountCreation) ? _("You have to enable the root account or create a local user account to proceed.") : null}
           onNext={onNext}
         />
     );

--- a/test/check-users
+++ b/test/check-users
@@ -35,7 +35,7 @@ class TestUsers(VirtInstallMachineCase):
             - The root account can be enabled and a root password set
             - The user can skip creating a user account
             - The user can skip enabling the root account
-            - The user can skip both and proceed to the next step
+            - The user can't skip both
         """
         b = self.browser
         i = Installer(b, self.machine)
@@ -82,13 +82,7 @@ class TestUsers(VirtInstallMachineCase):
         i.reach_on_sidebar(i.steps.ACCOUNTS)
         u.enable_user_account(False)
         u.enable_root_account(False)
-        i.next()
-        r.check_account("No user or root account has been configured")
-        assert u.dbus_get_root_locked()
-        assert not u.dbus_get_is_root_password_set()
-        users = u.dbus_get_users()
-        assert "tester" not in users
-
+        i.check_next_disabled()
 
     @staticmethod
     def _test_user_name(user, installer, valid, invalid):


### PR DESCRIPTION
The users need to create an admin user account *or* set a root password, but you they do not have to do both.

Relevant to: rhbz#2379957
Resolves: rhbz#2392205
Resolves: rhbz#2392203