### PR TITLE
Fix error dialog flashing on reboot after successful installation

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -12,6 +12,7 @@ import { clients } from "../apis/index.js";
 import { initialState, reducer, useReducerWithThunk } from "../reducer.js";
 
 import { getInstallerConfValue, parseAnacondaConfBool, readConf } from "../helpers/conf.js";
+import { isExiting } from "../helpers/exit.js";
 import { debug } from "../helpers/log.js";
 import { getAnacondaUIVersion, getAnacondaVersion } from "../helpers/product.js";
 
@@ -157,7 +158,7 @@ const useAddress = (onCritFail) => {
 
                 setBackendReady(isReady);
 
-                if (!isReady && wasReadyRef.current && onCritFail) {
+                if (!isReady && wasReadyRef.current && onCritFail && !isExiting()) {
                     onCritFail()({
                         message: _("The Anaconda installation has stopped unexpectedly."),
                     });

--- a/src/helpers/exit.js
+++ b/src/helpers/exit.js
@@ -6,9 +6,16 @@ import cockpit from "cockpit";
 
 import { debug, error } from "./log.js";
 
+let _isExiting = false;
+
+export const isExiting = () => _isExiting;
+
 export const exitGui = () => {
+    _isExiting = true;
+
     const pidFile = cockpit.file("/run/anaconda/webui_script.pid", { superuser: "try" });
     let pid;
+
     pidFile.read()
             .then(content => {
                 pid = content.trim();


### PR DESCRIPTION
When the user clicks 'Reboot into installed system', exitGui() kills the webui-desktop process, which causes the Anaconda backend to remove the /run/anaconda/backend_ready flag. The file watcher in app.jsx detects this removal while the UI is still alive and triggers the "The Anaconda installation has stopped unexpectedly" error dialog.

Call Boss.Quit() via D-Bus before killing the process for a clean shutdown, and track the intentional exit so the backend_ready watcher skips the error when the user initiated the quit.