### PR TITLE
tests: there is not need to ignore icons any more

### DIFF
--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -37,7 +37,7 @@ from timezone import DateAndTime
 from users import Users
 from utils import add_public_key
 
-pixel_tests_ignore = [".logo", "#betanag-icon", "#anaconda-screen-review-target-system-timezone"]
+pixel_tests_ignore = ["#anaconda-screen-review-target-system-timezone"]
 
 
 class VirtInstallMachineCase(MachineCase):

--- a/test/check-progress
+++ b/test/check-progress
@@ -68,7 +68,6 @@ class TestInstallationProgress(VirtInstallMachineCase):
         b.assert_pixels(
             "#app",
             "installation-progress-complete",
-            ignore=[".logo", "#betanag-icon"],
         )
 
         # Check that at this stage 'Modify Storage' is not available


### PR DESCRIPTION
Since 5ab1a92cd0b328d0376875fef58698c4cbab8e76 icons are now rendered stable for pixel testing.