### PR TITLE
Network configuration in wizard page

### DIFF
--- a/docs/installation-steps.rst
+++ b/docs/installation-steps.rst
@@ -5,13 +5,14 @@ Installation Flow Overview
 This document describes the step-by-step process for installing the system using the Web UI.
 
 1. **Welcome**
-2. **Date and time**
-3. **Software selection**
-4. **Installation method**
-5. **Storage configuration**
-6. **Create Account**
-7. **Review and install**
-8. **Installation progress**
+2. **Network**
+3. **Date and time**
+4. **Software selection**
+5. **Installation method**
+6. **Storage configuration**
+7. **Create Account**
+8. **Review and install**
+9. **Installation progress**
 
 Detailed Step Descriptions
 =============================
@@ -21,17 +22,22 @@ Detailed Step Descriptions
 
 Select the language & keyboard to use during installation and for the target system.
 
-2. Date and time
+2. Network
+----------
+
+Configure network connections for the system.
+
+3. Date and time
 ----------------
 
 Configure your system's timezone, date, and time settings. You can also set up network time synchronization.
 
-3. Software selection
+4. Software selection
 ---------------------
 
 Select packages to install by choosing a base environment.
 
-4. Installation method
+5. Installation method
 ----------------------
 
 Choose the target device(s) for the installation and the partitioning scenario.
@@ -73,22 +79,22 @@ Reinstalls Fedora while preserving your existing home directory and user data. U
 
 Installs using only unallocated free space, preserving existing partitions and data. Use when you want to dual-boot with existing operating systems. This option only appears when existing partitions are detected on the selected disks.
 
-5. Storage configuration
+6. Storage configuration
 ------------------------
 
 Automatic partitioning configuration, disk encryption, and storage options.
 
-6. Create Account
+7. Create Account
 -----------------
 
 Set up user accounts and administrator passwords for your system.
 
-7. Review and install
+8. Review and install
 ---------------------
 
 Review your installation settings and start the installation process.
 
-8. Installation progress
+9. Installation progress
 ------------------------
 
 Monitor the installation progress and completion.

--- a/src/components/network/CockpitNetworkConfiguration.jsx
+++ b/src/components/network/CockpitNetworkConfiguration.jsx
@@ -11,31 +11,11 @@ import { PageSection } from "@patternfly/react-core/dist/esm/components/Page/ind
 
 import { useMaybeBackdrop } from "../../hooks/CockpitIntegration.jsx";
 
+import { useNetworkStatus } from "./useNetworkStatus.js";
+
 import "./CockpitNetworkConfiguration.scss";
 
 const _ = cockpit.gettext;
-
-// Hook to track checkpoint status from the Cockpit networkmanager iframe
-const useNetworkStatus = () => {
-    const [hasActiveCheckpoint, setHasActiveCheckpoint] = useState(false);
-
-    useEffect(() => {
-        const checkpointState = window.sessionStorage.getItem("cockpit_has_checkpoint");
-        setHasActiveCheckpoint(checkpointState === "true");
-
-        const handleCheckpointEvent = (event) => {
-            if (event.key === "cockpit_has_checkpoint") {
-                setHasActiveCheckpoint(event.newValue === "true");
-            }
-        };
-
-        window.addEventListener("storage", handleCheckpointEvent);
-
-        return () => window.removeEventListener("storage", handleCheckpointEvent);
-    }, []);
-
-    return { hasActiveCheckpoint };
-};
 
 export const CockpitNetworkConfiguration = ({
     onCritFail,

--- a/src/components/network/NetworkConfiguration.jsx
+++ b/src/components/network/NetworkConfiguration.jsx
@@ -40,6 +40,21 @@ export const NetworkConfiguration = ({
             iframe.contentWindow.addEventListener("error", exception => {
                 onCritFail({ context: _("Network plugin failed") })({ message: exception.error.message, stack: exception.error.stack });
             });
+
+            // Hide elements not needed in the installer context
+            const hideSelectors = ["#networking-graphs", ".cockpit-log-panel"];
+            const iframeDoc = iframe.contentDocument;
+            const observer = new MutationObserver(() => {
+                hideSelectors.forEach(sel => {
+                    const el = iframeDoc.querySelector(sel);
+                    if (el && el.style.display !== "none") {
+                        el.style.display = "none";
+                    }
+                });
+            });
+            observer.observe(iframeDoc.body, { childList: true, subtree: true });
+
+            return () => observer.disconnect();
         }
     }, [isIframeMounted, onCritFail]);
 

--- a/src/components/network/NetworkConfiguration.jsx
+++ b/src/components/network/NetworkConfiguration.jsx
@@ -19,7 +19,7 @@ const _ = cockpit.gettext;
 export const NetworkConfiguration = ({
     onCritFail,
 }) => {
-    const { setIsFormValid } = useContext(PageContext) ?? {};
+    const { setIsFormDisabled, setIsFormValid } = useContext(PageContext) ?? {};
     const [isIframeMounted, setIsIframeMounted] = useState(false);
     const { hasActiveCheckpoint } = useNetworkStatus();
     const backdropClass = useMaybeBackdrop();
@@ -28,7 +28,8 @@ export const NetworkConfiguration = ({
 
     useEffect(() => {
         setIsFormValid(!hasActiveCheckpoint);
-    }, [hasActiveCheckpoint, setIsFormValid]);
+        setIsFormDisabled(hasActiveCheckpoint);
+    }, [hasActiveCheckpoint, setIsFormDisabled, setIsFormValid]);
 
     useEffect(() => {
         if (isIframeMounted) {

--- a/src/components/network/NetworkConfiguration.jsx
+++ b/src/components/network/NetworkConfiguration.jsx
@@ -26,10 +26,13 @@ export const NetworkConfiguration = ({
     const handleIframeLoad = () => setIsIframeMounted(true);
     const idPrefix = "network-configuration";
 
+    const hasModal = backdropClass !== "";
+    const isBlocked = hasActiveCheckpoint || hasModal;
+
     useEffect(() => {
-        setIsFormValid(!hasActiveCheckpoint);
-        setIsFormDisabled(hasActiveCheckpoint);
-    }, [hasActiveCheckpoint, setIsFormDisabled, setIsFormValid]);
+        setIsFormValid(!isBlocked);
+        setIsFormDisabled(isBlocked);
+    }, [isBlocked, setIsFormDisabled, setIsFormValid]);
 
     useEffect(() => {
         if (isIframeMounted) {

--- a/src/components/network/NetworkConfiguration.jsx
+++ b/src/components/network/NetworkConfiguration.jsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+import cockpit from "cockpit";
+
+import React, { useContext, useEffect, useState } from "react";
+
+import { PageContext } from "../../contexts/Common.jsx";
+
+import { useMaybeBackdrop } from "../../hooks/CockpitIntegration.jsx";
+
+import { useNetworkStatus } from "./useNetworkStatus.js";
+
+import "./NetworkConfiguration.scss";
+
+const _ = cockpit.gettext;
+
+export const NetworkConfiguration = ({
+    onCritFail,
+}) => {
+    const { setIsFormValid } = useContext(PageContext) ?? {};
+    const [isIframeMounted, setIsIframeMounted] = useState(false);
+    const { hasActiveCheckpoint } = useNetworkStatus();
+    const backdropClass = useMaybeBackdrop();
+    const handleIframeLoad = () => setIsIframeMounted(true);
+    const idPrefix = "network-configuration";
+
+    useEffect(() => {
+        setIsFormValid(!hasActiveCheckpoint);
+    }, [hasActiveCheckpoint, setIsFormValid]);
+
+    useEffect(() => {
+        if (isIframeMounted) {
+            const iframe = document.getElementById("network-configuration-frame");
+            iframe.contentWindow.addEventListener("error", exception => {
+                onCritFail({ context: _("Network plugin failed") })({ message: exception.error.message, stack: exception.error.stack });
+            });
+        }
+    }, [isIframeMounted, onCritFail]);
+
+    return (
+        <div className={backdropClass + " " + idPrefix + "-page-section"}>
+            <iframe
+              src="/cockpit/@localhost/network/index.html"
+              name="network-configuration"
+              id="network-configuration-frame"
+              onLoad={handleIframeLoad}
+              className={idPrefix + "-iframe"} />
+        </div>
+    );
+};

--- a/src/components/network/NetworkConfiguration.scss
+++ b/src/components/network/NetworkConfiguration.scss
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+@import "global-variables";
+@import "../../styles/cockpit-iframe-backdrop";
+
+.network-configuration-page-section,
+.network-configuration-iframe {
+  width: 100%;
+  height: 100%;
+}
+
+.network-configuration-iframe {
+  border-radius: var(--pf-t--global--border--radius--medium);
+  border: var(--pf-t--global--border--width--box--default) solid var(--pf-t--global--border--color--default);
+  background-clip: content-box;
+}

--- a/src/components/network/index.js
+++ b/src/components/network/index.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import cockpit from "cockpit";
+
+import { NetworkConfiguration } from "./NetworkConfiguration.jsx";
+
+const _ = cockpit.gettext;
+
+export class Page {
+    _description = "Configure network connections for the system.";
+
+    constructor ({ isBootIso }) {
+        this.component = NetworkConfiguration;
+        this.id = "anaconda-screen-network";
+        this.isHidden = !isBootIso;
+        this.label = _("Network");
+        this.title = _("Network Configuration");
+    }
+}

--- a/src/components/network/useNetworkStatus.js
+++ b/src/components/network/useNetworkStatus.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+import { useEffect, useState } from "react";
+
+// Hook to track checkpoint status from the Cockpit networkmanager iframe
+export const useNetworkStatus = () => {
+    const [hasActiveCheckpoint, setHasActiveCheckpoint] = useState(false);
+
+    useEffect(() => {
+        const checkpointState = window.sessionStorage.getItem("cockpit_has_checkpoint");
+        setHasActiveCheckpoint(checkpointState === "true");
+
+        const handleCheckpointEvent = (event) => {
+            if (event.key === "cockpit_has_checkpoint") {
+                setHasActiveCheckpoint(event.newValue === "true");
+            }
+        };
+
+        window.addEventListener("storage", handleCheckpointEvent);
+
+        return () => window.removeEventListener("storage", handleCheckpointEvent);
+    }, []);
+
+    return { hasActiveCheckpoint };
+};

--- a/src/components/steps.js
+++ b/src/components/steps.js
@@ -9,6 +9,7 @@ import { debug } from "../helpers/log.js";
 import { Page as PageDateAndTime } from "./datetime/index.js";
 import { Page as PageProgress } from "./installation/index.js";
 import { Page as PageInstallationLanguage } from "./localization/index.js";
+import { Page as PageNetworkConfiguration } from "./network/index.js";
 import { Page as PageReviewConfiguration } from "./review/index.js";
 import { Page as PageSoftwareSelection } from "./software/index.js";
 import { Page as PageInstallationMethod } from "./storage/installation-method/index.js";
@@ -23,6 +24,7 @@ export const getSteps = (automatedInstall, userInterfaceConfig, args) => {
     const hiddenScreens = userInterfaceConfig.hidden_webui_pages || [];
     const stepsOrder = [
         new PageInstallationLanguage(args),
+        new PageNetworkConfiguration(args),
         new PageDateAndTime(args),
         new PageSoftwareSelection(args),
         new PageInstallationMethod(args),

--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -116,6 +116,8 @@ class VirtInstallMachineCase(MachineCase):
         self.resetLanguage()
 
         self.allow_journal_messages('.*cockpit.bridge-WARNING: Could not start ssh-agent.*')
+        # Nested Cockpit (e.g. storage/network iframes) and language changes which reload the page can log this; harmless.
+        self.allow_journal_messages("Error .* data: Connection reset by peer")
         self.installation_finished = False
 
         if not self.is_nondestructive():

--- a/test/check-network
+++ b/test/check-network
@@ -125,6 +125,69 @@ class TestNetwork(VirtInstallMachineCase):
             [con_name, "ipv4.dns", dns_server, None],
         ])
 
+    # FIXME add "" vm_setup back when
+    # https://github.com/cockpit-project/cockpit/issues/22926 is fixed
+    #@run_on_vm_setups("", "bootopts-net1")
+    @run_on_vm_setups("bootopts-net1")
+    def testWizardCockpitConfigurationPreInstall(self):
+        """
+        Description:
+            Test configuration of settings of a device from a wizard page.
+
+        Expected results:
+            - Change breaking connection raises expected confirmation dialog
+            - The configured values are correctly applied to connection profile and device.
+        """
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m)
+        n = Network(b, m)
+
+        i.open()
+
+        i.reach(i.steps.NETWORK)
+
+        iface = n.get_the_iface()
+
+        n.disable_ipv4_on_iface_wizard(iface)
+
+        i.next()
+        i.back()
+
+        # After editing, therefore persisting, the automatic default connection
+        # is updated by Cockpit (COCKPIT-1750)
+        con_name = iface
+
+        mtu_value = "1600"
+        n.set_mtu_on_iface_wizard(iface, mtu_value)
+
+        n.check_con_settings([
+            [con_name, "802-3-ethernet.mtu", mtu_value, None],
+        ])
+
+        i.next()
+        i.back()
+
+        dns_server = "8.8.8.8"
+        n.add_dns_server_to_iface_wizard(iface, dns_server)
+
+        n.check_con_settings([
+            [con_name, "ipv4.dns", dns_server, None],
+        ])
+
+        # Check that the checkpoint does not fail silently, ie check after
+        # checkpoint timeout (INSTALLER-4594)
+        time.sleep(COCKPIT_CHECKPOINT_ROLLBACK_TIME+2)
+
+        n.check_con_settings([
+            [con_name, "802-3-ethernet.mtu", mtu_value, None],
+        ])
+
+        n.check_con_settings([
+            [con_name, "ipv4.dns", dns_server, None],
+        ])
+
+
     @nondestructive
     def testCockpitJsErrorHandling(self):
         """

--- a/test/check-network
+++ b/test/check-network
@@ -126,6 +126,68 @@ class TestNetworkDestructive(VirtInstallMachineCase):
             [con_name, "ipv4.dns", dns_server, None],
         ])
 
+    # FIXME add "" vm_setup back when
+    # https://github.com/cockpit-project/cockpit/issues/22926 is fixed
+    #@run_on_vm_setups("", "bootopts-net1")
+    @run_on_vm_setups("bootopts-net1")
+    def testWizardCockpitConfigurationPreInstall(self):
+        """
+        Description:
+            Test configuration of settings of a device from a wizard page.
+
+        Expected results:
+            - Change breaking connection raises expected confirmation dialog
+            - The configured values are correctly applied to connection profile and device.
+        """
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m)
+        n = Network(b, m)
+
+        i.open()
+
+        i.reach(i.steps.NETWORK)
+
+        iface = n.get_the_iface()
+
+        n.disable_ipv4_on_iface_wizard(iface)
+
+        i.next()
+        i.back()
+
+        # After editing, therefore persisting, the automatic default connection
+        # is updated by Cockpit (COCKPIT-1750)
+        con_name = iface
+
+        mtu_value = "1600"
+        n.set_mtu_on_iface_wizard(iface, mtu_value)
+
+        n.check_con_settings([
+            [con_name, "802-3-ethernet.mtu", mtu_value, None],
+        ])
+
+        i.next()
+        i.back()
+
+        dns_server = "8.8.8.8"
+        n.add_dns_server_to_iface_wizard(iface, dns_server)
+
+        n.check_con_settings([
+            [con_name, "ipv4.dns", dns_server, None],
+        ])
+
+        # Check that the checkpoint does not fail silently, ie check after
+        # checkpoint timeout (INSTALLER-4594)
+        time.sleep(COCKPIT_CHECKPOINT_ROLLBACK_TIME+2)
+
+        n.check_con_settings([
+            [con_name, "802-3-ethernet.mtu", mtu_value, None],
+        ])
+
+        n.check_con_settings([
+            [con_name, "ipv4.dns", dns_server, None],
+        ])
+
 
 @nondestructive
 class TestNetwork(VirtInstallMachineCase):

--- a/test/helpers/installer.py
+++ b/test/helpers/installer.py
@@ -14,6 +14,7 @@ class InstallerSteps(UserDict):
     DATE_TIME = steps.DATE_TIME
     CUSTOM_MOUNT_POINT = steps.CUSTOM_MOUNT_POINT
     INSTALLATION_METHOD = steps.INSTALLATION_METHOD
+    NETWORK = steps.NETWORK
     SOFTWARE_SELECTION = steps.SOFTWARE_SELECTION
     LANGUAGE = steps.LANGUAGE
     PROGRESS = steps.PROGRESS
@@ -30,6 +31,7 @@ class InstallerSteps(UserDict):
         CUSTOM_MOUNT_POINT = self.CUSTOM_MOUNT_POINT
         DATE_TIME = self.DATE_TIME
         INSTALLATION_METHOD = self.INSTALLATION_METHOD
+        NETWORK = self.NETWORK
         SOFTWARE_SELECTION = self.SOFTWARE_SELECTION
         LANGUAGE = self.LANGUAGE
         PROGRESS = self.PROGRESS
@@ -37,7 +39,8 @@ class InstallerSteps(UserDict):
         STORAGE_CONFIGURATION = self.STORAGE_CONFIGURATION
 
         _steps_jump = {
-            LANGUAGE: [DATE_TIME],
+            LANGUAGE: [NETWORK],
+            NETWORK: [DATE_TIME],
             DATE_TIME: [SOFTWARE_SELECTION],
             SOFTWARE_SELECTION: [INSTALLATION_METHOD],
             STORAGE_CONFIGURATION: [ACCOUNTS],

--- a/test/helpers/network.py
+++ b/test/helpers/network.py
@@ -148,8 +148,7 @@ class Network():
     def enter_network(self):
         b = self.browser
         self.configure_network()
-        b._wait_present("iframe[name='cockpit-network']")
-        b.switch_to_frame("cockpit-network")
+        self._switch_to_frame("cockpit-network")
         b.wait_visible("#networking-interfaces")
 
     def exit_network(self):
@@ -245,6 +244,13 @@ class Network():
         n.wait_for_iface_setting("MTU", mtu)
         n.exit_network()
 
+    def set_mtu_on_iface_wizard(self, iface, mtu):
+        self._switch_to_frame()
+        self.select_iface(iface)
+        self.set_mtu(mtu)
+        self.wait_for_iface_setting("MTU", mtu)
+        self.browser.switch_to_top()
+
     def set_mtu(self, mtu):
         b = self.browser
         self.configure_iface_setting("MTU")
@@ -269,6 +275,12 @@ class Network():
         n.select_iface(iface)
         n.add_dns_server(ip)
         n.exit_network()
+
+    def add_dns_server_to_iface_wizard(self, iface, ip):
+        self._switch_to_frame()
+        self.select_iface(iface)
+        self.add_dns_server(ip)
+        self.browser.switch_to_top()
 
     def add_dns_server(self, ip):
         b = self.browser
@@ -296,6 +308,18 @@ class Network():
         self.disable_ipv4()
         n.keep_connection()
         n.exit_network()
+
+    def _switch_to_frame(self, name="network-configuration"):
+        b = self.browser
+        b._wait_present(f"iframe[name='{name}']")
+        b.switch_to_frame(name)
+
+    def disable_ipv4_on_iface_wizard(self, iface):
+        self._switch_to_frame()
+        self.select_iface(iface)
+        self.disable_ipv4()
+        self.keep_connection()
+        self.browser.switch_to_top()
 
     def disable_ipv4(self):
         b = self.browser

--- a/test/helpers/steps.py
+++ b/test/helpers/steps.py
@@ -3,6 +3,7 @@
 
 
 LANGUAGE = "anaconda-screen-language"
+NETWORK = "anaconda-screen-network"
 DATE_TIME = "anaconda-screen-date-time"
 INSTALLATION_METHOD = "anaconda-screen-method"
 SOFTWARE_SELECTION = "anaconda-screen-software-selection"


### PR DESCRIPTION
Draft for https://redhat.atlassian.net/browse/INSTALLER-4650

Requires https://github.com/rhinstaller/anaconda/pull/6989

If we follow on this path:

- [x] fix tests
- [x] add tests
- [x] ~remove network configuration from header menu. (Maybe it would be good to keep it there as an addon to a new simple connectivity UI in Wizard)~
- [x] rebase upon ks support

Notes:

- the patchset disables navigation elements also for iframe modal dialogs but not all of them pass the event to anaconda: https://github.com/cockpit-project/cockpit/pull/22963 (in the video: the "Keep Connection" dialog does, the MTU setting dialog does not.)
- The PR / solution does not seem to be very viable as it seems we will move towards integration of a component provided by Cockpit. (UPDATE: or maybe rather keep using iframe integration and parametrize the screen for Anaconda). Although I am sceptical about minimal Wizard page being sustainable - I can see requests for at least adding virtual devices configuration appearing quickly - it could make sense to have minimal network page (mainly for Wireless configuration, maybe even anaconda-webui specific code if it does not fit to Cockpit, or special anaconda-wizard mode of cockpit module) and keep the access to the Cockpit module available (from the wizard page or even the page header menu as it is currently).
- The part disabling the navigation can be useful also for different (non-iframe) approaches. UPDATE: it was moved to a separate PR: https://github.com/rhinstaller/anaconda-webui/pull/1231

Video:

NOTE: the disabling of navigation on sidebar on the video is now moved to a separate PR: https://github.com/rhinstaller/anaconda-webui/pull/1231

https://github.com/user-attachments/assets/4b13cc59-5017-4205-8116-cf8433c52127

