### PR TITLE
users: implement granular Accounts actions

### DIFF
--- a/src/actions/users-actions.js
+++ b/src/actions/users-actions.js
@@ -12,37 +12,63 @@ import {
 import { canModifyRootConfiguration, canModifyUserConfiguration } from "../helpers/users.js";
 import { parseAnacondaConfBool } from "../helpers/utils.js";
 
-export const setUsersAction = (users) => ({
-    payload: { users },
-    type: "SET_USERS"
+export const setUsersAction = (payload) => ({
+    payload,
+    type: "SET_USERS",
 });
 
-/** @param {{ automatedInstall?: boolean, conf?: object }} args  Bootstrap from `Application` / `UsersClient.init` */
-export const getUsersAction = (args = {}) => async (dispatch) => {
-    const { automatedInstall, conf } = args;
+export const setFirstUserAction = ({ confirmPassword, gecos, name, password }) => ({
+    payload: { confirmPassword, gecos, name, password },
+    type: "SET_FIRST_USER",
+});
+
+export const clearUsersAction = () => ({
+    type: "CLEAR_USERS",
+});
+
+export const setRootAccountAction = ({ isRootEnabled, rootConfirmPassword, rootPassword }) => ({
+    payload: { isRootEnabled, rootConfirmPassword, rootPassword },
+    type: "SET_ROOT_ACCOUNT",
+});
+
+export const setUserConfigurationPolicyAction = (payload) => ({
+    payload,
+    type: "SET_USER_CONFIGURATION_POLICY",
+});
+
+export const getUserConfigurationAction = ({ automatedInstall, conf }) => async (dispatch) => {
+    const [userList, canChangeRootPassword] = await Promise.all([
+        getUsers(),
+        getCanChangeRootPassword(),
+    ]);
+    const usersSpecifiedByKickstart = (userList ?? []).length > 0;
+    const canChangeRootPasswordBool = !!canChangeRootPassword;
+
     const canChangeRoot = parseAnacondaConfBool(conf?.["User Interface"]?.can_change_root);
     const canChangeUsers = parseAnacondaConfBool(conf?.["User Interface"]?.can_change_users);
-    const [users, isRootAccountLocked, canChangeRootPassword] = await Promise.all([
-        getUsers(),
-        getIsRootAccountLocked(),
-        getCanChangeRootPassword()
-    ]);
-    const userList = users ?? [];
-    const usersSpecifiedByKickstart = userList.length > 0;
-
-    dispatch(setUsersAction({
-        canChangeRootPassword: !!canChangeRootPassword,
+    dispatch(setUserConfigurationPolicyAction({
         canModifyRootConfiguration: canModifyRootConfiguration({
-            automatedInstall: !!automatedInstall,
+            automatedInstall,
             canChangeRoot,
-            canChangeRootPassword,
+            canChangeRootPassword: canChangeRootPasswordBool,
         }),
         canModifyUserConfiguration: canModifyUserConfiguration({
             canChangeUsers,
             usersSpecifiedByKickstart,
         }),
+        usersSpecifiedByKickstart,
+    }));
+};
+
+export const getUsersAction = () => async (dispatch) => {
+    const [users, isRootAccountLocked] = await Promise.all([
+        getUsers(),
+        getIsRootAccountLocked(),
+    ]);
+    const userList = users ?? [];
+
+    dispatch(setUsersAction({
         isRootEnabled: !isRootAccountLocked,
         users: userList,
-        usersSpecifiedByKickstart,
     }));
 };

--- a/src/apis/users.js
+++ b/src/apis/users.js
@@ -4,7 +4,7 @@
  */
 import cockpit from "cockpit";
 
-import { getUsersAction } from "../actions/users-actions.js";
+import { getUserConfigurationAction, getUsersAction } from "../actions/users-actions.js";
 
 import { error } from "../helpers/log.js";
 import { _callClient, _getProperty, _setProperty, objectFromDbus } from "./helpers.js";
@@ -43,13 +43,15 @@ export class UsersClient {
     }
 
     /**
-     * @param {object} args  Bootstrap args from `Application` (`conf`, `automatedInstall`).
+     * @param {object} args  Bootstrap args from `Application` (`conf`, etc.).
      */
     init (args = {}) {
         this.client.addEventListener(
             "close", () => error("Users client closed")
         );
-        return this.dispatch(getUsersAction(args));
+
+        this.dispatch(getUsersAction());
+        this.dispatch(getUserConfigurationAction({ automatedInstall: args.automatedInstall, conf: args.conf }));
     }
 }
 

--- a/src/components/users/Accounts.jsx
+++ b/src/components/users/Accounts.jsx
@@ -22,7 +22,9 @@ import {
 } from "../../apis/users.js";
 
 import {
-    setUsersAction,
+    clearUsersAction,
+    setFirstUserAction,
+    setRootAccountAction,
 } from "../../actions/users-actions.js";
 
 import {
@@ -119,8 +121,8 @@ const isUserNameWithInvalidCharacters = (userName) => {
 };
 
 const CreateAccount = ({
+    dispatch,
     idPrefix,
-    setAccounts,
     setIsUserValid,
     setSkipAccountCreation,
     skipAccountCreation,
@@ -203,20 +205,20 @@ const CreateAccount = ({
 
     useEffect(() => {
         if (skipAccountCreation) {
-            setAccounts({ confirmPassword, password, users: [] });
+            dispatch(clearUsersAction());
             return;
         }
-        const first = { ...(accounts.users?.[0] ?? {}), gecos: fullName, name: userName };
-        const users = accounts.users?.length
-            ? [first, ...accounts.users.slice(1)]
-            : (userName || fullName ? [first] : []);
-        setAccounts({ confirmPassword, password, users });
+        dispatch(setFirstUserAction({
+            confirmPassword,
+            gecos: fullName,
+            name: userName,
+            password,
+        }));
     }, [
-        accounts.users,
         confirmPassword,
+        dispatch,
         fullName,
         password,
-        setAccounts,
         skipAccountCreation,
         userName,
     ]);
@@ -347,8 +349,8 @@ const RootAccountReadonly = ({ idPrefix, setIsRootValid }) => {
 };
 
 const RootAccountEditable = ({
+    dispatch,
     idPrefix,
-    setAccounts,
     setIsRootValid,
 }) => {
     const accounts = useContext(UsersContext);
@@ -379,7 +381,7 @@ const RootAccountEditable = ({
           id={idPrefix + "-enable-root-account"}
           label={_("Enable root account")}
           isChecked={isRootAccountEnabled}
-          onChange={(_event, enable) => setAccounts({ isRootEnabled: enable })}
+          onChange={(_event, enable) => dispatch(setRootAccountAction({ isRootEnabled: enable }))}
           body={content}
         />
     );
@@ -402,8 +404,8 @@ const RootAccountEditable = ({
     );
 
     useEffect(() => {
-        setAccounts({ rootConfirmPassword: confirmPassword, rootPassword: password });
-    }, [setAccounts, password, confirmPassword]);
+        dispatch(setRootAccountAction({ rootConfirmPassword: confirmPassword, rootPassword: password }));
+    }, [confirmPassword, dispatch, password]);
 
     return (
         <FormSection
@@ -414,7 +416,7 @@ const RootAccountEditable = ({
     );
 };
 
-const RootAccount = ({ idPrefix, setAccounts, setIsRootValid }) => {
+const RootAccount = ({ dispatch, idPrefix, setIsRootValid }) => {
     const accounts = useContext(UsersContext);
     const canModifyRootConfiguration = accounts.canModifyRootConfiguration !== false;
 
@@ -428,8 +430,8 @@ const RootAccount = ({ idPrefix, setAccounts, setIsRootValid }) => {
     }
     return (
         <RootAccountEditable
+          dispatch={dispatch}
           idPrefix={idPrefix}
-          setAccounts={setAccounts}
           setIsRootValid={setIsRootValid}
         />
     );
@@ -443,7 +445,6 @@ export const Accounts = ({
     const [isUserValid, setIsUserValid] = useState();
     const [isRootValid, setIsRootValid] = useState();
     const accounts = useContext(UsersContext);
-    const setAccounts = useMemo(() => args => dispatch(setUsersAction(args)), [dispatch]);
     const [skipAccountCreation, setSkipAccountCreation] = useState(false);
 
     const kickstartUsersReadOnly = accounts.usersSpecifiedByKickstart === true &&
@@ -460,7 +461,6 @@ export const Accounts = ({
     }, [
         accounts.isRootEnabled,
         accounts.canModifyUserConfiguration,
-        accounts.usersSpecifiedByKickstart,
         isRootValid,
         isUserValid,
         setIsFormValid,
@@ -485,17 +485,17 @@ export const Accounts = ({
                 )
                 : (
                     <CreateAccount
+                      dispatch={dispatch}
                       idPrefix={idPrefix + "-create-account"}
                       setIsUserValid={setIsUserValid}
-                      setAccounts={setAccounts}
                       setSkipAccountCreation={setSkipAccountCreation}
                       skipAccountCreation={skipAccountCreation}
                     />
                 )}
             <RootAccount
+              dispatch={dispatch}
               idPrefix={idPrefix + "-root-account"}
               setIsRootValid={setIsRootValid}
-              setAccounts={setAccounts}
             />
         </Form>
     );

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -81,7 +81,6 @@ export const payloadInitialState = {
 /* FIXME: This is not storing information from the anaconda backend, but also non-submitted user input */
 /* The Store is meant to store information from the backend only */
 export const usersInitialState = {
-    canChangeRootPassword: true,
     canModifyRootConfiguration: true,
     canModifyUserConfiguration: true,
     confirmPassword: "",
@@ -263,9 +262,52 @@ export const payloadReducer = (state = payloadInitialState, action) => {
     }
 };
 
+const updateFirstUserData = (currentUsers, { gecos, name }) => {
+    const list = currentUsers ?? [];
+    const first = { ...(list[0] ?? {}), gecos, name };
+    const tail = list.slice(1);
+    return (name || gecos || tail.length > 0)
+        ? [first, ...tail]
+        : [];
+};
+
+const updateRootData = (state, { isRootEnabled, rootConfirmPassword, rootPassword }) => {
+    const next = { ...state };
+    if (isRootEnabled !== undefined) {
+        next.isRootEnabled = isRootEnabled;
+    }
+    if (rootConfirmPassword !== undefined) {
+        next.rootConfirmPassword = rootConfirmPassword;
+    }
+    if (rootPassword !== undefined) {
+        next.rootPassword = rootPassword;
+    }
+    return next;
+};
+
 export const usersReducer = (state = usersInitialState, action) => {
     if (action.type === "SET_USERS") {
-        return { ...state, ...action.payload.users };
+        return { ...state, ...action.payload };
+    } else if (action.type === "SET_USER_CONFIGURATION_POLICY") {
+        return { ...state, ...action.payload };
+    } else if (action.type === "SET_FIRST_USER") {
+        const { confirmPassword, gecos, name, password } = action.payload;
+        const users = updateFirstUserData(state.users, { gecos, name });
+        return {
+            ...state,
+            confirmPassword: confirmPassword !== undefined ? confirmPassword : state.confirmPassword,
+            password: password !== undefined ? password : state.password,
+            users,
+        };
+    } else if (action.type === "CLEAR_USERS") {
+        return {
+            ...state,
+            confirmPassword: "",
+            password: "",
+            users: [],
+        };
+    } else if (action.type === "SET_ROOT_ACCOUNT") {
+        return updateRootData(state, action.payload);
     } else {
         return state;
     }


### PR DESCRIPTION
Replace broad setUsersAction usage on the Accounts page with focused action creators. In this way we no longer rebuild the whole users array on every keystroke retriggering effects and causing a render loop.