### PR TITLE
mount point mapping: keep menu within wizard scroll context

### DIFF
--- a/src/components/storage/mount-point-mapping/MountPointMapping.jsx
+++ b/src/components/storage/mount-point-mapping/MountPointMapping.jsx
@@ -326,7 +326,6 @@ export const DeviceColumnSelect = ({
 
     return (
         <Select
-          menuAppendTo="inline"
           isGrouped={Object.keys(optionGroups).length > 1}
           isOpen={isOpen}
           selected={device}
@@ -340,6 +339,7 @@ export const DeviceColumnSelect = ({
               handleRequestChange({ deviceSpec: "", mountPoint: request["mount-point"], requestIndex });
               setIsOpen(false);
           }}
+          popperProps={{ appendTo: "inline" }}
           shouldFocusToggleOnSelect
           toggle={toggleRef => (
               <MenuToggle


### PR DESCRIPTION
PatternFly Select is placed to document.body (default), causing the menu to be cut off and unscrollable, as document.body has scrolling disabled. Switching to appendTo="inline" mounts the menu next to the trigger, so it inherits a scrollable container and displays the menu correctly.

Resolves: rhbz#2397098

Before:
<img width="1339" height="827" alt="Screen Shot 2025-09-23 at 09 25 23" src="https://github.com/user-attachments/assets/d4cfe205-c3fb-4051-8ae9-489cac814157" />


After:
<img width="1339" height="827" alt="Screen Shot 2025-09-23 at 09 29 48" src="https://github.com/user-attachments/assets/b3083adf-2b6c-476c-828a-0f628c61181f" />
