### PR TITLE
tests: workaround wrongly detected 'use-configured-storage-kickstart' scenario

### DIFF
--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -210,7 +210,8 @@ class VirtInstallMachineCase(MachineCase):
         self.removeAllDisks()
         s.dbus_reset_scenario()
         # Create an AUTOMATIC partitioning because MANUAL partitioning tests might take the last created
-        s.dbus_create_partitioning("AUTOMATIC")
+        if len(s.dbus_get_created_partitioning()) != 0:
+            s.dbus_create_partitioning("AUTOMATIC")
         s.dbus_reset_selected_disks()
         # CLEAR_PARTITIONS_DEFAULT = -1
         s.dbus_set_initialization_mode(-1)

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -459,8 +459,8 @@ class StorageDBus():
             {STORAGE_OBJECT_PATH} \
             {STORAGE_INTERFACE} CreatedPartitioning')
 
-        res = ret[ret.find("[") + 1:ret.rfind("]")].split()
-        return [item.strip('"') for item in res]
+        data = ret.split(" ")
+        return [i.replace('"', '').replace('\n', '') for i in data[2:]]
 
     def dbus_set_initialization_mode(self, value):
         self.machine.execute(f'busctl --address="{self._bus_address}" \


### PR DESCRIPTION
The new 'Storage configured via kickstart' scenario, automatically gets preset when the is one created partitioning when loading the app. This is safe guess for real world scenarios and also mimics the GTK UI behavior.

The non-destructive tests, as they can't clean up created partitioning sometime hit this issue causing flakes by wrong scenario selection.

To fix this, make sure that there is never a single partitioning when starting the nondestructive tests, by not creating it in the storage cleanup.