### PR TITLE
webui-desktop: detect graphical session via WAYLAND_DISPLAY only

### DIFF
--- a/webui-desktop
+++ b/webui-desktop
@@ -187,7 +187,7 @@ else
 
     USER_GRAPHICAL_SESSION_AVAILABLE=0
     if [ "$USER_SESSION_AVAILABLE" = "1" ]; then
-        if printf '%s\n' "${user_environment[@]}" | grep -qE '^(DISPLAY|WAYLAND_DISPLAY)='; then
+        if printf '%s\n' "${user_environment[@]}" | grep -q '^WAYLAND_DISPLAY='; then
             USER_GRAPHICAL_SESSION_AVAILABLE=1
         fi
     fi


### PR DESCRIPTION
When reading systemd --user show-environment, set USER_GRAPHICAL_SESSION_AVAILABLE only if WAYLAND_DISPLAY is present, not DISPLAY alone. This improves opening the browser for local WebUI installs on Wayland-only sessions and makes local WebUI install more reliable.