### PR TITLE
storage: detect locked LUKS on selected disks including whole-disk LUKS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ ignore_names = [
    "_testBtrfsSubvolumes_partition_disk",
    "_testDiskSelectionLVM_partition_disk",
    "_testDuplicateDeviceNames_partition_disk",
+   "_testEncryptedHomeSecondDisk_partition_disk",
    "_testEncryptedUnlockBTRFSonLUKS_partition_disk",
    "_testEncryptedUnlockLUKSonRAID_partition_disk",
    "_testEncryptedUnlockRAIDonLUKS_partition_disk",

--- a/src/helpers/storage.js
+++ b/src/helpers/storage.js
@@ -18,7 +18,7 @@
 import { checkIfArraysAreEqual } from "./utils.js";
 
 /* Get the list of IDs of all the ancestors of the given device
- * (including the device itself)
+ * (excluding the device itself)
  * @param {Object} deviceData - The device data object
  * @param {string} device - The ID of the device
  * @returns {Array}
@@ -36,7 +36,7 @@ export const getDeviceAncestors = (deviceData, device) => {
 };
 
 /* Get the list of IDs of all the descendants of the given device
- * (including the device itself)
+ * (excluding the device itself)
  * @param {string} device - The ID of the device
  * @param {Object} deviceData - The device data object
  * @returns {Array}
@@ -56,11 +56,9 @@ export const getDeviceChildren = ({ device, deviceData }) => {
  */
 export const getLockedLUKSDevices = (selectedDisks, deviceData) => {
     // check for selected disks and their children devices for locked LUKS devices
-    const relevantDevs = [];
-    selectedDisks.forEach(device => {
-        const children = getDeviceChildren({ device, deviceData });
-        relevantDevs.push(...children);
-    });
+    const relevantDevs = selectedDisks.flatMap(disk => (
+        [disk, ...getDeviceChildren({ device: disk, deviceData })]
+    ));
 
     return Object.keys(deviceData).filter(d => {
         return (

--- a/test/check-storage-mountpoints
+++ b/test/check-storage-mountpoints
@@ -798,5 +798,83 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         r.check_disk_row(dev_win_fed, "/", f"{dev_win_fed}5", "14.0 GB", True, "btrfs", is_encrypted=False)
 
 
+    def _testEncryptedHomeSecondDisk_partition_disk(self):
+        b = self.browser
+        m = self.machine
+        s = Storage(b, m)
+
+        disk1 = "/dev/vda"
+        disk2 = "/dev/vdb"
+        # On disk1: EFI, /boot (ext4), and root (xfs)
+        s.partition_disk(disk1, [("512MiB", "efi"), ("1GiB", "ext4"), ("", "xfs")])
+        # On disk2: whole-disk LUKS with xfs inside (no partition table)
+        m.execute(f"wipefs -a {disk2}")
+        s.create_luks_partition(disk2, "homepass", "encrypted-home", "xfs")
+
+    @run_boot("efi")
+    @disk_images([("", 15), ("", 10)])
+    @nondestructive
+    def testEncryptedHomeSecondDisk(self):
+        """
+        Description:
+            Test encrypted /home reuse on a separate disk via 'Mount point mapping'.
+
+        Expected results:
+            - The 'Unlock' dialog is available and used to unlock the /home disk
+            - The user can assign /boot, /boot/efi, and / on disk1
+            - The user can assign /home to the unlocked encrypted device on disk2
+            - The review screen shows /home as encrypted and mounted (not reformatted)
+
+        References:
+            - https://bugzilla.redhat.com/show_bug.cgi?id=2396646
+        """
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m)
+        s = Storage(b, m)
+        r = Review(b, m)
+
+        dev1 = "vda"
+        dev2 = "vdb"
+
+        i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+        s.select_disks([(dev1, True), (dev2, True)])
+
+        # Unlock the encrypted second disk (home)
+        s.unlock_all_encrypted()
+        s.unlock_device("homepass", [f"{dev2}"], [f"{dev2}"])
+
+        # Proceed to mount point mapping with both disks selected
+        s.select_mountpoint()
+
+        # Assign /, /boot/efi and /boot on disk1
+        s.select_mountpoint_row_device(1, f"{dev1}3")
+        next_idx = 2
+        if self.is_efi:
+            s.select_mountpoint_row_device(next_idx, f"{dev1}1")
+            s.check_mountpoint_row_format_type(next_idx, "EFI System Partition")
+            next_idx += 1
+        s.select_mountpoint_row_device(next_idx, f"{dev1}2")
+        s.check_mountpoint_row_format_type(next_idx, "ext4")
+        next_idx += 1
+
+        # Add and assign /home to the unlocked encrypted device on disk2
+        s.add_mountpoint_row()
+        s.select_mountpoint_row_mountpoint(next_idx, "/home")
+        luks_device = s.get_luks_device_name(f"/dev/{dev2}")
+        s.select_mountpoint_row_device(next_idx, luks_device)
+
+        # Verify review shows /home as encrypted and mounted on disk2
+        i.reach(i.steps.REVIEW)
+        r.check_disk(dev1, "16.1 GB vda (Virtio Block Device)")
+        r.check_disk_row(dev1, "/boot/efi", f"{dev1}1", "537 MB", False, "efi")
+        r.check_disk_row(dev1, "/boot", f"{dev1}2", "1.07 GB", False, "ext4")
+        r.check_disk_row(dev1, "/", f"{dev1}3", "14.5", True, "xfs")
+
+        r.check_disk(dev2, "10.7 GB vdb (Virtio Block Device)")
+        r.check_disk_row(dev2, "/home", "", "10.7", False, "xfs", is_encrypted=True, action="mount")
+
+
 if __name__ == '__main__':
     test_main()

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -257,6 +257,10 @@ class StorageUtils(StorageDestination):
         done
         """, timeout=30)
 
+    def get_luks_device_name(self, device):
+        ret = self.machine.execute(f'cryptsetup luksUUID {device}')
+        return f"luks-{ret.strip()}"
+
     def create_luks_partition(self, device, passphrase, luks_name, fsformat="", close_luks=True):
         self.machine.execute(f"""
         set -ex


### PR DESCRIPTION
The disks were not detected as LUKS encrypted because getLockedLUKSDevices was checking only child devices, not disks.

Also add test scenario for mount-point-mapping unlock flow for /home on encrypted second disk (whole disk).

Finally fix the comments on the getDeviceAncestors & getDeviceChildren to reflect that they are not returning the device itself in the returned list. This was probably an older behavior.

Resolves: rhbz#2396646