### PR TITLE
webui-desktop: redirect browser stdout/stderr to a log file

### DIFF
--- a/webui-desktop
+++ b/webui-desktop
@@ -240,7 +240,8 @@ else
                 XDG_SESSION_TYPE=wayland \
                 XDG_RUNTIME_DIR="${INSTALLER_XDG_RUNTIME_DIR}" \
                 WAYLAND_DISPLAY="${ROOT_WAYLAND_SOCKET}" \
-                dbus-run-session -- "${BROWSER[@]}" "$WEBUI_URL" &
+                dbus-run-session -- "${BROWSER[@]}" "$WEBUI_URL" \
+                >/tmp/webui-browser.log 2>&1 &
             BLOCK_ON_PID=$!
         fi
     else


### PR DESCRIPTION
The browser process inherits the stdout pipe from webui-desktop back
to anaconda's proc.communicate(). When exitGui() kills webui-desktop,
the cleanup trap kills the browser, but Firefox may survive (it forks
into its own process group). While Firefox is alive it holds the pipe
open, so proc.communicate() never returns, anaconda never exits, and
the atexit handler that calls systemctl reboot is never reached.

Redirect the browser's stdout/stderr to webui-browser.log file so that
even if Firefox outlives webui-desktop, it cannot block anaconda's pipe.