### PR TITLE
Drop Sizzle and align tests with Cockpit testlib without Sizzle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,11 +131,6 @@ install: $(DIST_TEST) po/LINGUAS
 	mkdir -p $(DESTDIR)/usr/lib/systemd/system/
 	cp src/systemd/webui-cockpit-ws.service $(DESTDIR)/usr/lib/systemd/system/
 
-# required for running integration tests;
-TEST_NPMS = \
-	node_modules/sizzle \
-	$(NULL)
-
 dist: $(TARFILE)
 	@ls -1 $(TARFILE)
 
@@ -147,7 +142,7 @@ $(TARFILE): $(DIST_TEST) $(SPEC)
 	tar --xz $(TAR_ARGS) -cf $(TARFILE) --transform 's,^,$(RPM_NAME)/,' \
 		--exclude '*.in' --exclude test/reference \
 		$$(git ls-files | grep -v node_modules) \
-		$(COCKPIT_REPO_FILES) $(NODE_MODULES_TEST) $(SPEC) $(TEST_NPMS) VERSION.txt \
+		$(COCKPIT_REPO_FILES) $(NODE_MODULES_TEST) $(SPEC) VERSION.txt \
 		dist/
 
 srpm: $(TARFILE) $(SPEC)

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "jed": "1.1.1",
     "qunit": "2.25.0",
     "sass": "1.98.0",
-    "sizzle": "2.3.10",
     "stdio": "2.1.3",
     "stylelint": "17.6.0",
     "stylelint-config-recommended-scss": "17.0.1",

--- a/src/components/review/StorageReview.jsx
+++ b/src/components/review/StorageReview.jsx
@@ -130,18 +130,24 @@ const DeviceRow = ({ disk, isReviewScreen }) => {
                 )
                 : ""
         );
-
+        const encryptedText = hasEncryptedAncestor(devices, device) ? (isReformattedMountPoint ? _("encrypt") : _("encrypted")) : "";
+        const deviceText = cockpit.format("$0$1", parents.join(", "), showMaybeType());
         return (
             {
                 columns: [
-                    { title: cockpit.format("$0$1", parents.join(", "), showMaybeType()), width: 17 },
+                    { title: deviceText, width: 17 },
                     { title: size, width: 15 },
                     { title: action, width: 17 },
-                    { title: hasEncryptedAncestor(devices, device) ? (isReformattedMountPoint ? _("encrypt") : _("encrypted")) : "", width: 17 },
+                    { title: encryptedText, width: 17 },
                     { title: mount, width: 17 },
                     ...(isReviewScreen ? [{ title: helperText, width: 17 }] : []),
                 ],
-                props: { key: device },
+                props: {
+                    "data-device": deviceText,
+                    "data-mount": mount,
+                    ...(encryptedText ? { "data-encrypted": encryptedText } : {}),
+                    key: device
+                },
             }
         );
     };
@@ -177,6 +183,8 @@ const DeviceRow = ({ disk, isReviewScreen }) => {
                     ...(isReviewScreen ? [{ title: "" }] : []),
                 ],
                 props: {
+                    "data-action": actionDescriptionText,
+                    "data-device": device,
                     key: device + actionType,
                 },
             }

--- a/src/components/reviewWizardPageClasses.js
+++ b/src/components/reviewWizardPageClasses.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import { Page as PageDateAndTime } from "./datetime/index.js";
+import { Page as PageInstallationLanguage } from "./localization/index.js";
+import { Page as PageSoftwareSelection } from "./software/index.js";
+import { Page as PageInstallationMethod } from "./storage/installation-method/index.js";
+import { Page as PageAccounts } from "./users/index.js";
+
+/**
+ * Wizard Page classes shown on the review screen, in an order that matches the review UI
+ * (accounts before installation type and storage).
+ * Kept separate from components/index.jsx so the review screen does not import the review
+ * Page re-export (which would create a circular module dependency).
+ */
+export const REVIEW_WIZARD_PAGE_CLASSES = [
+    PageInstallationLanguage,
+    PageDateAndTime,
+    PageSoftwareSelection,
+    PageAccounts,
+    PageInstallationMethod,
+];
+
+/**
+ * Same pages as REVIEW_WIZARD_PAGE_CLASSES, grouped to match the review screen layout
+ * (system settings vs installation and storage).
+ */
+export const REVIEW_WIZARD_PAGE_GROUPS = [
+    [PageInstallationLanguage, PageDateAndTime, PageSoftwareSelection, PageAccounts],
+    [PageInstallationMethod],
+];
+
+/**
+ * Completion state for each entry in REVIEW_WIZARD_PAGE_CLASSES (same order).
+ * Hooks are called explicitly so call order stays valid for the rules of hooks.
+ *
+ * @param {{ automatedInstall: boolean, hiddenScreens: string[], payloadType?: string }} ctx
+ */
+export function useReviewWizardPagesCompletion (ctx) {
+    return [
+        PageInstallationLanguage.useReviewPageComplete(ctx),
+        PageDateAndTime.useReviewPageComplete(ctx),
+        PageSoftwareSelection.useReviewPageComplete(ctx),
+        PageAccounts.useReviewPageComplete(ctx),
+        PageInstallationMethod.useReviewPageComplete(ctx),
+    ];
+}

--- a/src/components/software/SoftwareSelectionReviewDescription.jsx
+++ b/src/components/software/SoftwareSelectionReviewDescription.jsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import { useContext, useMemo } from "react";
+
+import { PayloadContext } from "../../contexts/Common.jsx";
+
+export const SoftwareSelectionReviewDescription = () => {
+    const { environments, selection } = useContext(PayloadContext) ?? {};
+
+    return useMemo(() => {
+        const envId = selection?.environment;
+        if (!envId) {
+            return "";
+        }
+        const env = environments?.find(e => e.id === envId);
+        return env?.name || envId;
+    }, [environments, selection?.environment]);
+};

--- a/src/components/storage/installation-method/ReclaimSpaceModal.jsx
+++ b/src/components/storage/installation-method/ReclaimSpaceModal.jsx
@@ -319,7 +319,7 @@ const getDeviceRow = (disk, devices, level = 0, unappliedActions, setUnappliedAc
                 { title: size },
                 { title: deviceActions }
             ],
-            props: { className: classNames.join(" "), key: disk },
+            props: { className: classNames.join(" "), "data-device": device.name.v, key: disk },
         },
         ...device.children.v.map((child) => getDeviceRow(child, devices, level + 1, unappliedActions, setUnappliedActions))
     ];

--- a/src/components/storage/installation-method/StorageInstallationReviewSummary.jsx
+++ b/src/components/storage/installation-method/StorageInstallationReviewSummary.jsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import React from "react";
+import { Stack } from "@patternfly/react-core/dist/esm/layouts/Stack/index.js";
+
+import { IncompleteStepIndicator } from "../../review/Common.jsx";
+import { StorageReview, StorageReviewNote } from "../../review/StorageReview.jsx";
+
+export const StorageInstallationReviewSummary = ({ complete }) => (
+    <>
+        <Stack hasGutter>
+            <StorageReview isReviewScreen />
+            {!complete && <IncompleteStepIndicator />}
+        </Stack>
+        <StorageReviewNote />
+    </>
+);

--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -392,7 +392,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         dev = "vda"
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/", "vda3", "1.70 GB", False, None, False, 4)
+        r.check_disk_row(dev, "/", "vda3", "1.70 GB", False)
         r.check_disk_mount_point_helper_text(dev, "/", "Needs at least")
 
         i.check_next_disabled()
@@ -477,7 +477,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         r.check_disk_row(dev, "/boot/efi", "vda1", "99.6 MB", False)
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False)
-        r.check_disk_row(dev, "/", "vda3", "14.9 GB", False, None, False, 4)
+        r.check_disk_row(dev, "/", "vda3", "14.9 GB", False)
 
         # Check fstab
         fstab = m.execute("cat /etc/fstab")
@@ -536,7 +536,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False)
-        r.check_disk_row(dev, "/", "vda3", "15.0 GB", False, None, False, 4)
+        r.check_disk_row(dev, "/", "vda3", "15.0 GB", False)
         r.check_disk_row(dev, "/home", "vda3", "15.0 GB", False)
 
         # Check fstab

--- a/test/check-storage-mountpoints-raid
+++ b/test/check-storage-mountpoints-raid
@@ -189,7 +189,7 @@ class TestStorageMountPointsRAID(VirtInstallMachineCase):
         r.check_disk("vda", "16.1 GB vda (Virtio Block Device)")
         r.check_disk_row("vda", "/boot", "vda2", "1.00 GB", False)
         r.check_disk("MDRAID-SOMERAID", "32.2 GB MDRAID-SOMERAID (MDRAID set (stripe))")
-        r.check_disk_row("MDRAID-SOMERAID", "/", "SOMERAID1", "32.2 GB", False)
+        r.check_disk_row("MDRAID-SOMERAID", "/", "SOMERAID1, RAID", "32.2 GB", False)
 
 
 if __name__ == '__main__':

--- a/test/check-storage-reclaim
+++ b/test/check-storage-reclaim
@@ -75,7 +75,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
 
         # Test cancelled reclaim is not taking effect
         s.reclaim_remove_device("vda2")
-        s.reclaim_check_action_present("vda2", "delete", True)
+        s.reclaim_check_action_present("vda2", "delete")
         s.reclaim_modal_cancel()
 
         # Continue without reclaiming space
@@ -122,29 +122,29 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         s.reclaim_check_available_space("2.06 MB")
 
         # Check that all partitions are present
-        s.reclaim_check_device_row("vda (Virtio", "", "disk", "16.1 GB")
-        s.reclaim_check_device_row("vda1", "", "biosboot", "1.05 MB")
-        s.reclaim_check_device_row("vda2", "", "ext4", "6.44 GB")
-        s.reclaim_check_device_row("vda3", "", "btrfs", "5.37 GB")
-        s.reclaim_check_device_row("vda4", "", "btrfs", "4.29 GB")
+        s.reclaim_check_device_row("vda", deviceType="disk", space="16.1 GB")
+        s.reclaim_check_device_row("vda1", deviceType="biosboot", space="1.05 MB")
+        s.reclaim_check_device_row("vda2", deviceType="ext4", space="6.44 GB")
+        s.reclaim_check_device_row("vda3", deviceType="btrfs", space="5.37 GB")
+        s.reclaim_check_device_row("vda4", deviceType="btrfs", space="4.29 GB")
 
         # Check that deleting a disk will delete all contained partitions
-        s.reclaim_remove_device("vda (Virtio")
+        s.reclaim_remove_device("vda")
         for device in ["vda1", "vda2", "vda3"]:
             s.reclaim_check_action_present(device, "delete")
 
         s.reclaim_check_available_space("16.1 GB")
 
         # Undo disk device deletion
-        s.reclaim_undo_action("vda (Virtio")
+        s.reclaim_undo_action("vda")
         for device in ["vda1", "vda2", "vda3"]:
-            s.reclaim_check_action_present(device, "delete", False)
+            s.reclaim_check_action_present(device, "delete", present=False)
 
         s.reclaim_check_available_space("2.06 MB")
 
         # Check that actions for devices whose parents are marked for deletion are not sent to blivet
         s.reclaim_remove_device("vda4")
-        s.reclaim_remove_device("vda (Virtio")
+        s.reclaim_remove_device("vda")
         s.reclaim_modal_submit()
 
         i.back()
@@ -153,14 +153,14 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
 
         # Remove one partition and allocate enough space for the installation
         s.reclaim_remove_device("vda2")
-        s.reclaim_check_action_present("vda2", "delete", True)
+        s.reclaim_check_action_present("vda2", "delete")
         s.reclaim_check_available_space("6.44 GB")
 
         # Check that deleting a parent disk which contains partitions marked for deletion
         # correctly calculates the available space
-        s.reclaim_remove_device("vda (Virtio")
+        s.reclaim_remove_device("vda")
         s.reclaim_check_available_space("16.1 GB")
-        s.reclaim_undo_action("vda (Virtio")
+        s.reclaim_undo_action("vda")
         s.reclaim_check_available_space("6.44 GB")
 
         s.reclaim_modal_submit()
@@ -202,14 +202,14 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         s.reclaim_check_available_space("2.06 MB")
 
         # Check that shrinking action is only available for partitions
-        s.reclaim_check_action_button_present("vda (Virtio", "shrink", False)
+        s.reclaim_check_action_button_present("vda", "shrink", present=False)
         for device in ["vda2"]:
-            s.reclaim_check_action_button_present(device, "shrink", True)
+            s.reclaim_check_action_button_present(device, "shrink")
 
         for device in ["vda3", "vda4"]:
             # Shrinking Btrfs partitions is not yet supported by blivet:
             # https://bugzilla.redhat.com/show_bug.cgi?id=962143
-            s.reclaim_check_action_button_present(device, "shrink", True, True)
+            s.reclaim_check_action_button_present(device, "shrink", disabled=True)
 
         # Shrink a partition too much and expect a warning
         s.reclaim_shrink_device("vda2", "0.100", "6.44")
@@ -223,7 +223,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         # Undo the shrink actions
         for device in ["vda2"]:
             s.reclaim_undo_action(device)
-            s.reclaim_check_action_present(device, "shrink", False)
+            s.reclaim_check_action_present(device, "shrink", present=False)
 
         s.reclaim_check_available_space("2.06 MB")
 
@@ -277,19 +277,19 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         s.reclaim_set_checkbox(True)
         i.next(next_page=i.steps.INSTALLATION_METHOD)
 
-        s.reclaim_check_device_row("vda (Virtio", "", "disk", "16.1 GB")
-        s.reclaim_check_device_row("vda1", "", "vfat", "512 MB")
-        s.reclaim_check_device_row("vda2", "", "swap", "2.00 GB")
-        s.reclaim_check_device_row("vda3", "", "ext4", "8.00 GB")
-        s.reclaim_check_device_row("vda4", "", "extended partition", "")
-        s.reclaim_check_device_row("vda5", "", "btrfs", "2.50 GB")
-        s.reclaim_check_device_row("", "BTRFS", "btrfs volume", "")
-        s.reclaim_check_device_row("", "@subvol1", "btrfs subvolume", "")
-        s.reclaim_check_device_row("", "@subvol2", "btrfs subvolume", "")
+        s.reclaim_check_device_row("vda", deviceType="disk", space="16.1 GB")
+        s.reclaim_check_device_row("vda1", deviceType="vfat", space="512 MB")
+        s.reclaim_check_device_row("vda2", deviceType="swap", space="2.00 GB")
+        s.reclaim_check_device_row("vda3", deviceType="ext4", space="8.00 GB")
+        s.reclaim_check_device_row("vda4", deviceType="extended partition")
+        s.reclaim_check_device_row("vda5", deviceType="btrfs", space="2.50 GB")
+        s.reclaim_check_device_row("BTRFS", name="BTRFS", deviceType="btrfs volume")
+        s.reclaim_check_device_row("@subvol1", name="@subvol1", deviceType="btrfs subvolume")
+        s.reclaim_check_device_row("@subvol2", name="@subvol2", deviceType="btrfs subvolume")
 
         # Remove only the logical Btrfs partition (vda5)
         s.reclaim_remove_device("vda5")
-        s.reclaim_check_action_present("vda5", "delete", True)
+        s.reclaim_check_action_present("vda5", "delete")
 
         # Add a pixel test for the reclaim space dialog
         b.assert_pixels(
@@ -347,9 +347,9 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
             ignore=["#reclaim-space-modal-hint"],
         )
 
-        s.reclaim_check_device_row("vda1", "", "luks", "4.29 GB", locked=True)
-        s.reclaim_check_action_button_present("vda1", "shrink", True, True)
-        s.reclaim_check_action_button_present("vda1", "delete", True)
+        s.reclaim_check_device_row("vda1", deviceType="luks", space="4.29 GB", locked=True)
+        s.reclaim_check_action_button_present("vda1", "shrink", disabled=True)
+        s.reclaim_check_action_button_present("vda1", "delete")
 
     @disk_images([("fedora-rawhide", 15)])
     def testDeletePartition(self):
@@ -443,12 +443,12 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         s.reclaim_set_checkbox(True)
         i.next(next_page=i.steps.INSTALLATION_METHOD)
 
-        s.reclaim_shrink_device("vda1", "7", rowIndex=3)
+        s.reclaim_shrink_device("vda1", "7")
         s.reclaim_modal_submit()
 
         i.reach(i.steps.REVIEW)
         # Don't specify the exact original size as this might change with image refreshes
-        r.check_disk_row("vda", parent="vda1", size="7.00 GB", action="resized from")
+        r.check_disk_row("vda", parent="vda1", size="7.00 GB", action="resized from 11.2 GB")
         r.check_resized_system("Ubuntu", ["vda1"])
 
         i.reach_on_sidebar(i.steps.LANGUAGE)
@@ -457,11 +457,11 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         s.reclaim_set_checkbox(True)
         i.next(next_page=i.steps.INSTALLATION_METHOD)
 
-        s.reclaim_shrink_device("vda1", "7,10", rowIndex=3, ariaLabel="zmenšit")
+        s.reclaim_shrink_device("vda1", "7,10", ariaLabel="zmenšit")
         s.reclaim_modal_submit()
 
         i.reach(i.steps.REVIEW)
-        r.check_disk_row("vda", parent="vda1", size="7,10 GB", action="změněna velikost z")
+        r.check_disk_row("vda", parent="vda1", size="7,10 GB", action="změněna velikost z 11,2 GB")
 
 
 if __name__ == '__main__':

--- a/test/check-storage-reclaim-e2e
+++ b/test/check-storage-reclaim-e2e
@@ -37,7 +37,7 @@ class TestStorageReclaim_E2E(DualBootHelper_E2E, VirtInstallMachineCase):
         s.reclaim_set_checkbox(True)
         i.next(next_page=i.steps.INSTALLATION_METHOD)
 
-        s.reclaim_shrink_device("vda1", "7", rowIndex=3)
+        s.reclaim_shrink_device("vda1", "7")
         s.reclaim_modal_submit()
 
         i.reach(i.steps.REVIEW)

--- a/test/helpers/network.py
+++ b/test/helpers/network.py
@@ -3,7 +3,9 @@
 
 import os
 import sys
+from types import SimpleNamespace
 
+from netlib import NetworkCase
 from testlib import wait
 
 HELPERS_DIR = os.path.dirname(__file__)
@@ -228,12 +230,12 @@ class Network():
         ])
 
     def configure_iface_setting(self, setting_title):
-        b = self.browser
-        b.click(f"dt:contains('{setting_title}') + dd button")
+        shim = SimpleNamespace(browser=self.browser)
+        NetworkCase.configure_iface_setting(shim, setting_title)
 
     def wait_for_iface_setting(self, setting_title, setting_value):
-        b = self.browser
-        b.wait_in_text(f"dt:contains('{setting_title}') + dd", setting_value)
+        shim = SimpleNamespace(browser=self.browser)
+        NetworkCase.wait_for_iface_setting(shim, setting_title, setting_value)
 
     def set_mtu_on_iface(self, iface, mtu):
         n = self

--- a/test/helpers/review.py
+++ b/test/helpers/review.py
@@ -55,23 +55,30 @@ class Review(NetworkDBus, StorageDBus):
         self,
         disk,
         mount_point="", parent="", size="", reformat="",
-        fs_type=None, is_encrypted=False, rowIndex=None,
+        fs_type=None, is_encrypted=False,
         action="", prefix=""
     ):
-        action = f"format as {fs_type}" if reformat else action or "mount"
+        table = f"{prefix} #storage-review-table-{disk}".strip()
+
+        action_text = f"format as {fs_type}" if reformat else action or "mount"
         encrypt_text = "encrypted" if is_encrypted and not reformat else "encrypt" if is_encrypted and reformat else ""
-        self.browser.wait_visible(
-            f"{prefix} table[aria-label={disk}] "
-            f"tbody{'' if rowIndex is None else f':nth-child({rowIndex})'} "
-            f"td:contains('{parent}') + "
-            f"td:contains('{size}') + "
-            f"td:contains('{action}') + "
-            f"td:contains('{encrypt_text}') + "
-            f"td:contains('{mount_point}')"
-        )
+
+        # Action rows (delete/resize) have data-action and no data-mount;
+        # mount rows have data-mount and no data-action.
+        # Detect action rows: explicit non-default action, no mount_point, no reformat.
+        is_action_row = action and action not in ("mount", "biosboot") and not mount_point and not reformat
+        row = f'{table} tr[data-device="{parent}"]'
+        if is_action_row:
+            row = f'{row}[data-action="{action_text}"]'
+        if mount_point:
+            row = f'{row}[data-mount="{mount_point}"]'
+        if is_encrypted:
+            row = f'{row}[data-encrypted="{encrypt_text}"]'
+
+        self.browser.wait_visible(row)
 
     def check_disk_row_not_present(self, disk, mount):
-        self.browser.wait_not_present(f"table[aria-label={disk}] td:contains({mount})")
+        self.browser.wait_not_present(f'#storage-review-table-{disk} tr[data-mount="{mount}"]')
 
     def check_deleted_system(self, os_name):
         self.browser.wait_in_text(f"#{self._step}-target-storage-note li", os_name)

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -516,49 +516,57 @@ class StorageScenario():
 
 
 class StorageReclaimDialog():
+    _TABLE = "#reclaim-space-modal-table"
+
     def __init__(self, browser):
         self.browser = browser
 
-    def reclaim_check_device_row(self, location, name=None, deviceType=None, space=None, locked=False):
-        self.browser.wait_visible(
-            "#reclaim-space-modal-table "
-            f"td[data-label=Location]:contains({location}) + " +
-            (f"td[data-label=Name]:contains({name}) + " if deviceType != "disk" else "") +
-            f"td[data-label=Type]:contains({deviceType}) + "
-            f"td[data-label=Space]:contains({space})"
-        )
+    def _reclaim_row_selector(self, device):
+        """CSS selector for the table row identified by data-device attribute."""
+        return f'{self._TABLE} tr[data-device="{device}"]'
+
+    def _reclaim_row_btn_selector(self, device, aria_label):
+        return f'{self._reclaim_row_selector(device)} button[aria-label="{aria_label}"]'
+
+    def reclaim_check_device_row(self, device, location=None, name=None, deviceType=None, space=None, locked=False):
+        row = self._reclaim_row_selector(device)
+        self.browser.wait_visible(row)
+
+        if location is not None:
+            self.browser.wait_in_text(f'{row} td[data-label="Location"]', location)
+        if name is not None:
+            self.browser.wait_in_text(f'{row} td[data-label="Name"]', name)
+        if deviceType is not None:
+            self.browser.wait_in_text(f'{row} td[data-label="Type"]', deviceType)
+        if space is not None:
+            self.browser.wait_in_text(f'{row} td[data-label="Space"]', space)
         if locked:
-            self.browser.wait_visible(
-                f"#reclaim-space-modal-table tr:contains({name}) "
-                f"td[data-label=Type] .reclaim-space-modal-device-locked"
-            )
+            self.browser.wait_visible(f'{row} .reclaim-space-modal-device-locked')
 
     def reclaim_remove_device(self, device):
-        self.browser.click(f"#reclaim-space-modal-table tr:contains('{device}') button[aria-label='delete']")
+        self.browser.click(self._reclaim_row_btn_selector(device, "delete"))
 
     def reclaim_check_action_button_present(self, device, action, present=True, disabled=False):
-        disabled_sel = "[aria-disabled='true']" if disabled else ":not([aria-disabled='true'])"
-        selector = (
-            "#reclaim-space-modal-table "
-            f"tr:contains('{device}') "
-            f"button[aria-label='{action}']{disabled_sel}"
-        )
-
-        if present:
-            self.browser.wait_visible(selector)
+        sel = self._reclaim_row_btn_selector(device, action)
+        if not present:
+            self.browser.wait_not_present(sel)
+            return
+        self.browser.wait_visible(sel)
+        if disabled:
+            self.browser.wait_js_cond(
+                f'document.querySelector({json.dumps(sel)})?.ariaDisabled === "true"'
+            )
         else:
-            self.browser.wait_not_present(selector)
+            self.browser.wait_js_cond(
+                f'document.querySelector({json.dumps(sel)})?.ariaDisabled !== "true"'
+            )
 
     def reclaim_modal_submit_and_check_warning(self, warning):
         self.browser.click("button:contains('Reclaim space')")
         self.browser.wait_in_text("#reclaim-space-modal .pf-v6-c-alert", warning)
 
-    def reclaim_shrink_device(self, device, new_size, current_size=None, rowIndex=None, ariaLabel="shrink"):
-        self.browser.click(
-            "#reclaim-space-modal-table "
-            f"tbody{'' if rowIndex is None else f':nth-child({rowIndex})'} "
-            f"tr:contains('{device}') button[aria-label='{ariaLabel}']"
-        )
+    def reclaim_shrink_device(self, device, new_size, current_size=None, ariaLabel="shrink"):
+        self.browser.click(self._reclaim_row_btn_selector(device, ariaLabel))
         self.browser.wait_visible("#popover-reclaim-space-modal-shrink-body")
         if current_size is not None:
             self.browser.wait_val("#reclaim-space-modal-shrink-input", current_size)
@@ -571,22 +579,17 @@ class StorageReclaimDialog():
         self.browser.set_input_text("#reclaim-space-modal-shrink-input", new_size)
         self.browser.click("#reclaim-space-modal-shrink-button")
         self.browser.wait_not_present("#reclaim-space-modal-shrink-slider")
-        self.reclaim_check_action_present(device, ariaLabel, rowIndex=rowIndex)
+        self.reclaim_check_action_present(device, ariaLabel)
 
-    def reclaim_check_action_present(self, device, action, present=True, rowIndex=None):
-        selector = (
-            "#reclaim-space-modal-table "
-            f"tbody{'' if rowIndex is None else f':nth-child({rowIndex})'} "
-            f"tr:contains('{device}') "
-            "td:nth-child(5) "  # Actions column
-        )
+    def reclaim_check_action_present(self, device, action, present=True):
+        row = self._reclaim_row_selector(device)
         if present:
-            self.browser.wait_in_text(selector, action)
+            self.browser.wait_in_text(row, action)
         else:
-            self.browser.wait_not_in_text(selector, action)
+            self.browser.wait_not_in_text(row, action)
 
     def reclaim_undo_action(self, device):
-        self.browser.click(f"#reclaim-space-modal-table tr:contains('{device}') button[aria-label='undo']")
+        self.browser.click(self._reclaim_row_btn_selector(device, "undo"))
 
     def reclaim_check_available_space(self, space):
         self.browser.wait_text("#reclaim-space-modal-hint-available-free-space", space)


### PR DESCRIPTION
Remove the unused Sizzle devDependency and refresh the node_modules cache.

Cockpit test-functions only supports a single :contains() per selector when Sizzle is absent.

- reclaim: add data-device attribute to table rows and rewrite StorageReclaimDialog helpers to use CSS selectors instead of JS IIFEs
- review: assert disk table rows via wait_js_cond over #storage-review-table-<disk> tbody tr text
- network: call NetworkCase helpers through a SimpleNamespace(browser=...) so behaviour matches netlib without duplicating [data-label] selectors