### PR TITLE
tests: remove compose from the ResTuple

### DIFF
--- a/test/fedora-wiki/wiki-report.py
+++ b/test/fedora-wiki/wiki-report.py
@@ -37,7 +37,6 @@ class WikiReport:
         self.report_path = report_path
         self.report = self.parse_json_report()
         self.compose_id = self.report["metadata"]["compose"]
-        self.compose = self.compose_id.split("-")[-1]
         self.wiki_hostname = "stg.fedoraproject.org" if staging else "fedoraproject.org"
 
     def get_passed_testcases(self):
@@ -73,7 +72,6 @@ class WikiReport:
                     ResTuple(
                         bot=True,
                         cid=self.compose_id,
-                        compose=self.compose,
                         dist="Fedora",
                         env=fedora_testcase['environment'] if 'environment' in fedora_testcase else f"{testcase['arch']} {testcase['firmware']}",
                         user="anaconda-bot",


### PR DESCRIPTION
Setting `compose='20250910.n.0'` is wrong. It's not breaking anything because wikitcms [1] uses cid if present and ignores any release/milestone/compose values. However, release/milestone/compose and cid are alternative ways to try and identify the thing we're reporting for.

[1] https://pagure.io/fedora-qa/python-wikitcms/blob/main/f/src/wikitcms/wiki.py