### PR TITLE
storage: installation-method: the screen id is 'anaconda-screen-method'

### DIFF
--- a/src/components/storage/installation-method/InstallationMethod.jsx
+++ b/src/components/storage/installation-method/InstallationMethod.jsx
@@ -43,7 +43,7 @@ import { InstallationScenario } from "./InstallationScenario.jsx";
 import { ReclaimSpaceModal } from "./ReclaimSpaceModal.jsx";
 
 const _ = cockpit.gettext;
-const SCREEN_ID = "anaconda-screen-installation-method";
+const SCREEN_ID = "anaconda-screen-method";
 
 export const InstallationMethod = ({
     dispatch,


### PR DESCRIPTION
The mis-spelled page ID was causing the page notifications from the installation method page to not be shown in the UI, as the step id for the notification was incorrectly set.