### PR TITLE
test: specify test VM memory via DEFAULT_MACHINE_MEMORY_MB

### DIFF
--- a/test/machine_install.py
+++ b/test/machine_install.py
@@ -165,7 +165,7 @@ class VirtInstallMachine(VirtMachine):
                 f"{boot_arg} "
                 f"--name {self.label} "
                 f"--os-variant=detect=on "
-                "--memory 4096 "
+                f"--memory {self.memory_mb} "
                 "--noautoconsole "
                 f"--graphics vnc,listen={self.ssh_address} "
                 "--extra-args "

--- a/test/run
+++ b/test/run
@@ -26,6 +26,8 @@ else
 fi
 
 RUN_OPTS=""
+# Installer VMs need more RAM than typical Cockpit test guests
+export DEFAULT_MACHINE_MEMORY_MB=4096
 ALL_TESTS="$(test/common/run-tests --test-dir test -l)"
 
 RE_EXPENSIVE='E2E'


### PR DESCRIPTION
Installer test VMs use more RAM than the 1152 MiB cockpit default;
Cockpit testlib was not aware of that, since we are overriding the
VirtMachine class, and had the memory value hardcoded. This was causing
testlib to underestimate the per-slot RAM which in turn could
oversubscribe CI workers (e.g. Chromium ERR_INSUFFICIENT_RESOURCES).

- Export DEFAULT_MACHINE_MEMORY_MB=4096 from test/run before run-tests so bots
  lib/constants.py picks it up for VirtMachine defaults and run-tests scheduling
  (requires bots: https://github.com/cockpit-project/bots/pull/8981)
- VirtInstallMachine reads VirtMachine.memory_mb and passes to virt-install.
