### PR TITLE
tests: support new payload consumed from bots repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,10 @@ prepare-test-deps: bots test/common test/reference payload images
 .PHONY: payload
 payload: bots
 	bots/image-download $(PAYLOAD)
+	@echo "Unpacking $(PAYLOAD) to tmp for local serving"
+	@rm -rf tmp/$(PAYLOAD) && mkdir -p tmp/$(PAYLOAD)
+	@tar -C tmp/$(PAYLOAD) -xzf bots/images/$(PAYLOAD)
+	@echo "Payload unpacked into tmp/$(PAYLOAD)"
 
 .PHONY: images
 images: bots


### PR DESCRIPTION
Unpack the combined payload artifact from bots into tmp/<payload> during ‘make payload’.

Serve that directory locally in tests and point Anaconda to it:
- liveimg: use http://10.0.2.2:<port>/liveimg.tar.gz

For future we can now also consume dnf paylaod as follows:
- dnf: use repo baseurl http://10.0.2.2:<port>/repo/

Note: This is part of: https://github.com/rhinstaller/anaconda-webui/pull/1023 