### PR TITLE
infra: test-compose: install missing wikitcms dependency

### DIFF
--- a/.github/workflows/test-compose.yml
+++ b/.github/workflows/test-compose.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
+      - name: Install wikitcms
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip
+          sudo pip3 install wikitcms
+
       - name: Get current event compose ID
         id: get-compose
         run: |


### PR DESCRIPTION
Tested at my fork: https://github.com/KKoukiou/anaconda-webui/actions/runs/17971589561/job/51115292602 