### PR TITLE
keyboard: in Gnome spawn Gnome keyboard settings in storage configuration screen

### DIFF
--- a/src/components/storage/storage-configuration/DiskEncryption.jsx
+++ b/src/components/storage/storage-configuration/DiskEncryption.jsx
@@ -92,6 +92,7 @@ export const DiskEncryption = ({ dispatch, setIsFormValid }) => {
                     ? (
                         <Keyboard
                           idPrefix={idPrefix}
+                          isGnome={isGnome}
                           setIsFormValid={setIsFormValid}
                         />
                     )


### PR DESCRIPTION
The previous selector that was displayed in the disk enctryption screen is using APIs [1] which is not supported by Gnome [2].

[1] SetCompositorLayouts, XLayouts are based on localed
[2] https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/7761