### PR TITLE
Really disable navigation on wizard side navigation bar

### DIFF
--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -56,6 +56,7 @@ export const AnacondaWizard = ({ currentStepId, dispatch, isFetching, onCritFail
             let stepProps = {
                 id: s.id,
                 isAriaDisabled: isFormDisabled || isFetching,
+                isDisabled: isFormDisabled || isFetching,
                 isHidden: s.isHidden || s.isFinal,
                 isVisited,
                 name: s.label,

--- a/test/helpers/installer.py
+++ b/test/helpers/installer.py
@@ -178,6 +178,7 @@ class Installer():
 
     def click_step_on_sidebar(self, step=None):
         step = step or self.get_current_page()
+        self.browser.wait_visible(f"#{step}:not([disabled])")
         self.browser.click(f"#{step}")
 
     @log_step()


### PR DESCRIPTION
We should disable the navigation on wizard sidebar for real when isFormDisabled is true. Currently it is still possible to click away from the screen on the sidebar.

This is problematic for example when checkpoint is in progress in network configuration, where destroying the iframe can lead to broken connectivity.

Related: INSTALLER-4650

The problem: see on the video below that it is possible to move away from the screen during a checkpoint in progress via sidebar navigation:

The desired state is on [the video in a PR](https://github.com/rhinstaller/anaconda-webui/pull/1225#issue-4121956073) from which I split out this one.

https://github.com/user-attachments/assets/0b6f016f-ee72-42b4-908d-bd9381cfc493

