### PR TITLE
[do not merge] PoC for remote installation support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,17 @@ install: $(DIST_TEST) po/LINGUAS
 	cp browser-ext $(DESTDIR)/usr/libexec/anaconda
 	cp gnome-control-center-ext $(DESTDIR)/usr/libexec/anaconda
 	cp src/scripts/cockpit-coproc-wrapper.sh $(DESTDIR)/usr/libexec/anaconda/
+	cp src/scripts/cockpit-pin-auth $(DESTDIR)/usr/libexec/anaconda/
 	mkdir -p $(DESTDIR)/usr/lib/systemd/system/
 	cp src/systemd/webui-cockpit-ws.service $(DESTDIR)/usr/lib/systemd/system/
+	cp src/systemd/cockpit-pin-auth@.service $(DESTDIR)/usr/lib/systemd/system/
+	cp src/systemd/cockpit-pin-auth.socket $(DESTDIR)/usr/lib/systemd/system/
+	mkdir -p $(DESTDIR)/etc/cockpit
+	cp src/config/cockpit.conf $(DESTDIR)/etc/cockpit/
+	# static files for custom login page must be on this destination 	
+	mkdir -p $(DESTDIR)/usr/share/cockpit/static/
+	ln -sf ../anaconda-webui/login.js $(DESTDIR)/usr/share/cockpit/static/login-anaconda.js
+	ln -sf ../anaconda-webui/login.css $(DESTDIR)/usr/share/cockpit/static/login-anaconda.css
 
 # required for running integration tests;
 TEST_NPMS = \

--- a/Makefile
+++ b/Makefile
@@ -134,14 +134,15 @@ install: $(DIST_TEST) po/LINGUAS
 	cp src/systemd/webui-cockpit-ws.service $(DESTDIR)/usr/lib/systemd/system/
 	cp src/systemd/cockpit-pin-auth@.service $(DESTDIR)/usr/lib/systemd/system/
 	cp src/systemd/cockpit-pin-auth.socket $(DESTDIR)/usr/lib/systemd/system/
-	mkdir -p $(DESTDIR)/etc/cockpit
-	cp src/config/cockpit.conf $(DESTDIR)/etc/cockpit/
 	# static files for custom login page must be on this destination
 	mkdir -p $(DESTDIR)/usr/share/cockpit/static/
 	ln -sf ../anaconda-webui/login.js $(DESTDIR)/usr/share/cockpit/static/login-anaconda.js
 	ln -sf ../anaconda-webui/login.css $(DESTDIR)/usr/share/cockpit/static/login-anaconda.css
 	mkdir -p $(DESTDIR)/etc/anaconda/cockpit/conf.d/
 	cp src/config/cockpit/cockpit.conf $(DESTDIR)/etc/anaconda/cockpit/cockpit.conf
+	# Staged config, not active by default — webui-desktop copies it to conf.d/ at runtime
+	mkdir -p $(DESTDIR)/usr/share/anaconda/cockpit/conf.d/
+	cp src/config/cockpit/conf.d/50-remote-auth.conf $(DESTDIR)/usr/share/anaconda/cockpit/conf.d/
 
 dist: $(TARFILE)
 	@ls -1 $(TARFILE)

--- a/Makefile
+++ b/Makefile
@@ -128,9 +128,18 @@ install: $(DIST_TEST) po/LINGUAS
 	cp browser-ext $(DESTDIR)/usr/libexec/anaconda
 	cp gnome-control-center-ext $(DESTDIR)/usr/libexec/anaconda
 	cp src/scripts/cockpit-coproc-wrapper.sh $(DESTDIR)/usr/libexec/anaconda/
+	cp src/scripts/cockpit-pin-auth $(DESTDIR)/usr/libexec/anaconda/
 	cp src/scripts/anaconda-cockpit-conf-merge $(DESTDIR)/usr/libexec/anaconda/
 	mkdir -p $(DESTDIR)/usr/lib/systemd/system/
 	cp src/systemd/webui-cockpit-ws.service $(DESTDIR)/usr/lib/systemd/system/
+	cp src/systemd/cockpit-pin-auth@.service $(DESTDIR)/usr/lib/systemd/system/
+	cp src/systemd/cockpit-pin-auth.socket $(DESTDIR)/usr/lib/systemd/system/
+	mkdir -p $(DESTDIR)/etc/cockpit
+	cp src/config/cockpit.conf $(DESTDIR)/etc/cockpit/
+	# static files for custom login page must be on this destination
+	mkdir -p $(DESTDIR)/usr/share/cockpit/static/
+	ln -sf ../anaconda-webui/login.js $(DESTDIR)/usr/share/cockpit/static/login-anaconda.js
+	ln -sf ../anaconda-webui/login.css $(DESTDIR)/usr/share/cockpit/static/login-anaconda.css
 	mkdir -p $(DESTDIR)/etc/anaconda/cockpit/conf.d/
 	cp src/config/cockpit/cockpit.conf $(DESTDIR)/etc/anaconda/cockpit/cockpit.conf
 

--- a/build.js
+++ b/build.js
@@ -49,7 +49,7 @@ function watchDirs (dir, onChange) {
 
 const context = await esbuild.context({
     bundle: true,
-    entryPoints: ["./src/index.js"],
+    entryPoints: ["./src/index.js", "./src/login.js"],
     external: [
         "*.woff", "*.woff2", "*.jpg",
         "@patternfly/react-core/src/components/assets/*.svg",
@@ -74,6 +74,7 @@ const context = await esbuild.context({
                 { from: ["./images/qr-code-feedback.svg"], to: ["./qr-code-feedback.svg"] },
                 { from: ["./src/manifest.json"], to: ["./manifest.json"] },
                 { from: ["./src/index.html"], to: ["./index.html"] },
+                { from: ["./src/login.html"], to: ["./login.html"] },
                 { from: ["./VERSION.txt"], to: ["./VERSION.txt"] },
             ]
         }),
@@ -82,7 +83,8 @@ const context = await esbuild.context({
             quietDeps: true,
         }),
         cockpitPoEsbuildPlugin(),
-        cockpitCompressPlugin(),
+        // for some reason cockpit does not support compressed login.(js|css)
+        cockpitCompressPlugin({ exclude: /login\.(js|css)$/}),
         cockpitRsyncEsbuildPlugin({ dest: packageJson.name }),
 
         {

--- a/build.js
+++ b/build.js
@@ -49,7 +49,7 @@ function watchDirs (dir, onChange) {
 
 const context = await esbuild.context({
     bundle: true,
-    entryPoints: ["./src/index.js"],
+    entryPoints: ["./src/index.js", "./src/login.js"],
     external: ["*.woff", "*.woff2", "*.jpg", "*.svg", "../../assets*"],
     legalComments: "external", // Move all legal comments to a .LEGAL.txt file
     loader: {
@@ -69,6 +69,7 @@ const context = await esbuild.context({
                 { from: ["./images/qr-code-feedback.svg"], to: ["./qr-code-feedback.svg"] },
                 { from: ["./src/manifest.json"], to: ["./manifest.json"] },
                 { from: ["./src/index.html"], to: ["./index.html"] },
+                { from: ["./src/login.html"], to: ["./login.html"] },
                 { from: ["./VERSION.txt"], to: ["./VERSION.txt"] },
             ]
         }),
@@ -77,7 +78,8 @@ const context = await esbuild.context({
             quietDeps: true,
         }),
         cockpitPoEsbuildPlugin(),
-        cockpitCompressPlugin(),
+        // for some reason cockpit does not support compressed login.(js|css)
+        cockpitCompressPlugin({ exclude: /login\.(js|css)$/}),
         cockpitRsyncEsbuildPlugin({ dest: packageJson.name }),
 
         {

--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -65,7 +65,15 @@ exit 0
 %files
 %dir %{_datadir}/cockpit/anaconda-webui
 %doc README.rst
-%license LICENSE dist/index.js.LEGAL.txt
+%license LICENSE dist/index.js.LEGAL.txt dist/login.js.LEGAL.txt
+%{_datadir}/cockpit/anaconda-webui/login.html
+%{_datadir}/cockpit/anaconda-webui/login.js
+%{_datadir}/cockpit/anaconda-webui/login.js.map
+%{_datadir}/cockpit/anaconda-webui/login.js.LEGAL.txt
+%{_datadir}/cockpit/anaconda-webui/login.css
+%{_datadir}/cockpit/anaconda-webui/login.css.map
+%{_datadir}/cockpit/static/login-anaconda.js
+%{_datadir}/cockpit/static/login-anaconda.css
 %{_datadir}/cockpit/anaconda-webui/qr-code-feedback.svg
 %{_datadir}/cockpit/anaconda-webui/index.js.LEGAL.txt
 %{_datadir}/cockpit/anaconda-webui/index.html
@@ -77,6 +85,7 @@ exit 0
 %{_datadir}/cockpit/anaconda-webui/po.*.js.gz
 %{_datadir}/cockpit/anaconda-webui/VERSION.txt
 %{_libexecdir}/anaconda/cockpit-coproc-wrapper.sh
+%{_libexecdir}/anaconda/cockpit-pin-auth
 %dir %{_datadir}/anaconda/firefox-theme
 %dir %{_datadir}/anaconda/firefox-theme/default
 %dir %{_datadir}/anaconda/firefox-theme/default/chrome
@@ -94,6 +103,9 @@ exit 0
 %{_datadir}/applications/extlinks.desktop
 %{_datadir}/applications/anaconda-gnome-control-center.desktop
 %{_unitdir}/webui-cockpit-ws.service
+%{_unitdir}/cockpit-pin-auth.socket
+%{_unitdir}/cockpit-pin-auth@.service
+%config(noreplace) /etc/cockpit/cockpit.conf
 
 
 # The changelog is automatically generated and merged

--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -89,6 +89,9 @@ exit 0
 %dir /etc/anaconda/cockpit
 %config(noreplace) /etc/anaconda/cockpit/cockpit.conf
 %dir /etc/anaconda/cockpit/conf.d
+%dir %{_datadir}/anaconda/cockpit
+%dir %{_datadir}/anaconda/cockpit/conf.d
+%{_datadir}/anaconda/cockpit/conf.d/50-remote-auth.conf
 %{_libexecdir}/anaconda/cockpit-pin-auth
 %dir %{_datadir}/anaconda/firefox-theme
 %dir %{_datadir}/anaconda/firefox-theme/default
@@ -109,7 +112,6 @@ exit 0
 %{_unitdir}/webui-cockpit-ws.service
 %{_unitdir}/cockpit-pin-auth.socket
 %{_unitdir}/cockpit-pin-auth@.service
-%config(noreplace) /etc/cockpit/cockpit.conf
 
 
 # The changelog is automatically generated and merged

--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -65,7 +65,15 @@ exit 0
 %files
 %dir %{_datadir}/cockpit/anaconda-webui
 %doc README.rst
-%license LICENSE dist/index.js.LEGAL.txt
+%license LICENSE dist/index.js.LEGAL.txt dist/login.js.LEGAL.txt
+%{_datadir}/cockpit/anaconda-webui/login.html
+%{_datadir}/cockpit/anaconda-webui/login.js
+%{_datadir}/cockpit/anaconda-webui/login.js.map
+%{_datadir}/cockpit/anaconda-webui/login.js.LEGAL.txt
+%{_datadir}/cockpit/anaconda-webui/login.css
+%{_datadir}/cockpit/anaconda-webui/login.css.map
+%{_datadir}/cockpit/static/login-anaconda.js
+%{_datadir}/cockpit/static/login-anaconda.css
 %{_datadir}/cockpit/anaconda-webui/qr-code-feedback.svg
 %{_datadir}/cockpit/anaconda-webui/index.js.LEGAL.txt
 %{_datadir}/cockpit/anaconda-webui/index.html
@@ -81,6 +89,7 @@ exit 0
 %dir /etc/anaconda/cockpit
 %config(noreplace) /etc/anaconda/cockpit/cockpit.conf
 %dir /etc/anaconda/cockpit/conf.d
+%{_libexecdir}/anaconda/cockpit-pin-auth
 %dir %{_datadir}/anaconda/firefox-theme
 %dir %{_datadir}/anaconda/firefox-theme/default
 %dir %{_datadir}/anaconda/firefox-theme/default/chrome
@@ -98,6 +107,9 @@ exit 0
 %{_datadir}/applications/extlinks.desktop
 %{_datadir}/applications/anaconda-gnome-control-center.desktop
 %{_unitdir}/webui-cockpit-ws.service
+%{_unitdir}/cockpit-pin-auth.socket
+%{_unitdir}/cockpit-pin-auth@.service
+%config(noreplace) /etc/cockpit/cockpit.conf
 
 
 # The changelog is automatically generated and merged

--- a/src/components/login/LoginPage.jsx
+++ b/src/components/login/LoginPage.jsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+import cockpit from "cockpit";
+
+import React, { useState } from "react";
+import { Bullseye, ValidatedOptions } from "@patternfly/react-core";
+import {
+    ActionGroup,
+    Button,
+    Form,
+    FormGroup,
+    TextInputGroup,
+    TextInputGroupMain,
+    TextInputGroupUtilities,
+} from "@patternfly/react-core/dist/esm/components";
+import {
+    Alert,
+    AlertActionCloseButton
+} from "@patternfly/react-core/dist/esm/components/Alert";
+import {
+    Card,
+    CardBody,
+    CardTitle
+} from "@patternfly/react-core/dist/esm/components/Card";
+import EyeIcon from "@patternfly/react-icons/dist/esm/icons/eye-icon";
+import EyeSlashIcon from "@patternfly/react-icons/dist/esm/icons/eye-slash-icon";
+
+const _ = cockpit.gettext;
+
+export const LoginPage = () => {
+    const [pin, setPin] = useState("");
+    const [error, setError] = useState("");
+    const [isLoading, setIsLoading] = useState(false);
+    const [pinHidden, setPinHidden] = useState(true);
+
+    const handleSubmit = async (event) => {
+        event.preventDefault();
+        setError("");
+
+        if (!pin) {
+            setError(_("Please enter a PIN"));
+            return;
+        }
+
+        setIsLoading(true);
+
+        const headers = {
+            Authorization: "Basic " + window.btoa(unescape(encodeURIComponent(pin))),
+        };
+
+        try {
+            const response = await fetch("/cockpit/login", {
+                method: "GET",
+                headers
+            });
+
+            if (!response.ok) {
+                throw new Error("Authentication failed");
+            }
+
+            window.location = "/cockpit/@localhost/anaconda-webui/index.html";
+        } catch (err) {
+            console.error("Login error:", err);
+            setError(_("Invalid PIN. Please try again."));
+            setIsLoading(false);
+        }
+    };
+
+    return (
+
+        <Bullseye>
+            <Card>
+                <CardTitle>{_("Enter PIN to access the installer")}</CardTitle>
+                <CardBody>
+                    {error && (
+                        <Alert
+                          variant="danger"
+                          isInline
+                          title={error}
+                          actionClose={<AlertActionCloseButton onClose={() => setError("")} />}
+                        />
+                    )}
+                    <Form onSubmit={handleSubmit}>
+                        <FormGroup isRequired fieldId="pin-input">
+                            <TextInputGroup validated={error ? ValidatedOptions.error : undefined}>
+                                <TextInputGroupMain
+                                  isRequired
+                                  type={pinHidden ? "password" : "text"}
+                                  id="pin-input"
+                                  name="pin"
+                                  value={pin}
+                                  onChange={(_event, value) => setPin(value)}
+                                  placeholder={_("Enter PIN")}
+
+                                />
+                                <TextInputGroupUtilities>
+                                    <Button
+                                      variant="plain"
+                                      onClick={() => setPinHidden(!pinHidden)}
+                                      aria-label={pinHidden ? _("Show password") : _("Hide password")}
+                                      icon={pinHidden ? <EyeIcon /> : <EyeSlashIcon />}
+                                    />
+                                </TextInputGroupUtilities>
+                            </TextInputGroup>
+                        </FormGroup>
+                        <ActionGroup>
+                            <Button
+                              variant="primary"
+                              type="submit"
+                              isBlock
+                              isLoading={isLoading}
+                              isDisabled={isLoading}
+                            >
+                                {_("Log in")}
+                            </Button>
+                        </ActionGroup>
+                    </Form>
+                </CardBody>
+            </Card>
+        </Bullseye>
+
+    );
+};

--- a/src/components/login/LoginPage.jsx
+++ b/src/components/login/LoginPage.jsx
@@ -5,15 +5,12 @@
 import cockpit from "cockpit";
 
 import React, { useState } from "react";
-import { Bullseye, ValidatedOptions } from "@patternfly/react-core";
+import { Bullseye } from "@patternfly/react-core";
 import {
     ActionGroup,
     Button,
     Form,
     FormGroup,
-    TextInputGroup,
-    TextInputGroupMain,
-    TextInputGroupUtilities,
 } from "@patternfly/react-core/dist/esm/components";
 import {
     Alert,
@@ -24,8 +21,10 @@ import {
     CardBody,
     CardTitle
 } from "@patternfly/react-core/dist/esm/components/Card";
-import EyeIcon from "@patternfly/react-icons/dist/esm/icons/eye-icon";
-import EyeSlashIcon from "@patternfly/react-icons/dist/esm/icons/eye-slash-icon";
+import { InputGroup, InputGroupItem } from "@patternfly/react-core/dist/esm/components/InputGroup";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
+import { EyeIcon } from "@patternfly/react-icons/dist/esm/icons/eye-icon";
+import { EyeSlashIcon } from "@patternfly/react-icons/dist/esm/icons/eye-slash-icon";
 
 const _ = cockpit.gettext;
 
@@ -47,7 +46,9 @@ export const LoginPage = () => {
         setIsLoading(true);
 
         const headers = {
-            Authorization: "Basic " + window.btoa(unescape(encodeURIComponent(pin))),
+            // Cockpit Basic auth format: user:password\0known_hosts
+            // https://github.com/cockpit-project/cockpit/blob/25dd89e3d168861cd19acd50237f9c8884341cc5/pkg/static/login.js#L666
+            Authorization: `Basic ${window.btoa(unescape(encodeURIComponent(`:${pin}\0`)))}`,
         };
 
         try {
@@ -84,26 +85,28 @@ export const LoginPage = () => {
                     )}
                     <Form onSubmit={handleSubmit}>
                         <FormGroup isRequired fieldId="pin-input">
-                            <TextInputGroup validated={error ? ValidatedOptions.error : undefined}>
-                                <TextInputGroupMain
-                                  isRequired
-                                  type={pinHidden ? "password" : "text"}
-                                  id="pin-input"
-                                  name="pin"
-                                  value={pin}
-                                  onChange={(_event, value) => setPin(value)}
-                                  placeholder={_("Enter PIN")}
-
-                                />
-                                <TextInputGroupUtilities>
+                            <InputGroup>
+                                <InputGroupItem isFill>
+                                    <TextInput
+                                      isRequired
+                                      type={pinHidden ? "password" : "text"}
+                                      id="pin-input"
+                                      name="pin"
+                                      value={pin}
+                                      onChange={(_event, value) => setPin(value)}
+                                      placeholder={_("Enter PIN")}
+                                    />
+                                </InputGroupItem>
+                                <InputGroupItem>
                                     <Button
-                                      variant="plain"
+                                      variant="control"
                                       onClick={() => setPinHidden(!pinHidden)}
                                       aria-label={pinHidden ? _("Show password") : _("Hide password")}
-                                      icon={pinHidden ? <EyeIcon /> : <EyeSlashIcon />}
-                                    />
-                                </TextInputGroupUtilities>
-                            </TextInputGroup>
+                                    >
+                                        {pinHidden ? <EyeIcon /> : <EyeSlashIcon />}
+                                    </Button>
+                                </InputGroupItem>
+                            </InputGroup>
                         </FormGroup>
                         <ActionGroup>
                             <Button

--- a/src/config/cockpit.conf
+++ b/src/config/cockpit.conf
@@ -1,0 +1,2 @@
+[Basic]
+Command = /usr/libexec/anaconda/cockpit-pin-auth

--- a/src/config/cockpit.conf
+++ b/src/config/cockpit.conf
@@ -1,2 +1,7 @@
+# Cockpit authentication handler for Anaconda installer
+
+[WebService]
+CustomLoginPage = /usr/share/cockpit/anaconda-webui/
+
 [Basic]
 Command = /usr/libexec/anaconda/cockpit-pin-auth

--- a/src/config/cockpit.conf
+++ b/src/config/cockpit.conf
@@ -1,7 +1,0 @@
-# Cockpit authentication handler for Anaconda installer
-
-[WebService]
-CustomLoginPage = /usr/share/cockpit/anaconda-webui/
-
-[Basic]
-Command = /usr/libexec/anaconda/cockpit-pin-auth

--- a/src/config/cockpit/conf.d/50-remote-auth.conf
+++ b/src/config/cockpit/conf.d/50-remote-auth.conf
@@ -1,0 +1,15 @@
+# Copyright (C) 2025 Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Cockpit PIN authentication for remote WebUI access.
+# This file is NOT active by default. It is shipped to
+# /usr/share/anaconda/cockpit/conf.d/ and only copied into the
+# active /etc/anaconda/cockpit/conf.d/ at runtime by webui-desktop
+# when inst.webui.remote is set with a password and
+# inst.webui.remote.noauth is not set.
+
+[WebService]
+CustomLoginPage = /usr/share/cockpit/anaconda-webui/
+
+[Basic]
+Command = /usr/libexec/anaconda/cockpit-pin-auth

--- a/src/login.html
+++ b/src/login.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title translate>Anaconda Web UI</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta insert="dynamic_content_here" />
+
+    <link rel="stylesheet" href="cockpit/static/login-anaconda.css">
+    <link rel="stylesheet" href="cockpit/static/branding.css">
+
+    <script type="text/javascript" src="cockpit/static/login-anaconda.js"></script>
+</head>
+
+<body class="pf-m-redhat-font anaconda">
+    <div class="ct-page-fill" id="app"></div>
+</body>
+</html>

--- a/src/login.js
+++ b/src/login.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+import cockpit from "cockpit";
+
+import "cockpit-dark-theme";
+
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+import { LoginPage } from "./components/login/LoginPage.jsx";
+
+import "./components/app.scss";
+import "../pkg/lib/patternfly/patternfly-6-cockpit.scss";
+import "../pkg/lib/patternfly/patternfly-6-overrides.scss";
+
+const _ = cockpit.gettext;
+
+document.addEventListener("DOMContentLoaded", () => {
+    const root = createRoot(document.getElementById("app"));
+    root.render(<LoginPage />);
+    document.documentElement.setAttribute("dir", cockpit.language_direction);
+    document.documentElement.setAttribute("lang", convertToCockpitLang({ lang: cockpit.language }));
+});

--- a/src/login.js
+++ b/src/login.js
@@ -10,12 +10,11 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 
 import { LoginPage } from "./components/login/LoginPage.jsx";
+import { convertToCockpitLang } from "./helpers/language.js";
 
 import "./components/app.scss";
 import "../pkg/lib/patternfly/patternfly-6-cockpit.scss";
 import "../pkg/lib/patternfly/patternfly-6-overrides.scss";
-
-const _ = cockpit.gettext;
 
 document.addEventListener("DOMContentLoaded", () => {
     const root = createRoot(document.getElementById("app"));

--- a/src/scripts/cockpit-coproc-wrapper.sh
+++ b/src/scripts/cockpit-coproc-wrapper.sh
@@ -12,5 +12,5 @@ WEBUI_ADDRESS=$1
 # Start cockpit-bridge in unconfined context via su using coproc
 coproc BRIDGE { cockpit-bridge; }
 
-# Start cockpit-ws connected to the coproc
-exec /usr/libexec/cockpit-ws -p 80 -a "$WEBUI_ADDRESS" --no-tls --local-session=- <&${BRIDGE[0]} >&${BRIDGE[1]}
+# Start cockpit-ws connected to the coproc (with PIN authentication)
+exec /usr/libexec/cockpit-ws -p 80 -a "$WEBUI_ADDRESS" --no-tls <&${BRIDGE[0]} >&${BRIDGE[1]}

--- a/src/scripts/cockpit-coproc-wrapper.sh
+++ b/src/scripts/cockpit-coproc-wrapper.sh
@@ -12,6 +12,6 @@ WEBUI_ADDRESS=$1
 # Start cockpit-bridge in unconfined context via su using coproc
 coproc BRIDGE { cockpit-bridge; }
 
-# Start cockpit-ws connected to the coproc
+# Start cockpit-ws connected to the coproc (with PIN authentication)
 # TLS settings are now in /etc/anaconda/cockpit/cockpit.conf (AllowUnencrypted)
-exec /usr/libexec/cockpit-ws -p 80 -a "$WEBUI_ADDRESS" --local-session=- <&${BRIDGE[0]} >&${BRIDGE[1]}
+exec /usr/libexec/cockpit-ws -p 80 -a "$WEBUI_ADDRESS" <&${BRIDGE[0]} >&${BRIDGE[1]}

--- a/src/scripts/cockpit-coproc-wrapper.sh
+++ b/src/scripts/cockpit-coproc-wrapper.sh
@@ -12,6 +12,12 @@ WEBUI_ADDRESS=$1
 # Start cockpit-bridge in unconfined context via su using coproc
 coproc BRIDGE { cockpit-bridge; }
 
-# Start cockpit-ws connected to the coproc (with PIN authentication)
-# TLS settings are now in /etc/anaconda/cockpit/cockpit.conf (AllowUnencrypted)
-exec /usr/libexec/cockpit-ws -p 80 -a "$WEBUI_ADDRESS" <&${BRIDGE[0]} >&${BRIDGE[1]}
+# When auth is not enabled, use --local-session=- to connect
+# directly to the bridge (skips cockpit authentication).
+WS_EXTRA_ARGS=()
+if [[ "${WEBUI_AUTH:-0}" != "1" ]]; then
+    WS_EXTRA_ARGS+=(--local-session=-)
+fi
+
+exec /usr/libexec/cockpit-ws "${WS_EXTRA_ARGS[@]}" -p 80 -a "$WEBUI_ADDRESS" <&${BRIDGE[0]} >&${BRIDGE[1]}
+

--- a/src/scripts/cockpit-pin-auth
+++ b/src/scripts/cockpit-pin-auth
@@ -1,0 +1,135 @@
+#!/usr/bin/python3
+
+import base64
+import json
+import logging
+import os
+import sys
+import time
+
+logger = logging.getLogger(__name__)
+
+
+def send_frame(content: 'dict[str, str]'):
+    data = json.dumps(content).encode()
+    os.write(1, str(len(data) + 1).encode())
+    os.write(1, b"\n\n")
+    os.write(1, data)
+
+
+def send_auth_command(challenge: 'str | None', response: 'str | None'):
+    cmd = {
+        "command": "authorize",
+    }
+
+    if challenge is not None:
+        cmd["cookie"] = f"session{os.getpid()}{time.time()}"
+        cmd["challenge"] = challenge
+    if response is not None:
+        cmd["response"] = response
+
+    send_frame(cmd)
+
+
+def send_problem_init(problem, message, auth_methods):
+    cmd = {
+        "command": "init",
+        "problem": problem
+    }
+
+    if message:
+        cmd["message"] = message
+
+    if auth_methods:
+        cmd["auth-method-results"] = auth_methods
+
+    send_frame(cmd)
+
+
+def read_size(fd):
+    sep = b'\n'
+    size = 0
+    seen = 0
+
+    while True:
+        t = os.read(fd, 1)
+
+        if not t:
+            return 0
+
+        if t == sep:
+            break
+
+        size = (size * 10) + int(t)
+        seen = seen + 1
+
+        if seen > 7:
+            raise ValueError("Invalid frame: size too long")
+
+    return size
+
+
+def read_frame(fd):
+    size = read_size(fd)
+
+    data = b""
+    while size > 0:
+        d = os.read(fd, size)
+        size = size - len(d)
+        data += d
+
+    return data.decode()
+
+
+def read_auth_reply():
+    data = read_frame(1)
+    cmd = json.loads(data)
+    logger.debug("cmd %s", cmd)
+    response = cmd.get("response")
+    if cmd.get("command") != "authorize" or \
+       not cmd.get("cookie") or not response:
+        raise ValueError("Did not receive a valid authorize command")
+
+    return response
+
+
+def decode_basic_header(response):
+    starts = "Basic "
+
+    assert response
+    assert response.startswith(starts), response
+
+    val = base64.b64decode(response[len(starts):].encode()).decode()
+    user, password = val.split(':', 1)
+    return user, password.replace('\x00', '')
+
+
+def main(args):
+    logging.basicConfig(filename='/tmp/pin.log', encoding='utf-8', level=logging.DEBUG)
+
+    # logger.debug('goo')
+    send_auth_command("*", None)
+    # message = base64.b64encode(b'Enter pin to login').decode()
+    # logging.debug("pre-conversation")
+    # send_auth_command(f"X-Conversation conv {message}", None)
+    logging.debug("post-conversation")
+
+    password = ""
+    try:
+        response = read_auth_reply()
+        _user, password = decode_basic_header(response)
+    except (ValueError, TypeError, AssertionError) as e:
+        send_problem_init("internal-error", str(e), {})
+        raise
+
+    if password != "1234":
+        send_problem_init("authentication-failed", "PIN did not match",
+                          {"password": "denied"})
+        # send_auth_command(f"X-Conversation conv {message}", None)
+        return
+
+    os.execlpe("python3", "python3", "-m", "cockpit.bridge", os.environ)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/src/scripts/cockpit-pin-auth
+++ b/src/scripts/cockpit-pin-auth
@@ -100,8 +100,7 @@ def decode_basic_header(response):
     assert response.startswith(starts), response
 
     val = base64.b64decode(response[len(starts):].encode()).decode()
-    user, password = val.split(':', 1)
-    return user, password.replace('\x00', '')
+    return val.replace('\x00', '')
 
 
 def main(args):
@@ -117,7 +116,7 @@ def main(args):
     password = ""
     try:
         response = read_auth_reply()
-        _user, password = decode_basic_header(response)
+        password = decode_basic_header(response)
     except (ValueError, TypeError, AssertionError) as e:
         send_problem_init("internal-error", str(e), {})
         raise

--- a/src/scripts/cockpit-pin-auth
+++ b/src/scripts/cockpit-pin-auth
@@ -8,16 +8,17 @@ import sys
 import time
 
 logger = logging.getLogger(__name__)
+PASSWORD_FILE = "/run/anaconda/remote-password"
 
 
-def send_frame(content: 'dict[str, str]'):
+def send_frame(content: "dict[str, str]"):
     data = json.dumps(content).encode()
     os.write(1, str(len(data) + 1).encode())
     os.write(1, b"\n\n")
     os.write(1, data)
 
 
-def send_auth_command(challenge: 'str | None', response: 'str | None'):
+def send_auth_command(challenge: "str | None", response: "str | None"):
     cmd = {
         "command": "authorize",
     }
@@ -32,10 +33,7 @@ def send_auth_command(challenge: 'str | None', response: 'str | None'):
 
 
 def send_problem_init(problem, message, auth_methods):
-    cmd = {
-        "command": "init",
-        "problem": problem
-    }
+    cmd = {"command": "init", "problem": problem}
 
     if message:
         cmd["message"] = message
@@ -47,7 +45,7 @@ def send_problem_init(problem, message, auth_methods):
 
 
 def read_size(fd):
-    sep = b'\n'
+    sep = b"\n"
     size = 0
     seen = 0
 
@@ -86,8 +84,7 @@ def read_auth_reply():
     cmd = json.loads(data)
     logger.debug("cmd %s", cmd)
     response = cmd.get("response")
-    if cmd.get("command") != "authorize" or \
-       not cmd.get("cookie") or not response:
+    if cmd.get("command") != "authorize" or not cmd.get("cookie") or not response:
         raise ValueError("Did not receive a valid authorize command")
 
     return response
@@ -99,19 +96,17 @@ def decode_basic_header(response):
     assert response
     assert response.startswith(starts), response
 
-    val = base64.b64decode(response[len(starts):].encode()).decode()
-    return val.replace('\x00', '')
+    val = base64.b64decode(response[len(starts) :].encode()).decode()
+    # Standard Basic auth format is user:password — extract password after the colon
+    if ":" in val:
+        val = val.split(":", 1)[1]
+    return val.replace("\x00", "")
 
 
-def main(args):
-    logging.basicConfig(filename='/tmp/pin.log', encoding='utf-8', level=logging.DEBUG)
+def main():
+    logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
-    # logger.debug('goo')
     send_auth_command("*", None)
-    # message = base64.b64encode(b'Enter pin to login').decode()
-    # logging.debug("pre-conversation")
-    # send_auth_command(f"X-Conversation conv {message}", None)
-    logging.debug("post-conversation")
 
     password = ""
     try:
@@ -121,14 +116,19 @@ def main(args):
         send_problem_init("internal-error", str(e), {})
         raise
 
-    if password != "1234":
-        send_problem_init("authentication-failed", "PIN did not match",
-                          {"password": "denied"})
-        # send_auth_command(f"X-Conversation conv {message}", None)
+    try:
+        with open(PASSWORD_FILE) as f:
+            expected = f.read().strip()
+    except FileNotFoundError:
+        send_problem_init("internal-error", f"Password file {PASSWORD_FILE} not found", {})
+        return
+
+    if password != expected:
+        send_problem_init("authentication-failed", "PIN did not match", {"password": "denied"})
         return
 
     os.execlpe("python3", "python3", "-m", "cockpit.bridge", os.environ)
 
 
 if __name__ == "__main__":
-    main(sys.argv)
+    main()

--- a/src/systemd/cockpit-pin-auth.socket
+++ b/src/systemd/cockpit-pin-auth.socket
@@ -1,0 +1,15 @@
+[Unit]
+Description=Socket for cockpit pin auth service activation
+PartOf=cockpit-pin-auth.service
+# ensure our DynamicUser exists
+#Requires=cockpit-wsinstance-socket-user.service
+#After=cockpit-wsinstance-socket-user.service
+
+
+[Socket]
+ListenStream=/run/cockpit/wsinstance/cockpit-pin-auth.sock
+SocketUser=root
+#SocketGroup=cockpit-wsinstance-socket
+SocketMode=0666
+RemoveOnStop=yes
+Accept=yes

--- a/src/systemd/cockpit-pin-auth@.service
+++ b/src/systemd/cockpit-pin-auth@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Cockpit pin auth
+Requires=cockpit-pin-auth.socket
+
+[Service]
+ExecStart=/usr/libexec/anaconda/cockpit-pin-auth
+StandardInput=socket
+StandardOutput=inherit
+StandardError=journal
+Type=simple
+# bridge error, authentication failure, or timeout, that's not a problem with the unit
+SuccessExitStatus=1 5 127

--- a/test/check-remote-auth
+++ b/test/check-remote-auth
@@ -1,0 +1,55 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2025 Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase
+from installer import Installer
+from testlib import test_main  # pylint: disable=import-error
+
+
+class TestRemoteAuth(VirtInstallMachineCase):
+
+    provision = {
+        "machine1": {
+            "remote_password": "test1234",
+            "memory_mb": INSTALLER_VM_MEMORY_MB,
+        },
+    }
+
+    def testBasic(self):
+        """
+        Description:
+            Boot with ``inst.webui.remote inst.webui.remote.password=test1234``
+            and verify that PIN authentication is required.
+
+        Expected results:
+            - The login page is shown
+            - Wrong PIN is rejected with an error
+            - Correct PIN grants access to the installer
+        """
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m)
+
+        b.open("/cockpit/@localhost/anaconda-webui/index.html")
+
+        # Login page should be visible
+        b.wait_visible("#pin-input")
+
+        # Wrong password should be rejected
+        b.set_input_text("#pin-input", "wrongpin")
+        b.click("button[type=submit]")
+        b.wait_in_text(".pf-v6-c-alert", "Invalid PIN")
+
+        # Correct password should grant access
+        b.set_input_text("#pin-input", "test1234")
+        b.click("button[type=submit]")
+
+        # After login redirect, the installer loads at the root path
+        with b.wait_timeout(30):
+            b.wait_js_cond('window.location.pathname === "/cockpit/@localhost/anaconda-webui/index.html"')
+
+
+if __name__ == '__main__':
+    test_main()

--- a/test/machine_install.py
+++ b/test/machine_install.py
@@ -45,6 +45,7 @@ class VirtInstallMachine(VirtMachine):
         self.kickstart_file_name = kwargs.pop("kickstart_file_name", None)
         self.pause_at_summary = kwargs.pop("pause_at_summary", False)
         self.payload_type = kwargs.pop("payload_type", "liveimg".lower())
+        self.remote_password = kwargs.pop("remote_password", "")
         # Always enforce the minimum RAM the installer requires. Covers every entry point the same way:
         # test/run (CI), local test/check-*, and GlobalMachine.reset() which omits memory_mb.
         kwargs["memory_mb"] = max(kwargs.get("memory_mb") or 0, INSTALLER_VM_MEMORY_MB)
@@ -194,6 +195,7 @@ class VirtInstallMachine(VirtMachine):
             if self.console_file
             else ""
         )
+        auth_method = f"inst.webui.remote.password={self.remote_password}" if self.remote_password else "inst.webui.remote.noauth"
         try:
             self._execute(
                 "virt-install "
@@ -208,7 +210,7 @@ class VirtInstallMachine(VirtMachine):
                 f"{serial_opt}"
                 f"--graphics vnc,listen={self.ssh_address} "
                 "--extra-args "
-                f"'{virt_kargs}{inst_graphical}inst.sshd inst.webui inst.webui.remote {selinux}{inst_ks_arg} "
+                f"'{virt_kargs}{inst_graphical}inst.sshd inst.webui inst.webui.remote {auth_method} {selinux}{inst_ks_arg} "
                 f"inst.updates=http://10.0.2.2:{self.http_install_port}/"
                 f"{self.label}-updates.img' "
                 "--network none "

--- a/webui-desktop
+++ b/webui-desktop
@@ -34,13 +34,15 @@ BROWSER_HOME=""
 
 THEME_ID="default"
 WEBUI_REMOTE=0
-while getopts t:r: option
+WEBUI_NOAUTH=0
+while getopts t:r:n: option
 do
     case "${option}"
         in
         t)THEME_ID=${OPTARG};;
         r)WEBUI_REMOTE=${OPTARG};;
-        *) echo "Usage: $0 [-t THEME_ID] [-r WEBUI_REMOTE]" >&2
+        n)WEBUI_NOAUTH=${OPTARG};;
+        *) echo "Usage: $0 [-t THEME_ID] [-r WEBUI_REMOTE] [-n WEBUI_NOAUTH]" >&2
        exit 1 ;;
     esac
 done
@@ -53,7 +55,21 @@ then
     WEBUI_ADDRESS="0.0.0.0"
 fi
 
+REMOTE_AUTH_DROPIN="/etc/anaconda/cockpit/conf.d/50-remote-auth.conf"
+REMOTE_AUTH_SOURCE="/usr/share/anaconda/cockpit/conf.d/50-remote-auth.conf"
+PASSWORD_FILE="/run/anaconda/remote-password"
+WEBUI_AUTH=0
+
+if [[ -f "$PASSWORD_FILE" ]] && [[ "$WEBUI_NOAUTH" != "1" ]]; then
+    cp "$REMOTE_AUTH_SOURCE" "$REMOTE_AUTH_DROPIN"
+    WEBUI_AUTH=1
+else
+    rm -f "$REMOTE_AUTH_DROPIN"
+fi
+
 echo "WEBUI_ADDRESS=$WEBUI_ADDRESS" > /tmp/webui-cockpit-ws.env
+echo "WEBUI_AUTH=$WEBUI_AUTH" >> /tmp/webui-cockpit-ws.env
+
 systemctl start webui-cockpit-ws
 
 # Function to setup user-related environment


### PR DESCRIPTION

## Context

Proof-of-concept for PIN-based authentication as part of the remote installation feature ([INSTALLER-4395](https://redhat.atlassian.net/browse/INSTALLER-4395) / [INSTALLER-3723](https://redhat.atlassian.net/browse/INSTALLER-3723)).

**Do not merge** — keeping this open while the broader design is worked out. It was the basis for the team demo on April 8 and drove the architectural decisions we've aligned on since.

## What This Demonstrates

Cockpit (the framework Anaconda's Web UI is built on) lets you replace its default login page and authentication handler with custom implementations. This PoC exercises both:

### Custom login page

`src/components/login/LoginPage.jsx`, built into `login.html`/`login.js`. A minimal PIN entry form — shows/hides the PIN, submits it as a Basic auth header (PIN as username). Cockpit routes that to the custom auth handler.

Wired up via `[WebService] CustomLoginPage` in `cockpit.conf`.

### Custom auth handler

`src/scripts/cockpit-pin-auth` — a Python script that speaks Cockpit's auth protocol over a Unix socket. Receives the Basic auth credentials from Cockpit, validates the PIN, and if correct, exec's `cockpit.bridge` to start the actual installer session.

Deployed as a socket-activated systemd unit (`cockpit-pin-auth.socket` + `cockpit-pin-auth@.service`), separate from the main cockpit-ws process. Each connection spawns a fresh instance. After the PIN is accepted, Cockpit's session cookie takes over.

### Cockpit config

`src/config/cockpit.conf` sets `CustomLoginPage` and overrides the `[Basic]` auth command. Currently installs to `/etc/cockpit/cockpit.conf`.

**Known issue**: config path should move to an anaconda-owned path (e.g., `/etc/anaconda/cockpit/`) so it doesn't persist to the installed system. Tracked as a follow-up.

## How to Try It

Build an updates image and run it against a Fedora Rawhide boot ISO:

```bash
make create-updates.img
```

Then boot a Rawhide installer with `inst.updates` pointing to the generated `updates.img`, for example with `virt-install`:

```bash
virt-install \
  --location <rawhide-boot-iso> \
  --extra-args "inst.updates=<path-or-url-to-updates.img> inst.webui.remote" \
  ...
```

The PIN is hardcoded to `1234` in `src/scripts/cockpit-pin-auth`. Once the installer is running, point a browser at the VM's IP on port 80 — you'll get the custom login page. Enter `1234` to authenticate.

Session behavior observed in the demo: tab close preserves the session (cookie survives), browser close requires re-login.

## What's Deliberately Incomplete

- **PIN mechanism**: Hardcoded to `1234`. Real implementation would read from a boot parameter and display on the local console.
- **Config path**: Uses `/etc/cockpit/` — should be anaconda-owned.
- **Single-connection enforcement**: Not implemented. Multiple sessions can connect simultaneously (this was live-demoed as a problem — one session can start installation while another changes storage config).
- **TLS**: Not configured. Connection is unencrypted in this PoC.
- **Login page pre-auth info**: IP address / Fedora edition can't easily be shown before login because Cockpit APIs require authentication. Still being figured out.

## What We're Looking For

If you're looking at this from the Cockpit side:
- Is there a simpler way to get OS/network info on the login page without requiring auth?
- What's the recommended mechanism for enforcing a single concurrent session?
- How does Cockpit distinguish a reconnection (same user, dropped connection) from a new session?
