### PR TITLE
spec: switch to %autosetup for unpacking and patching

### DIFF
--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -44,7 +44,7 @@ BuildRequires: desktop-file-utils
 Anaconda installer Web interface
 
 %prep
-%setup -q -n %{name}
+%autosetup -p 1 -n %{name}
 
 %build
 # Nothing to build


### PR DESCRIPTION
This simplifies the %prep section by automatically applying all declared patches with the correct -p1 strip level.