### PR TITLE
users: fix Accounts re-renders

### DIFF
--- a/src/actions/users-actions.js
+++ b/src/actions/users-actions.js
@@ -12,10 +12,26 @@ import {
 import { canModifyRootConfiguration, canModifyUserConfiguration } from "../helpers/users.js";
 import { parseAnacondaConfBool } from "../helpers/utils.js";
 
-export const setUsersAction = (users) => ({
-    payload: { users },
-    type: "SET_USERS"
+export const setUsersAction = (payload) => ({
+    payload,
+    type: "SET_USERS",
 });
+
+/**
+ * Patch users slice from the Accounts UI (draft first user, root passwords, etc.).
+ */
+export const applyUsersPatch = (patch = {}) => (dispatch) => {
+    const { firstUser, ...rest } = patch;
+    const payload = { ...rest };
+
+    if (firstUser !== undefined) {
+        payload.firstUser = firstUser;
+    }
+
+    if (Object.keys(payload).length > 0) {
+        dispatch(setUsersAction(payload));
+    }
+};
 
 /** @param {{ automatedInstall?: boolean, conf?: object }} args  Bootstrap from `Application` / `UsersClient.init` */
 export const getUsersAction = (args = {}) => async (dispatch) => {

--- a/src/components/users/Accounts.jsx
+++ b/src/components/users/Accounts.jsx
@@ -22,7 +22,7 @@ import {
 } from "../../apis/users.js";
 
 import {
-    setUsersAction,
+    applyUsersPatch,
 } from "../../actions/users-actions.js";
 
 import {
@@ -206,13 +206,15 @@ const CreateAccount = ({
             setAccounts({ confirmPassword, password, users: [] });
             return;
         }
-        const first = { ...(accounts.users?.[0] ?? {}), gecos: fullName, name: userName };
-        const users = accounts.users?.length
-            ? [first, ...accounts.users.slice(1)]
-            : (userName || fullName ? [first] : []);
-        setAccounts({ confirmPassword, password, users });
+        setAccounts({
+            firstUser: {
+                confirmPassword,
+                gecos: fullName,
+                name: userName,
+                password,
+            },
+        });
     }, [
-        accounts.users,
         confirmPassword,
         fullName,
         password,
@@ -443,7 +445,7 @@ export const Accounts = ({
     const [isUserValid, setIsUserValid] = useState();
     const [isRootValid, setIsRootValid] = useState();
     const accounts = useContext(UsersContext);
-    const setAccounts = useMemo(() => args => dispatch(setUsersAction(args)), [dispatch]);
+    const setAccounts = useMemo(() => args => dispatch(applyUsersPatch(args)), [dispatch]);
     const [skipAccountCreation, setSkipAccountCreation] = useState(false);
 
     const kickstartUsersReadOnly = accounts.usersSpecifiedByKickstart === true &&

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -265,7 +265,31 @@ export const payloadReducer = (state = payloadInitialState, action) => {
 
 export const usersReducer = (state = usersInitialState, action) => {
     if (action.type === "SET_USERS") {
-        return { ...state, ...action.payload.users };
+        const { firstUser, ...rest } = action.payload;
+        let next = { ...state, ...rest };
+        if (firstUser !== undefined) {
+            const existing = state.users ?? [];
+            const [currentFirst = {}, ...tail] = existing;
+            const updatedFirst = {
+                ...currentFirst,
+                gecos: firstUser.gecos,
+                name: firstUser.name,
+            };
+            const updatedUsers = (firstUser.name || firstUser.gecos || tail.length > 0)
+                ? [updatedFirst, ...tail]
+                : [];
+            next = {
+                ...next,
+                users: updatedUsers,
+            };
+            if (firstUser.password !== undefined) {
+                next.password = firstUser.password;
+            }
+            if (firstUser.confirmPassword !== undefined) {
+                next.confirmPassword = firstUser.confirmPassword;
+            }
+        }
+        return next;
     } else {
         return state;
     }


### PR DESCRIPTION
`setUsersAction` is now an async thunk that reads the current user list from the backend, merges the first user when needed, copies only defined keys (`assignDefined`), and dispatches when the payload is non-empty.