### PR TITLE
Change default boot mode to UEFI for tests

### DIFF
--- a/test/README.rst
+++ b/test/README.rst
@@ -235,7 +235,7 @@ You can set these environment variables to configure the test suite::
     TEST_FIRMWARE  The firmware to run the tests against. Currently supported values:
                      "bios"
                      "efi"
-                  "bios" is the default.
+                  "efi" is the default.
 
 Debugging tests
 ---------------

--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -34,8 +34,8 @@ INSTALLER_VM_MEMORY_MB = 4096
 
 class VirtInstallMachineCase(MachineCase):
     # The boot modes in which the test should run
-    boot_modes = ["bios"]
-    is_efi = os.environ.get("TEST_FIRMWARE", "bios") == "efi"
+    boot_modes = ["efi"]
+    is_efi = os.environ.get("TEST_FIRMWARE", "efi") == "efi"
     report_to_wiki = os.path.exists(os.path.join(TEST_DIR, "report.json"))
     MachineCase.machine_class = VirtInstallMachine
     report_file = os.path.join(TEST_DIR, "report.json")
@@ -67,7 +67,7 @@ class VirtInstallMachineCase(MachineCase):
 
     def setUp(self):
         method = getattr(self, self._testMethodName)
-        boot_modes = getattr(method, "boot_modes", ["bios"])
+        boot_modes = getattr(method, "boot_modes", ["efi"])
         self.run_on_vm_setups = getattr(method, "run_on_vm_setups", [""])
         self.disk_images = getattr(method, "disk_images", [("", 15)])
 
@@ -337,7 +337,7 @@ def run_boot(*modes):
     The VirtMachine has self.is_efi = True/False set.
     We need to skip the test if self.is_efi is True but 'efi' is not in the modes list.
 
-    The absence of the decorator is equivalent to run_boot("bios").
+    The absence of the decorator is equivalent to run_boot("efi").
 
     :param modes: Boot modes in which the test should run (e.g., "bios", "efi").
     """

--- a/test/check-kickstart-automated
+++ b/test/check-kickstart-automated
@@ -7,7 +7,7 @@ from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, pixel_te
 from installer import Installer
 from payload_dnf import PayloadDNF
 from review import Review
-from storage import Storage
+from storage import EFI_PARTITION_DEFAULT_SIZE_MB, Storage
 from testlib import test_main  # pylint: disable=import-error
 from timezone import DateAndTime
 from users import Users, override_user_interface_conf_keys
@@ -87,7 +87,7 @@ class TestKickstartAutomated(VirtInstallMachineCase):
         r.check_storage_config("Use configured storage")
         dev1 = "vda"
         r.check_disk(dev1, "16.1 GB vda (Virtio Block Device)")
-        r.check_disk_row(dev1, "/boot/efi", "vda1", "524 MB", True, "efi")
+        r.check_disk_row(dev1, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, True, "efi")
         r.check_disk_row(dev1, "/", "vda5", "11.3 GB", True, "xfs")
         r.check_disk_row(dev1, "/boot", "vda2", "1.07 GB", True, "xfs")
         r.check_disk_row(dev1, "/home", "vda3", "2.15 GB", True, "xfs")

--- a/test/check-kickstart-automated
+++ b/test/check-kickstart-automated
@@ -87,8 +87,8 @@ class TestKickstartAutomated(VirtInstallMachineCase):
         r.check_storage_config("Use configured storage")
         dev1 = "vda"
         r.check_disk(dev1, "16.1 GB vda (Virtio Block Device)")
-        r.check_disk_row(dev1, "", "vda1", "1.05 MB", True, "biosboot")
-        r.check_disk_row(dev1, "/", "vda5", "11.8 GB", True, "xfs")
+        r.check_disk_row(dev1, "/boot/efi", "vda1", "524 MB", True, "efi")
+        r.check_disk_row(dev1, "/", "vda5", "11.3 GB", True, "xfs")
         r.check_disk_row(dev1, "/boot", "vda2", "1.07 GB", True, "xfs")
         r.check_disk_row(dev1, "/home", "vda3", "2.15 GB", True, "xfs")
         r.check_disk_row(dev1, "swap", "vda4", "1.07 GB", True, "swap")

--- a/test/check-review
+++ b/test/check-review
@@ -53,7 +53,7 @@ class TestReview(VirtInstallMachineCase):
         # check selected disks are shown
         r.check_disk("vda", "16.1 GB vda (Virtio Block Device)")
         r.check_disk_row("vda", "/boot", "vda2", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs")
-        r.check_disk_row("vda", "/", "vda3, LVM", "14.0 GB", True, "xfs")
+        r.check_disk_row("vda", "/", "vda3, LVM", "13.3 GB", True, "xfs")
 
         # check storage configuration
         r.check_storage_config("Use entire disk")
@@ -80,9 +80,9 @@ class TestReview(VirtInstallMachineCase):
 
         # check selected disks are shown
         r.check_disk("vda", "16.1 GB vda (Virtio Block Device)")
-        r.check_disk_row("vda", "",    "vda1", "1.05 MB", True, "biosboot")
+        r.check_disk_row("vda", "/boot/efi", "vda1", "629 MB", True, "efi", is_encrypted=False)
         r.check_disk_row("vda", "/boot", "vda2", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
-        r.check_disk_row("vda", "/", "vda3, LVM", "13.9 GB", True, "xfs", is_encrypted=True)
+        r.check_disk_row("vda", "/", "vda3, LVM", "13.3 GB", True, "xfs", is_encrypted=True)
 
         # move the mouse away to avoid highlighting any UI element (pixel ref does not expect that)
         b.mouse("#app", "mouseenter")

--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -6,7 +6,7 @@
 from anacondalib import VirtInstallMachineCase, disk_images, pixel_tests_ignore, run_boot
 from installer import Installer
 from review import Review
-from storage import Storage
+from storage import EFI_PARTITION_DEFAULT_SIZE_MB, Storage
 from storagelib import StorageCase  # pylint: disable=import-error
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 from utils import pretend_live_workstation_iso
@@ -184,7 +184,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         def checkStorageReview(prefix=""):
             disk = "vda"
             r.check_disk(disk, "16.1 GB vda (Virtio Block Device)", prefix=prefix)
-            r.check_disk_row(disk, "/boot/efi", "vda1", "524 MB", False, "efi", prefix=prefix)
+            r.check_disk_row(disk, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False, "efi", prefix=prefix)
             r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False, prefix=prefix)
             r.check_disk_row(disk, "/", "vda3, LVM", "6.01 GB", False, prefix=prefix)
             r.check_disk_row(disk, "/home", "vda3, LVM", "8.12 GB", False, prefix=prefix)
@@ -464,7 +464,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         dev = "vda"
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/boot/efi", "vda1", "524 MB", False)
+        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False)
         r.check_disk_row(dev, "/", "vda3", "14.5 GB", False)
 
@@ -523,7 +523,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         dev = "vda"
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/boot/efi", "vda1", "524 MB", False)
+        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False)
         r.check_disk_row(dev, "/", "vda3", "14.5 GB", False)
         r.check_disk_row(dev, "/home", "vda3", "14.5 GB", False)
@@ -581,7 +581,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         dev = "vda"
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/boot/efi", "vda1", "524 MB", False)
+        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "ext4")
         r.check_disk_row(dev, "/", "vda3", "14.5 GB", True, "btrfs")
         r.check_disk_row(dev, "/home", "vda3", "14.5 GB", False)

--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -31,10 +31,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         self.confirm()
 
         self.click_dropdown(self.card_row("Storage", 2), "Create partition")
-        if self.is_efi:
-            self.dialog({"size": 100, "type": "efi", "mount_point": "/boot/efi"})
-        else:
-            self.dialog({"size": 1, "type": "biosboot"})
+        self.dialog({"size": 524, "type": "efi", "mount_point": "/boot/efi"})
 
         self.click_dropdown(self.card_row("Storage", 3), "Create partition")
         self.dialog({"size": 1070, "type": "ext4", "mount_point": "/boot"})
@@ -105,7 +102,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         i.reach(i.steps.REVIEW)
 
-        r.check_disk_row(dev, "/", "vda3", "15.0 GB", False, None, True)
+        r.check_disk_row(dev, "/", "vda3", "14.5 GB", False, None, True)
 
         # Exit the cockpit-storage iframe
         i.reach_on_sidebar(i.steps.INSTALLATION_METHOD)
@@ -160,7 +157,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         browser.click(self.card_parent_link())
 
         browser.click(self.card_button("LVM2 logical volumes", "Create new logical volume"))
-        self.dialog({"name": "swap", "size": 898})
+        self.dialog({"name": "swap", "size": 377})
         self.click_card_row("LVM2 logical volumes", 3)
         self.click_card_dropdown("Unformatted data", "Format")
         self.dialog({"type": "swap"})
@@ -187,11 +184,11 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         def checkStorageReview(prefix=""):
             disk = "vda"
             r.check_disk(disk, "16.1 GB vda (Virtio Block Device)", prefix=prefix)
-            r.check_disk_row(disk, "", "vda1", "1.05 MB", action="biosboot", prefix=prefix)
+            r.check_disk_row(disk, "/boot/efi", "vda1", "524 MB", False, "efi", prefix=prefix)
             r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False, prefix=prefix)
             r.check_disk_row(disk, "/", "vda3, LVM", "6.01 GB", False, prefix=prefix)
             r.check_disk_row(disk, "/home", "vda3, LVM", "8.12 GB", False, prefix=prefix)
-            r.check_disk_row(disk, "swap", "vda3, LVM", "898 MB", False, prefix=prefix)
+            r.check_disk_row(disk, "swap", "vda3, LVM", "377 MB", False, prefix=prefix)
 
         s.return_to_installation()
 
@@ -230,7 +227,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         self.confirm()
 
         self.click_dropdown(self.card_row("Storage", 2), "Create partition")
-        self.dialog({"size": 1, "type": "biosboot"})
+        self.dialog({"size": 100, "type": "efi", "mount_point": "/boot/efi"})
 
         self.click_dropdown(self.card_row("Storage", 3), "Create partition")
         self.dialog({"size": 1070, "type": "ext4", "mount_point": "/boot"})
@@ -242,8 +239,9 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         def checkStorageReview(prefix=""):
             r.check_disk(dev, "16.1 GB vda (Virtio Block Device)", prefix=prefix)
+            r.check_disk_row(dev, "/boot/efi", "vda1", "99.6 MB", False, "efi", prefix=prefix)
             r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False, prefix=prefix)
-            r.check_disk_row(dev, "/", "vda3", "15.0 GB", False, prefix=prefix)
+            r.check_disk_row(dev, "/", "vda3", "14.9 GB", False, prefix=prefix)
 
         s.return_to_installation()
         checkStorageReview(prefix="#cockpit-storage-integration-check-storage-dialog")
@@ -254,6 +252,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         # Check fstab
         fstab = m.execute("cat /etc/fstab")
+        self.assertTrue("/mnt/sysroot/boot/efi auto noauto 0 0" in fstab)
         self.assertTrue("/mnt/sysroot/boot auto noauto 0 0" in fstab)
         self.assertTrue("/mnt/sysroot auto noauto 0 0" in fstab)
 
@@ -322,7 +321,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         self.confirm()
 
         self.click_dropdown(self.card_row("Storage", 2), "Create partition")
-        self.dialog({"size": 1, "type": "biosboot"})
+        self.dialog({"size": 100, "type": "efi", "mount_point": "/boot/efi"})
 
         self.click_dropdown(self.card_row("Storage", 3), "Create partition")
         self.dialog({"size": 1000, "type": "ext4", "mount_point": "/boot"})
@@ -428,7 +427,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         i.check_next_disabled()
 
-    @run_boot("efi")
     def testBtrfsTopLevelVolume(self):
         """
         Description:
@@ -466,9 +464,9 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         dev = "vda"
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/boot/efi", "vda1", "99.6 MB", False)
+        r.check_disk_row(dev, "/boot/efi", "vda1", "524 MB", False)
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False)
-        r.check_disk_row(dev, "/", "vda3", "14.9 GB", False)
+        r.check_disk_row(dev, "/", "vda3", "14.5 GB", False)
 
         # Check fstab
         fstab = m.execute("cat /etc/fstab")
@@ -525,12 +523,14 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         dev = "vda"
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
+        r.check_disk_row(dev, "/boot/efi", "vda1", "524 MB", False)
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False)
-        r.check_disk_row(dev, "/", "vda3", "15.0 GB", False)
-        r.check_disk_row(dev, "/home", "vda3", "15.0 GB", False)
+        r.check_disk_row(dev, "/", "vda3", "14.5 GB", False)
+        r.check_disk_row(dev, "/home", "vda3", "14.5 GB", False)
 
         # Check fstab
         fstab = m.execute("cat /etc/fstab")
+        self.assertTrue("/mnt/sysroot/boot/efi auto noauto 0 0" in fstab)
         self.assertTrue("/mnt/sysroot/boot auto noauto 0 0" in fstab)
         self.assertTrue("/mnt/sysroot btrfs noauto,subvol=root 0 0" in fstab)
         self.assertTrue("/mnt/sysroot/home btrfs noauto,subvol=home 0 0" in fstab)
@@ -561,17 +561,18 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         i.next(next_page=i.steps.CUSTOM_MOUNT_POINT)
 
         s.check_mountpoint_row(1, "/", "root", False, "btrfs")
-        s.check_mountpoint_row(2, "/boot", "vda2", False, "ext4")
-        s.check_mountpoint_row(3, "/home", "home", False, "btrfs")
+        s.check_mountpoint_row(2, "/boot/efi", "vda1", False, "EFI System Partition")
+        s.check_mountpoint_row(3, "/boot", "vda2", False, "ext4")
+        s.check_mountpoint_row(4, "/home", "home", False, "btrfs")
 
         s.select_mountpoint_row_reformat(1)
-        s.select_mountpoint_row_reformat(2)
-        s.select_mountpoint_row_reformat(3, False)
+        s.select_mountpoint_row_reformat(3)
+        s.select_mountpoint_row_reformat(4, False)
 
-        # Root should be preselected to reformat
         s.check_mountpoint_row(1, "/", "root", True, "btrfs")
-        s.check_mountpoint_row(2, "/boot", "vda2", True, "ext4")
-        s.check_mountpoint_row(3, "/home", "home", False, "btrfs")
+        s.check_mountpoint_row(2, "/boot/efi", "vda1", False, "EFI System Partition")
+        s.check_mountpoint_row(3, "/boot", "vda2", True, "ext4")
+        s.check_mountpoint_row(4, "/home", "home", False, "btrfs")
 
         i.next(should_fail=True)
         i.reach(i.steps.REVIEW)
@@ -580,12 +581,14 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         dev = "vda"
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
+        r.check_disk_row(dev, "/boot/efi", "vda1", "524 MB", False)
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "ext4")
-        r.check_disk_row(dev, "/", "vda3", "15.0 GB", True, "btrfs")
-        r.check_disk_row(dev, "/home", "vda3", "15.0 GB", False)
+        r.check_disk_row(dev, "/", "vda3", "14.5 GB", True, "btrfs")
+        r.check_disk_row(dev, "/home", "vda3", "14.5 GB", False)
 
         # Check fstab
         fstab = m.execute("cat /etc/fstab")
+        self.assertTrue("/mnt/sysroot/boot/efi auto noauto 0 0" in fstab)
         self.assertTrue("/mnt/sysroot/boot auto noauto 0 0" in fstab)
         self.assertTrue("/mnt/sysroot btrfs noauto,subvol=root 0 0" in fstab)
         self.assertTrue("/mnt/sysroot/home btrfs noauto,subvol=home 0 0" in fstab)
@@ -615,12 +618,12 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         s.enter_cockpit_storage()
 
-        # Create BIOS and boot partitions on vda
+        # Create ESP and boot partitions on vda
         self.click_dropdown(self.card_row("Storage", 1), "Create partition table")
         self.confirm()
 
         self.click_dropdown(self.card_row("Storage", 2), "Create partition")
-        self.dialog({"size": 1, "type": "biosboot"})
+        self.dialog({"size": 100, "type": "efi", "mount_point": "/boot/efi"})
 
         self.click_dropdown(self.card_row("Storage", 3), "Create partition")
         self.dialog({"size": 1070, "type": "ext4", "mount_point": "/boot"})
@@ -691,7 +694,8 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
 
-        # Create biosboot, /boot and / partitions on the RAID device
+        # Create bootloader and /boot partitions on vda
+        # Create ESP, /boot and / partitions on the RAID device
         self.click_dropdown(self.card_row("Storage", 4), "Create partition table")
         self.dialog({"type": "gpt"})
         self.click_dropdown(self.card_row("Storage", 5), "Create partition")
@@ -849,7 +853,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         self.confirm()
 
         self.click_dropdown(self.card_row("Storage", 2), "Create partition")
-        self.dialog({"size": 1, "type": "biosboot"})
+        self.dialog({"size": 100, "type": "efi", "mount_point": "/boot/efi"})
 
         self.click_dropdown(self.card_row("Storage", 3), "Create partition")
         self.dialog({"size": 1070, "type": "ext4", "mount_point": "/boot"})
@@ -869,14 +873,16 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         # verify review screen
         dev = "vda"
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
+        r.check_disk_row(dev, "/boot/efi", "vda1", "99.6 MB", False)
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False)
-        r.check_disk_row(dev, "/", "vda3", "15.0 GB", False)
+        r.check_disk_row(dev, "/", "vda3", "14.9 GB", False)
         dev = "vdb"
         r.check_disk(dev, "16.1 GB vdb (Virtio Block Device)")
         r.check_disk_row(dev, "/home", "", "16.1 GB", False)
 
         # Check fstab
         fstab = m.execute("cat /etc/fstab")
+        self.assertTrue("/mnt/sysroot/boot/efi auto noauto 0 0" in fstab)
         self.assertTrue("/mnt/sysroot/boot auto noauto 0 0" in fstab)
         self.assertTrue("/mnt/sysroot/home auto noauto 0 0" in fstab)
         self.assertTrue("/mnt/sysroot auto noauto 0 0" in fstab)
@@ -886,12 +892,15 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         s.select_mountpoint([("vda", True), ("vdb", True)])
 
         s.select_mountpoint_row_device(1, "vda3")
-        s.select_mountpoint_row_device(2, "vda2")
-
+        s.select_mountpoint_row_device(2, "vda1")
+        s.select_mountpoint_row_device(3, "vda2")
         s.add_mountpoint_row()
-        s.select_mountpoint_row_device(3, "vdb")
-        s.select_mountpoint_row_mountpoint(3, "/home")
+        s.select_mountpoint_row_device(4, "vdb")
+        s.select_mountpoint_row_mountpoint(4, "/home")
 
+    # https://fedoraproject.org/wiki/Changes/Anaconda_Drop_Support_UEFI_on_MBR
+    # Fedora installer has phased out support for booting in UEFI mode on MBR-partitioned disks.
+    @run_boot("bios")
     def testMBRParttable(self):
         """
         Description:

--- a/test/check-storage-cockpit-e2e
+++ b/test/check-storage-cockpit-e2e
@@ -34,7 +34,7 @@ class TestStorageCockpitIntegration_E2E(VirtInstallMachineCase, StorageCase):
         Description:
             Test scenario with three disks:
 
-            - 'biosboot' and '/boot' are on 'vda'.
+            - ESP and '/boot' are on 'vda'.
             - A RAID 0 array is created using partitions on 'vdb1' and 'vdc1'.
             - The root filesystem ('/') is placed on the RAID 0 device.
 
@@ -55,7 +55,7 @@ class TestStorageCockpitIntegration_E2E(VirtInstallMachineCase, StorageCase):
 
         s.enter_cockpit_storage()
 
-        # Create BIOS and boot partitions on vda
+        # Create ESP and /boot partitions on vda
         self.cockpitCreateBootloaderPartitions()
 
         self.click_dropdown(self.card_row("Storage", 4), "Create partition")
@@ -97,7 +97,7 @@ class TestStorageCockpitIntegration_E2E(VirtInstallMachineCase, StorageCase):
             with b.wait_timeout(30):
                 for disk in ("vda", "vdb", "vdc"):
                     r.check_disk(disk, f"16.1 GB {disk} (Virtio Block Device)")
-                    r.check_disk_row(disk, "/", "vda3, vdc1, vdb1, RAID", "47.2 GB", False, prefix=prefix)
+                    r.check_disk_row(disk, "/", "vda3, vdc1, vdb1, RAID", "47.1 GB", False, prefix=prefix)
 
         # verify review screen
         checkStorageReview()
@@ -121,7 +121,7 @@ class TestStorageCockpitIntegration_E2E(VirtInstallMachineCase, StorageCase):
 
         raid_root = next(part for part in vda3["children"] if part["type"] == "raid0")
         self.assertEqual(raid_root["mountpoints"], ["/"])
-        self.assertEqual(raid_root["size"], "44G")
+        self.assertEqual(raid_root["size"], "43.9G")
 
     @disk_images([("", 15), ("", 15), ("", 15)])
     @run_boot("bios", "efi")
@@ -131,7 +131,7 @@ class TestStorageCockpitIntegration_E2E(VirtInstallMachineCase, StorageCase):
         Description:
             Test scenario with three disks:
 
-            - 'biosboot' and '/boot' are on 'vda'.
+            - ESP or BIOS boot and '/boot' are on 'vda'.
             - A RAID 0 array is created using 'vdb' and 'vdc'.
             - The root filesystem ('/') is placed on the RAID 0 device.
 
@@ -160,8 +160,16 @@ class TestStorageCockpitIntegration_E2E(VirtInstallMachineCase, StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
 
-        # Create biosboot and /boot partitions on vda
-        self.cockpitCreateBootloaderPartitions()
+        # Create bootloader and /boot partitions on vda
+        if self.is_efi:
+            self.cockpitCreateBootloaderPartitions()
+        else:
+            self.click_dropdown(self.card_row("Storage", 1), "Create partition table")
+            self.confirm()
+            self.click_dropdown(self.card_row("Storage", 2), "Create partition")
+            self.dialog({"size": 1, "type": "biosboot"})
+            self.click_dropdown(self.card_row("Storage", 3), "Create partition")
+            self.dialog({"size": 1070, "type": "ext4", "mount_point": "/boot"})
 
         # Create / partition on the RAID device
         self.click_dropdown(self.card_row("Storage", 7), "Create partition table")
@@ -173,6 +181,8 @@ class TestStorageCockpitIntegration_E2E(VirtInstallMachineCase, StorageCase):
             with b.wait_timeout(30):
                 disk = "vda"
                 r.check_disk(disk, f"16.1 GB {disk} (Virtio Block Device)", prefix=prefix)
+                if self.is_efi:
+                    r.check_disk_row(disk, "/boot/efi", "vda1", "99.6 MB", False, prefix=prefix)
                 r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False, prefix=prefix)
 
                 disk = "MDRAID-SOMERAID"
@@ -226,7 +236,7 @@ class TestStorageCockpitIntegration_E2E(VirtInstallMachineCase, StorageCase):
         i.reach(i.steps.INSTALLATION_METHOD)
 
         s.enter_cockpit_storage()
-        # Create BIOS and boot partitions on vda
+        # Create ESP and /boot partitions on vda
         self.cockpitCreateBootloaderPartitions()
         # Create a partition for /
         self.click_dropdown(self.card_row("Storage", 4), "Create partition")

--- a/test/check-storage-erase-all-e2e
+++ b/test/check-storage-erase-all-e2e
@@ -67,7 +67,7 @@ class TestStorageEraseAll_E2E(VirtInstallMachineCase):
         vda3 = next(part for part in vda["children"] if part["name"] == "vda3")
         vda3_luks = next(part for part in vda3["children"] if part["type"] == "crypt")
         vda3_root = next(part for part in vda3_luks["children"] if "/" in part["mountpoints"])
-        self.assertEqual(vda3_root["size"], "13G")
+        self.assertEqual(vda3_root["size"], "12.4G")
 
     @disk_images([("", 15), ("debian-testing", 15)])
     @timeout(1200)
@@ -109,7 +109,7 @@ class TestStorageEraseAll_E2E(VirtInstallMachineCase):
         vda = next(dev for dev in block_devs if dev["name"] == "vda")
         vda3 = next(part for part in vda["children"] if part["name"] == "vda3")
         vda3_root = next(part for part in vda3["children"] if "/" in part["mountpoints"])
-        self.assertEqual(vda3_root["size"], "13G")
+        self.assertEqual(vda3_root["size"], "12.4G")
 
         vdb = next(dev for dev in block_devs if dev["name"] == "vdb")
         vdb_mountpoints = [part["mountpoints"] for part in vdb["children"]]

--- a/test/check-storage-home-reuse
+++ b/test/check-storage-home-reuse
@@ -8,7 +8,7 @@ import os
 from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images, run_boot
 from installer import Installer
 from review import Review
-from storage import BOOT_PARTITION_DEFAULT_SIZE, BOOT_PARTITION_DEFAULT_SIZE_GB, Storage
+from storage import BOOT_PARTITION_DEFAULT_SIZE, BOOT_PARTITION_DEFAULT_SIZE_GB, EFI_PARTITION_DEFAULT_SIZE, Storage
 from testlib import nondestructive, skipImage, test_main  # pylint: disable=import-error
 from utils import move_standard_fedora_disk_to_MBR_disk, move_standard_fedora_disk_to_win_disk, pretend_default_scheme, rsync_directory
 
@@ -40,7 +40,7 @@ class _TestStorageHomeReuseHelpers:
         dev = encrypted_disk.split("/")[-1]
         dev_fedora = new_disk
 
-        s.partition_disk(disk, [("500MiB", "efi"), (BOOT_PARTITION_DEFAULT_SIZE, "ext4"), ("", None)])
+        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), (BOOT_PARTITION_DEFAULT_SIZE, "ext4"), ("", None)])
 
         # Create standard encrypted btrfs layout in the empty disk and copy the data from the fedora
         # disk to emulate the Fedora encrypted layout

--- a/test/check-storage-home-reuse
+++ b/test/check-storage-home-reuse
@@ -40,7 +40,7 @@ class _TestStorageHomeReuseHelpers:
         dev = encrypted_disk.split("/")[-1]
         dev_fedora = new_disk
 
-        s.partition_disk(disk, [("1MiB", "biosboot"), ("1MiB", "efi"), (BOOT_PARTITION_DEFAULT_SIZE, "ext4"), ("", None)])
+        s.partition_disk(disk, [("500MiB", "efi"), (BOOT_PARTITION_DEFAULT_SIZE, "ext4"), ("", None)])
 
         # Create standard encrypted btrfs layout in the empty disk and copy the data from the fedora
         # disk to emulate the Fedora encrypted layout
@@ -49,8 +49,8 @@ class _TestStorageHomeReuseHelpers:
         set -xe
 
         # Create encrypted btrfs layout
-        echo {password} | cryptsetup luksFormat {disk}4
-        echo {password} | cryptsetup luksOpen {disk}4 crypt
+        echo {password} | cryptsetup luksFormat {disk}3
+        echo {password} | cryptsetup luksOpen {disk}3 crypt
         mkfs.btrfs /dev/mapper/crypt
         mount /dev/mapper/crypt /mnt
         btrfs subvolume create /mnt/root
@@ -67,14 +67,14 @@ class _TestStorageHomeReuseHelpers:
         # Adjust /etc/fstab to contain the new device UUIDS
         echo "UUID=$(blkid -s UUID -o value /dev/mapper/crypt) / btrfs defaults,subvol=root 0 0" > /mnt/root/etc/fstab
         echo "UUID=$(blkid -s UUID -o value /dev/mapper/crypt) /home btrfs defaults,subvol=home 0 0" >> /mnt/root/etc/fstab
-        echo "UUID=$(blkid -s UUID -o value /dev/{dev}3) /boot ext4 defaults 0 0" >> /mnt/root/etc/fstab
+        echo "UUID=$(blkid -s UUID -o value /dev/{dev}2) /boot ext4 defaults 0 0" >> /mnt/root/etc/fstab
 
         umount -l /mnt-fedora
         umount -l /mnt
         cryptsetup close crypt
 
         # Do the same for /boot
-        mount /dev/{dev}3 /mnt
+        mount /dev/{dev}2 /mnt
         mount /dev/{dev_fedora}3 /mnt-fedora
         rsync -aAXHv /mnt-fedora/ /mnt/
 
@@ -88,8 +88,8 @@ class TestStorageHomeReuse(VirtInstallMachineCase, _TestStorageHomeReuseHelpers)
     def _testBasic_partition_disk(self):
         self._remove_unknown_mountpoints("vda")
 
-    # Reinstall option does not work with UEFI when /boot is on btrfs
-    # @run_boot("bios", "efi")
+    # FIXME: Reinstall option does not work with UEFI when /boot is on btrfs
+    @run_boot("bios")
     @disk_images([("fedora-rawhide", 15)])
     def testBasic(self):
         """
@@ -161,6 +161,9 @@ class TestStorageHomeReuse(VirtInstallMachineCase, _TestStorageHomeReuseHelpers)
 
     @disk_images([("fedora-rawhide", 15), ("fedora-42", 15), ("ubuntu-stable", 15)])
     @skipImage("btrfs support missing on fedora-eln image", "fedora-eln-boot")
+    # FIXME: Reinstall option does not work with UEFI when /boot is on btrfs
+    # @run_boot("bios", "efi")
+    @run_boot("bios")
     def testMultipleRoots(self):
         """
         Description:
@@ -252,7 +255,7 @@ class TestStorageHomeReuseDestructive(VirtInstallMachineCase, _TestStorageHomeRe
         s.select_disks([("vda", True), ("vdb", False)])
 
         s.unlock_all_encrypted()
-        s.unlock_device("einszwei", ["vda4"], ["vda4"])
+        s.unlock_device("einszwei", ["vda3"], ["vda3"])
         s.set_scenario("home-reuse")
         i.reach(i.steps.REVIEW)
 
@@ -260,9 +263,9 @@ class TestStorageHomeReuseDestructive(VirtInstallMachineCase, _TestStorageHomeRe
         dev = "vda"
         r.check_disk(dev, f"16.1 GB {dev} (Virtio Block Device)")
         r.check_disk_row(dev, parent=f"{dev}1", action="delete")
-        r.check_disk_row(dev, "/boot", f"{dev}3", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
-        r.check_disk_row(dev, "/", f"{dev}4", "13.9 GB", True, "btrfs", is_encrypted=True)
-        r.check_disk_row(dev, "/home", f"{dev}4", "13.9 GB", False, "btrfs", is_encrypted=True, action="mount")
+        r.check_disk_row(dev, "/boot", f"{dev}2", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
+        r.check_disk_row(dev, "/", f"{dev}3", "13.4 GB", True, "btrfs", is_encrypted=True)
+        r.check_disk_row(dev, "/home", f"{dev}3", "13.4 GB", False, "btrfs", is_encrypted=True, action="mount")
 
     def _testNonLinuxSystem_partition_disk(self):
         b = self.browser
@@ -321,6 +324,9 @@ class TestStorageHomeReuseDestructive(VirtInstallMachineCase, _TestStorageHomeRe
         self._remove_unknown_mountpoints("vdb")
 
     @disk_images([("", 20), ("fedora-rawhide", 15)])
+    # https://fedoraproject.org/wiki/Changes/Anaconda_Drop_Support_UEFI_on_MBR
+    # Fedora installer has phased out support for booting in UEFI mode on MBR-partitioned disks.
+    @run_boot("bios")
     def testMBRParttable(self):
         """
         Description:
@@ -378,7 +384,6 @@ class TestStorageHomeReuseDestructive(VirtInstallMachineCase, _TestStorageHomeRe
         move_standard_fedora_disk_to_win_disk(storage, self.machine, "vda", "vdb")
         self._remove_unknown_mountpoints("vdb")
 
-    @run_boot("efi")
     @disk_images([("", 35), ("fedora-rawhide", 15)])
     def testWindowsSingleDisk(self):
         """

--- a/test/check-storage-home-reuse-e2e
+++ b/test/check-storage-home-reuse-e2e
@@ -5,7 +5,7 @@
 
 import os
 
-from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images, run_boot
 from installer import Installer
 from progress import Progress
 from storage import Storage
@@ -84,6 +84,7 @@ class TestStorageHomeReuse_E2E(VirtInstallMachineCase):
 
         self._remove_unknown_mountpoints()
 
+    @run_boot("bios")
     @disk_images([("fedora-rawhide", 15)])
     @timeout(1200)
     def testBasic(self):

--- a/test/check-storage-mountpoints
+++ b/test/check-storage-mountpoints
@@ -143,9 +143,9 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         m = self.machine
         s = Storage(b, m)
 
-        # BIOS boot /boot on ext4 / on xfs /home on btrfs
+        # EFI system partition, /boot on ext4, / on xfs, /home on btrfs
         disk = "/dev/vda"
-        s.partition_disk(disk, [("1MiB", "biosboot"), ("1GiB", "ext4"), ("10GiB", "xfs"), ("", "ext4")])
+        s.partition_disk(disk, [("500MiB", "efi"), ("1GiB", "ext4"), ("10GiB", "xfs"), ("", "ext4")])
 
     def testNoRootMountPoint(self):
         """
@@ -170,21 +170,24 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s.select_mountpoint([(dev, True)])
 
         # verify gathered requests
-        s.select_mountpoint_row_device(2, f"{dev}2")
+        s.select_mountpoint_row_device(2, f"{dev}1")
+        s.select_mountpoint_row_device(3, f"{dev}2")
         s.check_mountpoint_row(1, "/", "Select a device", True)
-        s.check_mountpoint_row(2, "/boot", f"{dev}2", False, "ext4")
+        s.check_mountpoint_row(2, "/boot/efi", f"{dev}1", False, "EFI System Partition")
+        s.check_mountpoint_row(3, "/boot", f"{dev}2", False, "ext4")
 
         # Test moving back and forth between screens.
         i.back()
         i.next(next_page=i.steps.CUSTOM_MOUNT_POINT)
         s.check_mountpoint_row(1, "/", "Select a device", True)
-        s.check_mountpoint_row(2, "/boot", f"{dev}2", False, "ext4")
+        s.check_mountpoint_row(2, "/boot/efi", f"{dev}1", False, "EFI System Partition")
+        s.check_mountpoint_row(3, "/boot", f"{dev}2", False, "ext4")
 
         s.add_mountpoint_row()
-        s.select_mountpoint_row_device(3, f"{dev}4")
-        s.check_mountpoint_row_format_type(3, "ext4")
-        s.select_mountpoint_row_mountpoint(3, "/home")
-        s.check_mountpoint_row_reformat(3, False)
+        s.select_mountpoint_row_device(4, f"{dev}4")
+        s.check_mountpoint_row_format_type(4, "ext4")
+        s.select_mountpoint_row_mountpoint(4, "/home")
+        s.check_mountpoint_row_reformat(4, False)
 
         i.check_next_disabled()
 
@@ -200,9 +203,9 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         m = self.machine
         s = Storage(b, m)
 
-        # BIOS boot partition, /boot partition, /
+        # EFI system partition, /boot partition, /
         disk1 = "/dev/vda"
-        s.partition_disk(disk1, [("1MiB", "biosboot"), ("1GiB", "xfs"), ("", "xfs")])
+        s.partition_disk(disk1, [("500MiB", "efi"), ("1GiB", "xfs"), ("", "xfs")])
 
         # /dev/vdb1 /home partition
         disk2 = "/dev/vdb"
@@ -218,7 +221,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         Expected results:
             - The mount point mapping scenario is available and can be used with
               multiple disks
-            - The bootloader requirements (biosboot) are verified for the selected disk[s]
+            - FIXME: The bootloader requirements (EFI system partition) are verified for the selected disk[s]
         """
         b = self.browser
         m = self.machine
@@ -232,16 +235,19 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
 
-        # Select only vdb disk and verify that mount point assignment is
-        # not available (missing biosboot)
-        s.select_disks([(dev1, False), (dev2, True)])
-        s.wait_scenario_available("mount-point-mapping", False)
+        # FIXME: Currently we don't check the partition constraints for mountable partitions,
+        # we only check that the biosboot requirement is met for BIOS installations
+        #
+        # # Select only vdb disk and verify that mount point assignment is
+        # # not available (missing EFI system partition)
+        # s.select_disks([(dev1, False), (dev2, True)])
+        # s.wait_scenario_available("mount-point-mapping", False)
 
         # Select only vda disk and verify that the partitioning request is correct
         s.select_mountpoint([(dev1, True), (dev2, False)])
 
         s.check_mountpoint_row_device_available(1, "vdb1", False)
-        s.check_mountpoint_row_device_available(1, "vda2")
+        s.check_mountpoint_row_device_available(1, "vda3")
 
         # Go back and change the disk selection. The partitioning should be re-created
         i.back()
@@ -254,21 +260,25 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s.select_mountpoint_row_device(1, f"{dev1}3")
         s.check_mountpoint_row(1, "/", f"{dev1}3", True, "xfs")
 
-        s.select_mountpoint_row_device(2, f"{dev1}2")
-        s.check_mountpoint_row(2, "/boot", f"{dev1}2", False, "xfs")
+        s.select_mountpoint_row_device(2, f"{dev1}1")
+        s.check_mountpoint_row(2, "/boot/efi", f"{dev1}1", False, "EFI System Partition")
+
+        s.select_mountpoint_row_device(3, f"{dev1}2")
+        s.check_mountpoint_row(3, "/boot", f"{dev1}2", False, "xfs")
 
         s.add_mountpoint_row()
-        s.select_mountpoint_row_device(3, f"{dev2}1")
-        s.select_mountpoint_row_mountpoint(3, "/home")
-        s.check_mountpoint_row(3, "/home", f"{dev2}1", False, "xfs")
+        s.select_mountpoint_row_device(4, f"{dev2}1")
+        s.select_mountpoint_row_mountpoint(4, "/home")
+        s.check_mountpoint_row(4, "/home", f"{dev2}1", False, "xfs")
 
         i.reach(i.steps.REVIEW)
 
         # verify review screen
         disk = "vda"
         r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
+        r.check_disk_row(disk, "/boot/efi", "vda1", "524 MB", False)
         r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False)
-        r.check_disk_row(disk, "/", "vda3", "15.0 GB", True, "xfs")
+        r.check_disk_row(disk, "/", "vda3", "14.5 GB", True, "xfs")
 
         disk = "vdb"
         r.check_disk(disk, "10.7 GB vdb (Virtio Block Device)")
@@ -285,9 +295,9 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         m = self.machine
         s = Storage(b, m)
 
-        # BIOS boot partition, /boot partition, /
+        # EFI system partition, /boot partition, /
         disk1 = "/dev/vda"
-        s.partition_disk(disk1, [("1MiB", "biosboot"), ("1GiB", "xfs"), ("1GiB", "xfs"), ("1GiB", "xfs"), ("", "xfs")])
+        s.partition_disk(disk1, [("500MiB", "efi"), ("1GiB", "xfs"), ("1GiB", "xfs"), ("1GiB", "xfs"), ("", "xfs")])
 
     @disk_images([("", 15)])
     def testPayloadSizeCheck(self):
@@ -316,7 +326,8 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         # perform assignment with not enough space on mount points
         # single mount point used to count the required space
         s.select_mountpoint_row_device(1, f"{dev}3")
-        s.select_mountpoint_row_device(2, f"{dev}2")
+        s.select_mountpoint_row_device(2, f"{dev}1")
+        s.select_mountpoint_row_device(3, f"{dev}2")
 
         i.reach(i.steps.REVIEW)
 
@@ -340,9 +351,9 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         # modify assignment adding small "/usr", still not enough space on mount points
         # two mount points used to count the required space
         s.add_mountpoint_row()
-        s.select_mountpoint_row_mountpoint(3, "/usr")
-        s.select_mountpoint_row_device(3, f"{dev}4")
-        s.select_mountpoint_row_reformat(3)
+        s.select_mountpoint_row_mountpoint(4, "/usr")
+        s.select_mountpoint_row_device(4, f"{dev}4")
+        s.select_mountpoint_row_reformat(4)
 
         i.reach(i.steps.REVIEW)
 
@@ -365,7 +376,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
 
         # modify assignment adding big enough "/usr"
         # two mount points used to count the required space
-        s.select_mountpoint_row_device(3, f"{dev}5")
+        s.select_mountpoint_row_device(4, f"{dev}5")
 
         i.reach(i.steps.REVIEW)
 
@@ -384,7 +395,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         disk1 = "/dev/vda"
         s.partition_disk(
             disk1,
-            [("1MiB", "biosboot"), ("1GiB", None), ("1GiB", None), ("1GiB", None), ("1GiB", "xfs")],
+            [("500MiB", "efi"), ("1GiB", None), ("1GiB", None), ("1GiB", None), ("1GiB", "xfs")],
         )
         s.create_luks_partition(f"{disk1}2", "einszwei", "encrypted-vol0", "xfs")
         s.create_luks_partition(f"{disk1}3", "einszweidrei", "encrypted-vol1", "xfs")
@@ -436,8 +447,10 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s = Storage(b, m)
         r = Review(b, m)
 
-        s.check_mountpoint_row_mountpoint(2, "/boot")
-        s.select_mountpoint_row_device(2, "vda5")
+        s.check_mountpoint_row_mountpoint(2, "/boot/efi")
+        s.check_mountpoint_row_mountpoint(3, "/boot")
+        s.select_mountpoint_row_device(2, f"{dev1}1")
+        s.select_mountpoint_row_device(3, f"{dev1}5")
 
         s.check_mountpoint_row_mountpoint(1, "/")
 
@@ -452,7 +465,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s.check_mountpoint_row_format_type(1, "xfs")
 
         i.reach(i.steps.REVIEW)
-        r.check_disk_row(dev1, "/", "vda3", "", True, "xfs", True)
+        r.check_disk_row(dev1, "/", "vda2", "", True, "xfs", True)
 
     def testEncryptedUnlockCockpit(self):
         """
@@ -481,7 +494,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s.confirm_entering_cockpit_storage()
         b.wait_visible(".cockpit-storage-integration-sidebar")
         s.check_constraint("/", True)
-        s.check_constraint("biosboot", True)
+        s.check_constraint("/boot/efi", True)
         s.check_constraint("/boot", False)
 
         frame = "iframe[name='cockpit-storage']"
@@ -493,7 +506,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         self.confirm()
 
         self.click_dropdown(self.card_row("Storage", 2), "Create partition")
-        self.dialog({"size": 1, "type": "biosboot"})
+        self.dialog({"size": 524, "type": "efi", "mount_point": "/boot/efi"})
 
         # FIXME: Cockpit uses MB/GB for units whereas anaconda uses MiB/GiB, so
         # when anaconda backend recommends a 1GiB boot partition and Cockpit
@@ -552,7 +565,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s.partition_disk(
             disk,
             [
-                ("1MiB", "biosboot"),
+                ("500MiB", "efi"),
                 ("1GiB", "ext4"),
                 ("5GiB", "btrfs", "-f", "-L", "root"),
                 ("5GiB", "btrfs", "-f", "-L", btrfsname),
@@ -591,13 +604,14 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s.select_mountpoint([("vda", True)])
 
         s.select_mountpoint_row_device(1, "root")
-        s.select_mountpoint_row_device(2, "vda2")
+        s.select_mountpoint_row_device(2, "vda1")
+        s.select_mountpoint_row_device(3, "vda2")
         s.add_mountpoint_row()
-        s.select_mountpoint_row_mountpoint(3, "/home/joe")
-        s.select_mountpoint_row_device(3, "home", device_id=btrfs_volume_ids[0])
+        s.select_mountpoint_row_mountpoint(4, "/home/joe")
+        s.select_mountpoint_row_device(4, "home", device_id=btrfs_volume_ids[0])
         s.add_mountpoint_row()
-        s.select_mountpoint_row_mountpoint(4, "/home/alan")
-        s.select_mountpoint_row_device(4, "home", device_id=btrfs_volume_ids[1])
+        s.select_mountpoint_row_mountpoint(5, "/home/alan")
+        s.select_mountpoint_row_device(5, "home", device_id=btrfs_volume_ids[1])
 
         i.reach(i.steps.REVIEW)
 
@@ -605,10 +619,11 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         disk = "vda"
         r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
 
+        r.check_disk_row(disk, "/boot/efi", "vda1", "524 MB", False)
         r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False)
         r.check_disk_row(disk, "/", "vda3", "5.37 GB", True, "btrfs")
         r.check_disk_row(disk, "/home/joe", "vda4", "5.37 GB", False, "btrfs")
-        r.check_disk_row(disk, "/home/alan", "vda5", "4.29 GB", False, "btrfs")
+        r.check_disk_row(disk, "/home/alan", "vda5", "3.77 GB", False, "btrfs")
 
     def _testUnusableFormats_partition_disk(self):
         b = self.browser
@@ -616,7 +631,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s = Storage(b, m)
 
         disk = "/dev/vda"
-        s.partition_disk(disk, [("1MiB", "biosboot"), ("1GiB", "ext4"), ("1GiB", None), ("1GiB", "lvmpv")])
+        s.partition_disk(disk, [("500MiB", "efi"), ("1GiB", "ext4"), ("1GiB", None), ("1GiB", "lvmpv")])
 
     def testUnusableFormats(self):
         """
@@ -671,7 +686,6 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         umount /mnt
         """)
 
-    @run_boot("efi")
     def testExtendedPartition(self):
         """
         Description:
@@ -711,7 +725,6 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         m.execute(f"wipefs -a {disk2}")
         s.create_luks_partition(disk2, "homepass", "encrypted-home", "xfs")
 
-    @run_boot("efi")
     @disk_images([("", 15), ("", 10)])
     def testEncryptedHomeSecondDisk(self):
         """
@@ -750,10 +763,9 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         # Assign /, /boot/efi and /boot on disk1
         s.select_mountpoint_row_device(1, f"{dev1}3")
         next_idx = 2
-        if self.is_efi:
-            s.select_mountpoint_row_device(next_idx, f"{dev1}1")
-            s.check_mountpoint_row_format_type(next_idx, "EFI System Partition")
-            next_idx += 1
+        s.select_mountpoint_row_device(next_idx, f"{dev1}1")
+        s.check_mountpoint_row_format_type(next_idx, "EFI System Partition")
+        next_idx += 1
         s.select_mountpoint_row_device(next_idx, f"{dev1}2")
         s.check_mountpoint_row_format_type(next_idx, "ext4")
         next_idx += 1
@@ -784,6 +796,9 @@ class TestStorageMountPointsDestructive(VirtInstallMachineCase, StorageCase):
         move_standard_fedora_disk_to_MBR_disk(storage, self.machine, "vda", "vdb")
 
     @disk_images([("", 15), ("fedora-rawhide", 15)])
+    # https://fedoraproject.org/wiki/Changes/Anaconda_Drop_Support_UEFI_on_MBR
+    # Fedora installer has phased out support for booting in UEFI mode on MBR-partitioned disks.
+    @run_boot("bios")
     def testMBRParttable(self):
         """
         Description:
@@ -831,7 +846,6 @@ class TestStorageMountPointsDestructive(VirtInstallMachineCase, StorageCase):
         storage = Storage(self.browser, self.machine)
         move_standard_fedora_disk_to_win_disk(storage, self.machine, "vda", "vdb")
 
-    @run_boot("efi")
     @disk_images([("", 35), ("fedora-rawhide", 15)])
     def testWindowsSingleDiskHomeReuse(self):
         """

--- a/test/check-storage-mountpoints
+++ b/test/check-storage-mountpoints
@@ -8,7 +8,7 @@ import os
 from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images, pixel_tests_ignore, run_boot
 from installer import Installer
 from review import Review
-from storage import Storage
+from storage import EFI_PARTITION_DEFAULT_SIZE, EFI_PARTITION_DEFAULT_SIZE_MB, Storage
 from storagelib import StorageCase  # pylint: disable=import-error
 from testlib import nondestructive, skipImage, test_main  # pylint: disable=import-error
 from utils import move_standard_fedora_disk_to_MBR_disk, move_standard_fedora_disk_to_win_disk, pretend_default_scheme
@@ -145,7 +145,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
 
         # EFI system partition, /boot on ext4, / on xfs, /home on btrfs
         disk = "/dev/vda"
-        s.partition_disk(disk, [("500MiB", "efi"), ("1GiB", "ext4"), ("10GiB", "xfs"), ("", "ext4")])
+        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "ext4"), ("10GiB", "xfs"), ("", "ext4")])
 
     def testNoRootMountPoint(self):
         """
@@ -205,7 +205,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
 
         # EFI system partition, /boot partition, /
         disk1 = "/dev/vda"
-        s.partition_disk(disk1, [("500MiB", "efi"), ("1GiB", "xfs"), ("", "xfs")])
+        s.partition_disk(disk1, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "xfs"), ("", "xfs")])
 
         # /dev/vdb1 /home partition
         disk2 = "/dev/vdb"
@@ -276,7 +276,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         # verify review screen
         disk = "vda"
         r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
-        r.check_disk_row(disk, "/boot/efi", "vda1", "524 MB", False)
+        r.check_disk_row(disk, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
         r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False)
         r.check_disk_row(disk, "/", "vda3", "14.5 GB", True, "xfs")
 
@@ -297,7 +297,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
 
         # EFI system partition, /boot partition, /
         disk1 = "/dev/vda"
-        s.partition_disk(disk1, [("500MiB", "efi"), ("1GiB", "xfs"), ("1GiB", "xfs"), ("1GiB", "xfs"), ("", "xfs")])
+        s.partition_disk(disk1, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "xfs"), ("1GiB", "xfs"), ("1GiB", "xfs"), ("", "xfs")])
 
     @disk_images([("", 15)])
     def testPayloadSizeCheck(self):
@@ -395,7 +395,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         disk1 = "/dev/vda"
         s.partition_disk(
             disk1,
-            [("500MiB", "efi"), ("1GiB", None), ("1GiB", None), ("1GiB", None), ("1GiB", "xfs")],
+            [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", None), ("1GiB", None), ("1GiB", None), ("1GiB", "xfs")],
         )
         s.create_luks_partition(f"{disk1}2", "einszwei", "encrypted-vol0", "xfs")
         s.create_luks_partition(f"{disk1}3", "einszweidrei", "encrypted-vol1", "xfs")
@@ -565,7 +565,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s.partition_disk(
             disk,
             [
-                ("500MiB", "efi"),
+                (EFI_PARTITION_DEFAULT_SIZE, "efi"),
                 ("1GiB", "ext4"),
                 ("5GiB", "btrfs", "-f", "-L", "root"),
                 ("5GiB", "btrfs", "-f", "-L", btrfsname),
@@ -619,7 +619,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         disk = "vda"
         r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
 
-        r.check_disk_row(disk, "/boot/efi", "vda1", "524 MB", False)
+        r.check_disk_row(disk, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
         r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False)
         r.check_disk_row(disk, "/", "vda3", "5.37 GB", True, "btrfs")
         r.check_disk_row(disk, "/home/joe", "vda4", "5.37 GB", False, "btrfs")
@@ -631,7 +631,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s = Storage(b, m)
 
         disk = "/dev/vda"
-        s.partition_disk(disk, [("500MiB", "efi"), ("1GiB", "ext4"), ("1GiB", None), ("1GiB", "lvmpv")])
+        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "ext4"), ("1GiB", None), ("1GiB", "lvmpv")])
 
     def testUnusableFormats(self):
         """

--- a/test/check-storage-mountpoints-btrfs
+++ b/test/check-storage-mountpoints-btrfs
@@ -19,7 +19,7 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase):
 
         disk = "/dev/vda"
         tmp_mount = "/tmp/btrfs-mount-test"
-        s.partition_disk(disk, [("1MiB", "biosboot"), ("1GiB", "ext4"), ("", "btrfs")])
+        s.partition_disk(disk, [("500MiB", "efi"), ("1GiB", "ext4"), ("", "btrfs")])
         m.execute(f"""
         mkdir -p {tmp_mount}
         mount {disk}3 {tmp_mount}
@@ -64,28 +64,33 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase):
         s.select_mountpoint_row_device(1, "root")
         s.check_mountpoint_row_format_type(1, "btrfs")
 
-        s.check_mountpoint_row(2, "/boot", "Select a device", False)
-        s.select_mountpoint_row_device(2, f"{dev}2")
-        s.check_mountpoint_row_format_type(2, "ext4")
+        s.check_mountpoint_row(2, "/boot/efi", "Select a device", False)
+        s.select_mountpoint_row_device(2, f"{dev}1")
+        s.check_mountpoint_row_format_type(2, "EFI System Partition")
+
+        s.check_mountpoint_row(3, "/boot", "Select a device", False)
+        s.select_mountpoint_row_device(3, f"{dev}2")
+        s.check_mountpoint_row_format_type(3, "ext4")
 
         s.add_mountpoint_row()
-        s.select_mountpoint_row_device(3, "home")
-        s.check_mountpoint_row_reformat(3, False)
-        s.select_mountpoint_row_mountpoint(3, "/home")
-        s.check_mountpoint_row_format_type(3, "btrfs")
+        s.select_mountpoint_row_device(4, "home")
+        s.check_mountpoint_row_reformat(4, False)
+        s.select_mountpoint_row_mountpoint(4, "/home")
+        s.check_mountpoint_row_format_type(4, "btrfs")
 
         # Toggle reformat option
-        s.select_mountpoint_row_reformat(2)
-        s.check_mountpoint_row_reformat(2, True)
+        s.select_mountpoint_row_reformat(3)
+        s.check_mountpoint_row_reformat(3, True)
 
         i.reach(i.steps.REVIEW)
 
         # verify review screen
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/boot", "vda2",  "1.07 GB", True, "ext4")
-        r.check_disk_row(dev, "/", "vda3", "15.0 GB", True, "btrfs")
-        r.check_disk_row(dev, "/home", "vda3", "15.0 GB",  False)
+        r.check_disk_row(dev, "/boot/efi", "vda1", "524 MB", True, "efi")
+        r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "ext4")
+        r.check_disk_row(dev, "/", "vda3", "14.5 GB", True, "btrfs")
+        r.check_disk_row(dev, "/home", "vda3", "14.5 GB", False)
         r.check_disk_row_not_present(dev, "unused")
 
         i.reach_on_sidebar(i.steps.INSTALLATION_METHOD)
@@ -105,43 +110,44 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase):
         s.select_mountpoint([(dev, True)])
 
         s.check_mountpoint_row(1, "/", "root", True)
-        s.check_mountpoint_row(2, "/boot", f"{dev}2", False)
-        s.check_mountpoint_row(3, "/home", "home", False)
+        s.check_mountpoint_row(2, "/boot/efi", f"{dev}1", False)
+        s.check_mountpoint_row(3, "/boot", f"{dev}2", False)
+        s.check_mountpoint_row(4, "/home", "home", False)
         s.add_mountpoint_row()
-        s.select_mountpoint_row_device(4, "home/Movies")
-        s.select_mountpoint_row_mountpoint(4, "/home/Movies")
+        s.select_mountpoint_row_device(5, "home/Movies")
+        s.select_mountpoint_row_mountpoint(5, "/home/Movies")
         s.add_mountpoint_row()
-        s.select_mountpoint_row_device(5, "home/Movies/Good_Movies")
-        s.select_mountpoint_row_mountpoint(5, "/home/Movies/Good_Movies")
+        s.select_mountpoint_row_device(6, "home/Movies/Good_Movies")
+        s.select_mountpoint_row_mountpoint(6, "/home/Movies/Good_Movies")
         s.add_mountpoint_row()
-        s.select_mountpoint_row_device(6, "home/Movies/Bad_Movies")
-        s.select_mountpoint_row_mountpoint(6, "/home/Movies/Bad_Movies")
+        s.select_mountpoint_row_device(7, "home/Movies/Bad_Movies")
+        s.select_mountpoint_row_mountpoint(7, "/home/Movies/Bad_Movies")
 
         # No error when no devices are reformatted
-        for row in range(3, 6):
+        for row in range(4, 7):
             s.wait_mountpoint_table_column_helper(row, "format", present=False)
 
         # When parent is re-formatted all child devices must be reformatted
-        s.select_mountpoint_row_device(4, "home/Movies")
-        s.select_mountpoint_row_reformat(4)
-        s.wait_mountpoint_table_column_helper(4, "format", text="Mismatch")
+        s.select_mountpoint_row_device(5, "home/Movies")
         s.select_mountpoint_row_reformat(5)
+        s.wait_mountpoint_table_column_helper(5, "format", text="Mismatch")
         s.select_mountpoint_row_reformat(6)
-        s.wait_mountpoint_table_column_helper(4, "format", present=False)
+        s.select_mountpoint_row_reformat(7)
+        s.wait_mountpoint_table_column_helper(5, "format", present=False)
 
         # Check also that the rules apply to children deeper in the device tree
-        s.select_mountpoint_row_reformat(3)
-        s.wait_mountpoint_table_column_helper(3, "format", present=False)
-        s.select_mountpoint_row_reformat(6, False)
-        s.wait_mountpoint_table_column_helper(3, "format", text="Mismatch")
+        s.select_mountpoint_row_reformat(4)
+        s.wait_mountpoint_table_column_helper(4, "format", present=False)
+        s.select_mountpoint_row_reformat(7, False)
+        s.wait_mountpoint_table_column_helper(4, "format", text="Mismatch")
 
         # When parent is re-formmated all child devices should be
         # * either also reformatted if selected
         # * either not selected (not part of the mountpoint assignment table)
-        s.remove_mountpoint_row(5, 6)
-        s.remove_mountpoint_row(5, 5)
-        s.wait_mountpoint_table_column_helper(3, "format", present=False)
+        s.remove_mountpoint_row(6, 7)
+        s.remove_mountpoint_row(6, 6)
         s.wait_mountpoint_table_column_helper(4, "format", present=False)
+        s.wait_mountpoint_table_column_helper(5, "format", present=False)
 
         i.check_next_disabled(False)
 
@@ -152,7 +158,7 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase):
 
         disk = "/dev/vda"
         tmp_mount = "/tmp/btrfs-mount-test"
-        s.partition_disk(disk, [("1MiB", "biosboot"), ("1GiB", "ext4"), ("", "btrfs")])
+        s.partition_disk(disk, [("500MiB", "efi"), ("1GiB", "ext4"), ("", "btrfs")])
         s.create_luks_partition(f"{disk}3", "einszweidrei", "encrypted-vol", "btrfs", close_luks=False)
         m.execute(f"""
         mkdir -p {tmp_mount}
@@ -195,12 +201,14 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase):
 
         # Select the mountpoints
         s.select_mountpoint_row_device(1, "root")
-        s.select_mountpoint_row_device(2, f"{dev}2")
+        s.select_mountpoint_row_device(2, f"{dev}1")
+        s.select_mountpoint_row_device(3, f"{dev}2")
 
         # Verify the review page
         i.reach(i.steps.REVIEW)
+        r.check_disk_row(dev, "/boot/efi", "vda1", "524 MB", False)
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False)
-        r.check_disk_row(dev, "/", "vda3", "15.0 GB", True, "btrfs", True)
+        r.check_disk_row(dev, "/", "vda3", "14.5 GB", True, "btrfs", True)
 
 
 if __name__ == '__main__':

--- a/test/check-storage-mountpoints-btrfs
+++ b/test/check-storage-mountpoints-btrfs
@@ -6,7 +6,7 @@
 from anacondalib import VirtInstallMachineCase
 from installer import Installer
 from review import Review
-from storage import Storage
+from storage import EFI_PARTITION_DEFAULT_SIZE, EFI_PARTITION_DEFAULT_SIZE_MB, Storage
 from testlib import nondestructive, skipImage, test_main  # pylint: disable=import-error
 
 
@@ -19,7 +19,7 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase):
 
         disk = "/dev/vda"
         tmp_mount = "/tmp/btrfs-mount-test"
-        s.partition_disk(disk, [("500MiB", "efi"), ("1GiB", "ext4"), ("", "btrfs")])
+        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "ext4"), ("", "btrfs")])
         m.execute(f"""
         mkdir -p {tmp_mount}
         mount {disk}3 {tmp_mount}
@@ -87,7 +87,7 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase):
         # verify review screen
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/boot/efi", "vda1", "524 MB", True, "efi")
+        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, True, "efi")
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "ext4")
         r.check_disk_row(dev, "/", "vda3", "14.5 GB", True, "btrfs")
         r.check_disk_row(dev, "/home", "vda3", "14.5 GB", False)
@@ -158,7 +158,7 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase):
 
         disk = "/dev/vda"
         tmp_mount = "/tmp/btrfs-mount-test"
-        s.partition_disk(disk, [("500MiB", "efi"), ("1GiB", "ext4"), ("", "btrfs")])
+        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "ext4"), ("", "btrfs")])
         s.create_luks_partition(f"{disk}3", "einszweidrei", "encrypted-vol", "btrfs", close_luks=False)
         m.execute(f"""
         mkdir -p {tmp_mount}
@@ -206,7 +206,7 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase):
 
         # Verify the review page
         i.reach(i.steps.REVIEW)
-        r.check_disk_row(dev, "/boot/efi", "vda1", "524 MB", False)
+        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False)
         r.check_disk_row(dev, "/", "vda3", "14.5 GB", True, "btrfs", True)
 

--- a/test/check-storage-mountpoints-btrfs-e2e
+++ b/test/check-storage-mountpoints-btrfs-e2e
@@ -3,7 +3,7 @@
 # Copyright (C) 2025 Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, run_boot
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase
 from installer import Installer
 from review import Review
 from storage import Storage
@@ -42,7 +42,6 @@ class TestStorageMountPointsBtrfs_E2E(VirtInstallMachineCase):
         rmdir {tmp_mount}
         """)
 
-    @run_boot("efi")
     @timeout(1200)
     def testPreserveHome(self):
         """

--- a/test/check-storage-mountpoints-lvm
+++ b/test/check-storage-mountpoints-lvm
@@ -20,7 +20,7 @@ class TestStorageMountPointsLVM(VirtInstallMachineCase):
         disk = "/dev/vda"
         vgname = "fedoravg"
 
-        s.partition_disk(disk, [("1MiB", "biosboot"), ("1GiB", "ext4"), ("", None)])
+        s.partition_disk(disk, [("500MiB", "efi"), ("1GiB", "ext4"), ("", None)])
         m.execute(f"""
         vgcreate -y -f {vgname} {disk}3
         lvcreate -y -l40%FREE -n root {vgname}
@@ -56,26 +56,30 @@ class TestStorageMountPointsLVM(VirtInstallMachineCase):
         # verify gathered requests
         # root partition is not auto-mapped
         s.check_mountpoint_row(1, "/", "Select a device", True)
-        s.check_mountpoint_row(2, "/boot", "Select a device", False)
+        s.check_mountpoint_row(2, "/boot/efi", "Select a device", False)
+        s.check_mountpoint_row(3, "/boot", "Select a device", False)
 
         s.select_mountpoint_row_device(1, f"{vgname}-root")
         s.check_mountpoint_row(1, "/", f"{vgname}-root", True, "ext4")
 
-        s.select_mountpoint_row_device(2, f"{dev}2")
-        s.check_mountpoint_row(2, "/boot", f"{dev}2", False, "ext4")
+        s.select_mountpoint_row_device(2, f"{dev}1")
+        s.check_mountpoint_row(2, "/boot/efi", f"{dev}1", False, "EFI System Partition")
+
+        s.select_mountpoint_row_device(3, f"{dev}2")
+        s.check_mountpoint_row(3, "/boot", f"{dev}2", False, "ext4")
 
         s.add_mountpoint_row()
-        s.select_mountpoint_row_device(3, f"{vgname}-home")
-        s.select_mountpoint_row_mountpoint(3, "/home")
-        s.check_mountpoint_row(3, "/home", f"{vgname}-home", False, "ext4")
+        s.select_mountpoint_row_device(4, f"{vgname}-home")
+        s.select_mountpoint_row_mountpoint(4, "/home")
+        s.check_mountpoint_row(4, "/home", f"{vgname}-home", False, "ext4")
 
         s.add_mountpoint_row()
-        s.select_mountpoint_row_device(4, f"{vgname}-swap")
-        s.check_mountpoint_row(4, "swap", f"{vgname}-swap", False, "swap")
+        s.select_mountpoint_row_device(5, f"{vgname}-swap")
+        s.check_mountpoint_row(5, "swap", f"{vgname}-swap", False, "swap")
 
         # Toggle reformat option
-        s.select_mountpoint_row_reformat(2)
-        s.check_mountpoint_row_reformat(2, True)
+        s.select_mountpoint_row_reformat(3)
+        s.check_mountpoint_row_reformat(3, True)
 
         i.reach(i.steps.REVIEW)
 
@@ -83,18 +87,18 @@ class TestStorageMountPointsLVM(VirtInstallMachineCase):
         disk = "vda"
         r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
 
+        r.check_disk_row(disk, "/boot/efi", "vda1", "524 MB", False)
         r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", True, "ext4")
-        r.check_disk_row(disk, "/", "vda3, LVM", "6.01 GB", True, "ext4")
-        r.check_disk_row(disk, "/home", "vda3, LVM", "8.12 GB", False)
-        r.check_disk_row(disk, "swap", "vda3, LVM", "902 MB", False)
+        r.check_disk_row(disk, "/", "vda3, LVM", "5.80 GB", True, "ext4")
+        r.check_disk_row(disk, "/home", "vda3, LVM", "7.83 GB", False)
+        r.check_disk_row(disk, "swap", "vda3, LVM", "872 MB", False)
 
         i.reach_on_sidebar(i.steps.CUSTOM_MOUNT_POINT)
 
         # remove the /home row and check that row 3 is now swap
-        s.remove_mountpoint_row(3, 4)
-
-        s.check_mountpoint_row_mountpoint(3, "swap")
-        s.check_mountpoint_row_device(3, f"{vgname}-swap")
+        s.remove_mountpoint_row(4, 5)
+        s.check_mountpoint_row_mountpoint(4, "swap")
+        s.check_mountpoint_row_device(4, f"{vgname}-swap")
 
         i.reach(i.steps.REVIEW)
 
@@ -102,9 +106,10 @@ class TestStorageMountPointsLVM(VirtInstallMachineCase):
         disk = "vda"
         r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
 
+        r.check_disk_row(disk, "/boot/efi", "vda1", "524 MB", False)
         r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", True, "ext4")
-        r.check_disk_row(disk, "/", "vda3, LVM", "6.01 GB", True, "ext4")
-        r.check_disk_row(disk, "swap", "vda3, LVM", "902 MB", False)
+        r.check_disk_row(disk, "/", "vda3, LVM", "5.80 GB", True, "ext4")
+        r.check_disk_row(disk, "swap", "vda3, LVM", "872 MB", False)
 
 
 if __name__ == '__main__':

--- a/test/check-storage-mountpoints-lvm
+++ b/test/check-storage-mountpoints-lvm
@@ -6,7 +6,7 @@
 from anacondalib import VirtInstallMachineCase
 from installer import Installer
 from review import Review
-from storage import Storage
+from storage import EFI_PARTITION_DEFAULT_SIZE, EFI_PARTITION_DEFAULT_SIZE_MB, Storage
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 
 
@@ -20,7 +20,7 @@ class TestStorageMountPointsLVM(VirtInstallMachineCase):
         disk = "/dev/vda"
         vgname = "fedoravg"
 
-        s.partition_disk(disk, [("500MiB", "efi"), ("1GiB", "ext4"), ("", None)])
+        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "ext4"), ("", None)])
         m.execute(f"""
         vgcreate -y -f {vgname} {disk}3
         lvcreate -y -l40%FREE -n root {vgname}
@@ -87,7 +87,7 @@ class TestStorageMountPointsLVM(VirtInstallMachineCase):
         disk = "vda"
         r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
 
-        r.check_disk_row(disk, "/boot/efi", "vda1", "524 MB", False)
+        r.check_disk_row(disk, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
         r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", True, "ext4")
         r.check_disk_row(disk, "/", "vda3, LVM", "5.80 GB", True, "ext4")
         r.check_disk_row(disk, "/home", "vda3, LVM", "7.83 GB", False)
@@ -106,7 +106,7 @@ class TestStorageMountPointsLVM(VirtInstallMachineCase):
         disk = "vda"
         r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
 
-        r.check_disk_row(disk, "/boot/efi", "vda1", "524 MB", False)
+        r.check_disk_row(disk, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
         r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", True, "ext4")
         r.check_disk_row(disk, "/", "vda3, LVM", "5.80 GB", True, "ext4")
         r.check_disk_row(disk, "swap", "vda3, LVM", "872 MB", False)

--- a/test/check-storage-mountpoints-raid
+++ b/test/check-storage-mountpoints-raid
@@ -19,9 +19,9 @@ class TestStorageMountPointsRAIDDestructive(VirtInstallMachineCase):
         m = self.machine
         s = Storage(b, m)
 
-        # BIOS boot partition, /boot partition, / on RAID
+        # EFI system partition, /boot partition, / on RAID
         disk = "/dev/vda"
-        s.partition_disk(disk, [("1MiB", "biosboot"), ("1GiB", "xfs"), ("5GiB", None), ("5GiB", None)])
+        s.partition_disk(disk, [("500MiB", "efi"), ("1GiB", "xfs"), ("5GiB", None), ("5GiB", None)])
         s.create_luks_partition(f"{disk}3", "einszweidrei", "encrypted-vol", close_luks=False)
         s.create_luks_partition(f"{disk}4", "einszweidrei", "encrypted-vol2", close_luks=False)
         s.create_raid_device("encryptedraid", "raid1", ["/dev/mapper/encrypted-vol", "/dev/mapper/encrypted-vol2"])
@@ -61,15 +61,18 @@ class TestStorageMountPointsRAIDDestructive(VirtInstallMachineCase):
         s.select_mountpoint_row_device(1, "encryptedraid")
         s.check_mountpoint_row_format_type(1, "xfs")
 
-        s.check_mountpoint_row_mountpoint(2, "/boot")
-        s.select_mountpoint_row_device(2, f"{dev}2")
-        s.select_mountpoint_row_reformat(2)
-        s.check_mountpoint_row_reformat(2, True)
+        s.check_mountpoint_row_mountpoint(2, "/boot/efi")
+        s.select_mountpoint_row_device(2, f"{dev}1")
+        s.check_mountpoint_row_mountpoint(3, "/boot")
+        s.select_mountpoint_row_device(3, f"{dev}2")
+        s.select_mountpoint_row_reformat(3)
+        s.check_mountpoint_row_reformat(3, True)
 
         i.reach(i.steps.REVIEW)
 
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
+        r.check_disk_row(dev, "/boot/efi", "vda1", "524 MB", False, "efi")
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "xfs")
         r.check_disk_row(dev, "/", "vda3, vda4, RAID", "5.35 GB", True, "xfs", True)
 
@@ -80,7 +83,7 @@ class TestStorageMountPointsRAIDDestructive(VirtInstallMachineCase):
 
         disk = "/dev/vda"
 
-        s.partition_disk(disk, [("1MiB", "biosboot"), ("1GiB", "xfs"), ("5GiB", None), ("5GiB", None)])
+        s.partition_disk(disk, [("500MiB", "efi"), ("1GiB", "xfs"), ("5GiB", None), ("5GiB", None)])
         s.create_raid_device("encryptedraid", "raid1", [f"{disk}3", f"{disk}4"])
         s.create_luks_partition("/dev/md/encryptedraid", "einszweidrei", "encrypted-vol", "xfs")
 
@@ -104,7 +107,7 @@ class TestStorageMountPointsRAIDDestructive(VirtInstallMachineCase):
         s = Storage(b, m)
         r = Review(b, m)
 
-        # BIOS boot partition, /boot partition, / on RAID
+        # EFI system partition, /boot partition, / on RAID
         dev = "vda"
 
         i.open()
@@ -116,14 +119,16 @@ class TestStorageMountPointsRAIDDestructive(VirtInstallMachineCase):
 
         s.select_mountpoint()
 
-        s.check_mountpoint_row_mountpoint(2, "/boot")
-        s.select_mountpoint_row_device(2, f"{dev}2")
-        s.select_mountpoint_row_reformat(2)
-        s.check_mountpoint_row_reformat(2, True)
+        s.check_mountpoint_row_mountpoint(2, "/boot/efi")
+        s.select_mountpoint_row_device(2, f"{dev}1")
+        s.check_mountpoint_row_mountpoint(3, "/boot")
+        s.select_mountpoint_row_device(3, f"{dev}2")
+        s.select_mountpoint_row_reformat(1)
+        s.check_mountpoint_row_reformat(1, True)
 
         toggle_selector = f"#{i.steps.CUSTOM_MOUNT_POINT}-table-row-1-device-select-toggle:not([disabled]):not([aria-disabled=true])"
         b.click(toggle_selector)
-        b.click(".pf-v6-c-menu__content li:nth-of-type(2) button")
+        b.click(".pf-v6-c-menu__content li:nth-of-type(3) button")
         b.wait_not_present(".pf-v6-c-menu")
         b.wait_js_func("ph_text", f"#{i.steps.CUSTOM_MOUNT_POINT}-table-row-1 .pf-v6-c-select__toggle-text", "luks")
 
@@ -131,6 +136,8 @@ class TestStorageMountPointsRAIDDestructive(VirtInstallMachineCase):
 
         i.reach(i.steps.REVIEW)
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
+        r.check_disk_row(dev, "/boot/efi", "vda1", "524 MB", False, "efi")
+        r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "xfs")
         r.check_disk_row(dev, "/", "vda3, vda4, RAID", "5.35 GB", True, "xfs", True)
 
 
@@ -141,8 +148,8 @@ class TestStorageMountPointsRAID(VirtInstallMachineCase):
         m = self.machine
         s = Storage(b, m)
 
-        # BIOS boot partition, /boot partition, / on RAID
-        s.partition_disk("/dev/vda", [("1MiB", "biosboot"), ("1GB", "xfs")])
+        # EFI system partition, /boot partition, / on RAID
+        s.partition_disk("/dev/vda", [("500MiB", "efi"), ("1GB", "xfs")])
         self.addCleanup(
             lambda: m.execute(
             """
@@ -165,7 +172,7 @@ class TestStorageMountPointsRAID(VirtInstallMachineCase):
         """
         Test scenario with three disks:
 
-        - 'biosboot' and '/boot' are on 'vda'.
+        - ESP and '/boot' are on 'vda'.
         - A RAID 0 array is created using 'vdb' and 'vdc'.
         - The root filesystem ('/') is placed on the RAID 0 device.
         """
@@ -180,9 +187,13 @@ class TestStorageMountPointsRAID(VirtInstallMachineCase):
 
         s.select_mountpoint([("vda", True), ("MDRAID-SOMERAID", True)]) # Select both disks
 
-        s.check_mountpoint_row_mountpoint(2, "/boot")
-        s.select_mountpoint_row_device(2, "vda2")
+        s.check_mountpoint_row_mountpoint(2, "/boot/efi")
+        s.select_mountpoint_row_device(2, "vda1")
         s.select_mountpoint_row_reformat(2, False)
+
+        s.check_mountpoint_row_mountpoint(3, "/boot")
+        s.select_mountpoint_row_device(3, "vda2")
+        s.select_mountpoint_row_reformat(3, False)
 
         s.check_mountpoint_row_mountpoint(1, "/")
         s.select_mountpoint_row_device(1, "SOMERAID1")
@@ -192,6 +203,7 @@ class TestStorageMountPointsRAID(VirtInstallMachineCase):
         i.reach(i.steps.REVIEW)
 
         r.check_disk("vda", "16.1 GB vda (Virtio Block Device)")
+        r.check_disk_row("vda", "/boot/efi", "vda1", "524 MB", False)
         r.check_disk_row("vda", "/boot", "vda2", "1.00 GB", False)
         r.check_disk("MDRAID-SOMERAID", "32.2 GB MDRAID-SOMERAID (MDRAID set (stripe))")
         r.check_disk_row("MDRAID-SOMERAID", "/", "SOMERAID1, RAID", "32.2 GB", False)

--- a/test/check-storage-mountpoints-raid
+++ b/test/check-storage-mountpoints-raid
@@ -6,7 +6,7 @@
 from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images
 from installer import Installer
 from review import Review
-from storage import Storage
+from storage import EFI_PARTITION_DEFAULT_SIZE, EFI_PARTITION_DEFAULT_SIZE_MB, Storage
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 
 
@@ -21,7 +21,7 @@ class TestStorageMountPointsRAIDDestructive(VirtInstallMachineCase):
 
         # EFI system partition, /boot partition, / on RAID
         disk = "/dev/vda"
-        s.partition_disk(disk, [("500MiB", "efi"), ("1GiB", "xfs"), ("5GiB", None), ("5GiB", None)])
+        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "xfs"), ("5GiB", None), ("5GiB", None)])
         s.create_luks_partition(f"{disk}3", "einszweidrei", "encrypted-vol", close_luks=False)
         s.create_luks_partition(f"{disk}4", "einszweidrei", "encrypted-vol2", close_luks=False)
         s.create_raid_device("encryptedraid", "raid1", ["/dev/mapper/encrypted-vol", "/dev/mapper/encrypted-vol2"])
@@ -72,7 +72,7 @@ class TestStorageMountPointsRAIDDestructive(VirtInstallMachineCase):
 
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/boot/efi", "vda1", "524 MB", False, "efi")
+        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False, "efi")
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "xfs")
         r.check_disk_row(dev, "/", "vda3, vda4, RAID", "5.35 GB", True, "xfs", True)
 
@@ -83,7 +83,7 @@ class TestStorageMountPointsRAIDDestructive(VirtInstallMachineCase):
 
         disk = "/dev/vda"
 
-        s.partition_disk(disk, [("500MiB", "efi"), ("1GiB", "xfs"), ("5GiB", None), ("5GiB", None)])
+        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "xfs"), ("5GiB", None), ("5GiB", None)])
         s.create_raid_device("encryptedraid", "raid1", [f"{disk}3", f"{disk}4"])
         s.create_luks_partition("/dev/md/encryptedraid", "einszweidrei", "encrypted-vol", "xfs")
 
@@ -136,7 +136,7 @@ class TestStorageMountPointsRAIDDestructive(VirtInstallMachineCase):
 
         i.reach(i.steps.REVIEW)
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
-        r.check_disk_row(dev, "/boot/efi", "vda1", "524 MB", False, "efi")
+        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False, "efi")
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "xfs")
         r.check_disk_row(dev, "/", "vda3, vda4, RAID", "5.35 GB", True, "xfs", True)
 
@@ -149,7 +149,7 @@ class TestStorageMountPointsRAID(VirtInstallMachineCase):
         s = Storage(b, m)
 
         # EFI system partition, /boot partition, / on RAID
-        s.partition_disk("/dev/vda", [("500MiB", "efi"), ("1GB", "xfs")])
+        s.partition_disk("/dev/vda", [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GB", "xfs")])
         self.addCleanup(
             lambda: m.execute(
             """
@@ -203,7 +203,7 @@ class TestStorageMountPointsRAID(VirtInstallMachineCase):
         i.reach(i.steps.REVIEW)
 
         r.check_disk("vda", "16.1 GB vda (Virtio Block Device)")
-        r.check_disk_row("vda", "/boot/efi", "vda1", "524 MB", False)
+        r.check_disk_row("vda", "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
         r.check_disk_row("vda", "/boot", "vda2", "1.00 GB", False)
         r.check_disk("MDRAID-SOMERAID", "32.2 GB MDRAID-SOMERAID (MDRAID set (stripe))")
         r.check_disk_row("MDRAID-SOMERAID", "/", "SOMERAID1, RAID", "32.2 GB", False)

--- a/test/check-storage-mountpoints-raid-e2e
+++ b/test/check-storage-mountpoints-raid-e2e
@@ -21,8 +21,8 @@ class TestStorageMountPointsRAID_E2E(VirtInstallMachineCase):
         disk2 = "/dev/vdb"
         raid_name = "raid1"
 
-        s.partition_disk(disk1, [("1MiB", "biosboot"),("1GiB", "xfs"), ("" , None)])
-        s.partition_disk(disk2, [("1MiB", "biosboot"),("1GiB", "xfs"), ("" , None)])
+        s.partition_disk(disk1, [("500MiB", "efi"), ("1GiB", "xfs"), ("", None)])
+        s.partition_disk(disk2, [("500MiB", "efi"), ("1GiB", "xfs"), ("", None)])
 
         # RAID1 on partition level for /boot and /
         s.create_raid_device(f"{raid_name}-boot", "raid1", [f"{disk1}2", f"{disk2}2"])
@@ -48,13 +48,12 @@ class TestStorageMountPointsRAID_E2E(VirtInstallMachineCase):
         """
         Description:
             Test RAID1 on partition level with LVM. Both disks (vda, vdb) have:
-            - Partition 1: biosboot (1M)
+            - Partition 1: EFI system partition (500 MiB)
             - Partition 2: RAID1 for /boot (xfs)
             - Partition 3: RAID1 for LVM (ext4 for /)
 
         Expected results:
-            - The user can select the devices for biosboot, boot and root partitions in the
-            mount point assignment screen
+            - The user can assign /boot/efi, /boot, and / on UEFI
             - The mount points are correctly assigned to the devices in the installed system
         """
         b = self.browser
@@ -73,7 +72,8 @@ class TestStorageMountPointsRAID_E2E(VirtInstallMachineCase):
 
         s.select_mountpoint([(dev1, True), (dev2, True)])
         s.select_mountpoint_row_device(1, "vol-group-root")
-        s.select_mountpoint_row_device(2, f"{raid_name}-boot")
+        s.select_mountpoint_row_device(2, f"{dev1}1")
+        s.select_mountpoint_row_device(3, f"{raid_name}-boot")
 
         i.next(should_fail=True)
         i.reach(i.steps.REVIEW)

--- a/test/check-storage-mountpoints-raid-e2e
+++ b/test/check-storage-mountpoints-raid-e2e
@@ -5,7 +5,7 @@
 
 from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images
 from installer import Installer
-from storage import Storage
+from storage import EFI_PARTITION_DEFAULT_SIZE, Storage
 from testlib import test_main, timeout  # pylint: disable=import-error
 
 
@@ -21,8 +21,8 @@ class TestStorageMountPointsRAID_E2E(VirtInstallMachineCase):
         disk2 = "/dev/vdb"
         raid_name = "raid1"
 
-        s.partition_disk(disk1, [("500MiB", "efi"), ("1GiB", "xfs"), ("", None)])
-        s.partition_disk(disk2, [("500MiB", "efi"), ("1GiB", "xfs"), ("", None)])
+        s.partition_disk(disk1, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "xfs"), ("", None)])
+        s.partition_disk(disk2, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "xfs"), ("", None)])
 
         # RAID1 on partition level for /boot and /
         s.create_raid_device(f"{raid_name}-boot", "raid1", [f"{disk1}2", f"{disk2}2"])

--- a/test/check-storage-reclaim
+++ b/test/check-storage-reclaim
@@ -7,7 +7,7 @@ from anacondalib import VirtInstallMachineCase, disk_images
 from installer import Installer
 from language import Language
 from review import Review
-from storage import BOOT_PARTITION_DEFAULT_SIZE, Storage
+from storage import BOOT_PARTITION_DEFAULT_SIZE, EFI_PARTITION_DEFAULT_SIZE, EFI_PARTITION_DEFAULT_SIZE_MB, Storage
 from testlib import (
     nondestructive,
     test_main,
@@ -22,7 +22,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         s.partition_disk(
             disk,
             [
-                ("500MiB", "efi"),
+                (EFI_PARTITION_DEFAULT_SIZE, "efi"),
                 ("6GiB", "ext4"),
                 ("5GiB", "btrfs", "-f", "-L", f"{btrfsname}A"),
                 ("", "btrfs", "-f", "-L", f"{btrfsname}B"),
@@ -39,7 +39,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         s.partition_disk(
             disk,
             [
-                ("500MiB", "efi"),
+                (EFI_PARTITION_DEFAULT_SIZE, "efi"),
                 (BOOT_PARTITION_DEFAULT_SIZE, "ext4"),
                 ("5GiB", "btrfs", "-f", "-L", f"{btrfsname}A"),
             ],
@@ -123,7 +123,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
 
         # Check that all partitions are present
         s.reclaim_check_device_row("vda", deviceType="disk", space="16.1 GB")
-        s.reclaim_check_device_row("vda1", deviceType="efi", space="524 MB")
+        s.reclaim_check_device_row("vda1", deviceType="efi", space=EFI_PARTITION_DEFAULT_SIZE_MB)
         s.reclaim_check_device_row("vda2", deviceType="ext4", space="6.44 GB")
         s.reclaim_check_device_row("vda3", deviceType="btrfs", space="5.37 GB")
         s.reclaim_check_device_row("vda4", deviceType="btrfs", space="3.77 GB")

--- a/test/check-storage-reclaim
+++ b/test/check-storage-reclaim
@@ -22,7 +22,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         s.partition_disk(
             disk,
             [
-                ("1MiB", "biosboot"),
+                ("500MiB", "efi"),
                 ("6GiB", "ext4"),
                 ("5GiB", "btrfs", "-f", "-L", f"{btrfsname}A"),
                 ("", "btrfs", "-f", "-L", f"{btrfsname}B"),
@@ -39,7 +39,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         s.partition_disk(
             disk,
             [
-                ("1MiB", "biosboot"),
+                ("500MiB", "efi"),
                 (BOOT_PARTITION_DEFAULT_SIZE, "ext4"),
                 ("5GiB", "btrfs", "-f", "-L", f"{btrfsname}A"),
             ],
@@ -84,7 +84,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
 
         i.reach(i.steps.REVIEW)
 
-        r.check_disk_row(dev, "/", "vda5, LVM", "6.44 GB", True, "xfs")
+        r.check_disk_row(dev, "/", "vda5, LVM", "5.91 GB", True, "xfs")
 
     def _testReclaimSpaceDeleteBtrfsSubvolumes_partition_disk(self):
         b = self.browser
@@ -123,10 +123,10 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
 
         # Check that all partitions are present
         s.reclaim_check_device_row("vda", deviceType="disk", space="16.1 GB")
-        s.reclaim_check_device_row("vda1", deviceType="biosboot", space="1.05 MB")
+        s.reclaim_check_device_row("vda1", deviceType="efi", space="524 MB")
         s.reclaim_check_device_row("vda2", deviceType="ext4", space="6.44 GB")
         s.reclaim_check_device_row("vda3", deviceType="btrfs", space="5.37 GB")
-        s.reclaim_check_device_row("vda4", deviceType="btrfs", space="4.29 GB")
+        s.reclaim_check_device_row("vda4", deviceType="btrfs", space="3.77 GB")
 
         # Check that deleting a disk will delete all contained partitions
         s.reclaim_remove_device("vda")
@@ -380,6 +380,8 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
 
         s.reclaim_remove_device("vda3")
         s.reclaim_modal_submit()
+        # Backend gives warning on the 100MB /boot/efi partition
+        i.next(should_fail=True)
 
         i.reach(i.steps.REVIEW)
         r.check_affected_system("Fedora Linux", [("vda3", ["boot", "home", "root", "var"])])
@@ -446,6 +448,10 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         s.reclaim_shrink_device("vda1", "7")
         s.reclaim_modal_submit()
 
+        # existing efi partition is smaller than the recommended 500 MiB
+        # so we need to click 'Next' twice to move past the storage configuration step
+        i.next(next_page=i.steps.STORAGE_CONFIGURATION)
+
         i.reach(i.steps.REVIEW)
         # Don't specify the exact original size as this might change with image refreshes
         r.check_disk_row("vda", parent="vda1", size="7.00 GB", action="resized from 11.2 GB")
@@ -459,6 +465,9 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
 
         s.reclaim_shrink_device("vda1", "7,10", ariaLabel="zmenšit")
         s.reclaim_modal_submit()
+        # existing efi partition is smaller than the recommended 500 MiB
+        # so we need to click 'Next' twice to move past the storage configuration step
+        i.next(next_page=i.steps.STORAGE_CONFIGURATION)
 
         i.reach(i.steps.REVIEW)
         r.check_disk_row("vda", parent="vda1", size="7,10 GB", action="změněna velikost z 11,2 GB")

--- a/test/check-storage-reclaim-e2e
+++ b/test/check-storage-reclaim-e2e
@@ -40,6 +40,8 @@ class TestStorageReclaim_E2E(DualBootHelper_E2E, VirtInstallMachineCase):
 
         s.reclaim_shrink_device("vda1", "7")
         s.reclaim_modal_submit()
+        # Debian /boot/efi is less than 500MB therefore we get a warning
+        i.next(should_fail=True)
 
         i.reach(i.steps.REVIEW)
         r.check_some_resized_checkbox_label()

--- a/test/check-storage-use-free-space
+++ b/test/check-storage-use-free-space
@@ -36,10 +36,16 @@ class TestStorageUseFreeSpace(VirtInstallMachineCase):
         i.reach(i.steps.INSTALLATION_METHOD)
         s.check_scenario_selected("use-free-space")
         i.next()
+        # debian's efi partition is smaller than the recommended 500 MiB
+        # so we need to click 'Next' twice to move past the storage configuration step
+        i.next(next_page=i.steps.STORAGE_CONFIGURATION)
         i.reach(i.steps.REVIEW)
         r.check_storage_config("Share disk with other operating systems: Debian GNU/Linux")
 
         i.reach_on_sidebar(i.steps.STORAGE_CONFIGURATION)
+        # debian's efi partition is smaller than the recommended 500 MiB
+        # so we need to click 'Next' twice to move past the storage configuration step
+        i.next(next_page=i.steps.STORAGE_CONFIGURATION)
         i.reach(i.steps.REVIEW)
         r.check_storage_config("Share disk with other operating systems: Debian GNU/Linux")
         r.check_disk_row("vda", "/", "vda3, LVM", "7.51 GB", True, "xfs")

--- a/test/helpers/review.py
+++ b/test/helpers/review.py
@@ -66,7 +66,7 @@ class Review(NetworkDBus, StorageDBus):
         # Action rows (delete/resize) have data-action and no data-mount;
         # mount rows have data-mount and no data-action.
         # Detect action rows: explicit non-default action, no mount_point, no reformat.
-        is_action_row = action and action not in ("mount", "biosboot") and not mount_point and not reformat
+        is_action_row = action and action not in ("mount", "biosboot", "efi") and not mount_point and not reformat
         row = f'{table} tr[data-device="{parent}"]'
         if is_action_row:
             row = f'{row}[data-action="{action_text}"]'

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -29,6 +29,10 @@ BOOT_PARTITION_DEFAULT_SIZE = '2GiB'
 # Default boot partition size for review display (GB format)
 BOOT_PARTITION_DEFAULT_SIZE_GB = '2.15 GB'
 
+# Default EFI system partition size for partition preparation (MiB format)
+EFI_PARTITION_DEFAULT_SIZE = '500MiB'
+# Default EFI system partition size for review display (MB format)
+EFI_PARTITION_DEFAULT_SIZE_MB = '524 MB'
 
 class StorageDestination():
     def __init__(self, browser, machine):

--- a/test/kickstarts/TestKickstartAutomated-testBasic.ks
+++ b/test/kickstarts/TestKickstartAutomated-testBasic.ks
@@ -1,7 +1,7 @@
 bootloader --timeout=1
 zerombr
 clearpart --all
-part biosboot --fstype=biosboot --size=1
+part /boot/efi --fstype=efi --size=500
 part /boot --fstype=xfs --size=1024
 part swap --size=1024
 part / --fstype=xfs --grow

--- a/test/kickstarts/TestKickstartAutomated-testBasic.ks
+++ b/test/kickstarts/TestKickstartAutomated-testBasic.ks
@@ -1,7 +1,7 @@
 bootloader --timeout=1
 zerombr
 clearpart --all
-part /boot/efi --fstype=efi --size=500
+part /boot/efi --fstype=efi --size=500  # EFI_PARTITION_KICKSTART_SIZE_MB
 part /boot --fstype=xfs --size=1024
 part swap --size=1024
 part / --fstype=xfs --grow

--- a/test/machine_install.py
+++ b/test/machine_install.py
@@ -123,7 +123,7 @@ class VirtInstallMachine(VirtMachine):
             os.system(f"cd {tmp_dir} && find . | cpio -c -o | gzip -9cv > {updates_image_edited}")
 
     def start(self):
-        self.is_efi = os.environ.get("TEST_FIRMWARE", "bios") == "efi"
+        self.is_efi = os.environ.get("TEST_FIRMWARE", "efi") == "efi"
         self.os = os.environ.get("TEST_OS", "fedora-rawhide-boot").split("-boot")[0]
 
         self.payload_path = os.path.join(ROOT_DIR, f"tmp/{self.os}-anaconda-payload")

--- a/test/run
+++ b/test/run
@@ -9,7 +9,7 @@
 # storage              - storage related tests
 # cockpit              - storage related tests that utilize Cockpit Storage plugin
 # other                - all remaining tests
-# efi                  - tests in UEFI mode (they might be tests which are also present in other scenarios)
+# bios                 - tests in BIOS mode (they might be tests which are also present in other scenarios)
 # compose-{compose-id} - tests defined in wiki-testmap.json ran against given compose
 # bootoptns-net1       - tests run for installation with network configuration via boot options
 
@@ -36,7 +36,7 @@ BASIC_TESTS="$(echo "$ALL_TESTS" | grep -vE "$RE_EXPENSIVE" | grep -vE "$RE_DNF_
 
 # every known case needs to set RUN_OPTS to something non-empty, so that we can check if we hit any branch
 case "${TEST_SCENARIO:=}" in
-    *efi*) export TEST_FIRMWARE="efi";;&
+    *bios*) export TEST_FIRMWARE="bios";;&
 
     *bootopts-net1*) export TEST_EXTRA_BOOT_ARGS="net.ifnames.prefix=net ip=net0:dhcp" TEST_VM_SETUP="bootopts-net1";;&
 

--- a/test/webui_testvm.py
+++ b/test/webui_testvm.py
@@ -17,11 +17,11 @@ def cmd_cli():
     parser.add_argument("image", help="Image name")
     parser.add_argument("--rsync", help="Rsync development files over on startup", action='store_true')
     parser.add_argument("--host", help="Hostname to rsync", default='test-updates')
-    parser.add_argument("--efi", help="Start the VM with an EFI firmware", action='store_true')
+    parser.add_argument("--bios", help="Start the VM with BIOS firmware (UEFI is the default)", action='store_true')
     args = parser.parse_args()
 
-    if args.efi:
-        os.environ["TEST_FIRMWARE"] = "efi"
+    if args.bios:
+        os.environ["TEST_FIRMWARE"] = "bios"
     machine = VirtInstallMachine(image=args.image, memory_mb=INSTALLER_VM_MEMORY_MB)
     try:
         machine.start()


### PR DESCRIPTION
Update all references to use inverted logic.
Also remove @run_boot('efi') decorators from test files as EFI is now default.

**To be landed together with: https://github.com/cockpit-project/bots/pull/9050**