### PR TITLE
workflows: reduce dependabot workflow secret access

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,6 +1,6 @@
 name: update node_modules
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize, labeled]
 
 env:


### PR DESCRIPTION
The dependabot workflow is expected to only run for branches on our own origin.