### PR TITLE
fix(timezone): correctly parse timezones with multiple slashes

### DIFF
--- a/src/components/datetime/Timezone.jsx
+++ b/src/components/datetime/Timezone.jsx
@@ -69,9 +69,9 @@ export const TimezoneSection = ({ locale, setSectionValid, setTimezoneLabel }) =
 
     useEffect(() => {
         if (timezone && typeof timezone === "string" && timezone.includes("/")) {
-            const [reg, cty] = timezone.split("/");
+            const [reg, ...cty] = timezone.split("/");
             setRegion(reg);
-            setCity(cty);
+            setCity(cty.join("/"));
         }
     }, [timezone]);
 

--- a/test/check-timezone
+++ b/test/check-timezone
@@ -77,6 +77,8 @@ class TestDateAndTime(VirtInstallMachineCase):
 
         i.open()
         i.reach(i.steps.DATE_TIME)
+        dt.set_auto_date_time(True)
+        dt.dbus_clear_time_sources()
 
         b.click(f"#{i.steps.DATE_TIME}-configure-ntp")
         dt.check_ntp_server_enabled("2.fedora.pool.ntp.org", 0)

--- a/test/check-timezone
+++ b/test/check-timezone
@@ -123,6 +123,12 @@ class TestDateAndTime(VirtInstallMachineCase):
         dt.check_timezone_label("MESZ, UTC+2")
         self.assertEqual(dt.dbus_get_timezone(), "Europe/Prague")
 
+        # Test timezone with multiple cities
+        dt.select_region("America")
+        dt.select_city("Argentina/Buenos_Aires")
+        dt.check_timezone_label("GMT-3, UTC-3")
+        self.assertEqual(dt.dbus_get_timezone(), "America/Argentina/Buenos_Aires")
+
     def testTimezoneAndTimeFormat(self):
         """
         Description:

--- a/test/helpers/timezone.py
+++ b/test/helpers/timezone.py
@@ -144,6 +144,11 @@ class DateTimeDBus():
             {self.TIMEZONE_INTERFACE} Timezone')
         return out.split('"')[1]
 
+    def dbus_clear_time_sources(self):
+        self.machine.execute(f'busctl --address="{self._bus_address}" \
+            set-property {self.TIMEZONE_SERVICE} {self.TIMEZONE_OBJECT_PATH} \
+            {self.TIMEZONE_INTERFACE} TimeSources "aa{{sv}}" {0}')
+
 class DateAndTime(DateTime, Timezone, TimeFormat, DateTimeDBus):
     def __init__(self, browser, machine):
         DateTime.__init__(self, browser, machine)


### PR DESCRIPTION
This should resolve the `RangeError` that is thrown during the installation of Fedora 43 when the time zone contains multiple slashes.

For example, a `RangeError` is thrown when the timezone is: `America/Argentina/Buenos_Aires`.

Example:

```ts
const timezone = 'America/Argentina/Buenos_Aires';

const [reg, cty] = timezone.split('/');
console.log(reg, cty); // output: America Argentina

const [reg, ...cty] = timezone.split('/');
console.log(reg, cty.join('/')); // output: America Argentina/Buenos_Aires
```