### PR TITLE
test: tune installer VM memory for ND and destructive runs

### DIFF
--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -29,6 +29,9 @@ from utils import add_public_key
 pixel_tests_ignore = ["#anaconda-screen-review-target-system-timezone"]
 
 
+INSTALLER_VM_MEMORY_MB = 4096
+
+
 class VirtInstallMachineCase(MachineCase):
     # The boot modes in which the test should run
     boot_modes = ["bios"]

--- a/test/check-kickstart-automated
+++ b/test/check-kickstart-automated
@@ -3,7 +3,7 @@
 # Copyright (C) 2025 Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from anacondalib import VirtInstallMachineCase, pixel_tests_ignore
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, pixel_tests_ignore
 from installer import Installer
 from payload_dnf import PayloadDNF
 from review import Review
@@ -16,7 +16,13 @@ from users import Users, override_user_interface_conf_keys
 class TestKickstartAutomated(VirtInstallMachineCase):
     """Destructive tests for kickstart-driven automated installations."""
 
-    provision = {"machine1": {"kickstart_file_name": "TestKickstartAutomated-testBasic.ks", "payload_type": "dnf"}}
+    provision = {
+        "machine1": {
+            "kickstart_file_name": "TestKickstartAutomated-testBasic.ks",
+            "payload_type": "dnf",
+            "memory_mb": INSTALLER_VM_MEMORY_MB,
+        },
+    }
 
     def testBasic(self):
         """

--- a/test/check-network
+++ b/test/check-network
@@ -5,7 +5,7 @@
 
 import time
 
-from anacondalib import VirtInstallMachineCase, run_on_vm_setups
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, run_on_vm_setups
 from installer import Installer
 from network import COCKPIT_CHECKPOINT_ROLLBACK_TIME, SYSROOT_PATH, Network
 from progress import Progress
@@ -13,7 +13,8 @@ from testlib import nondestructive, test_main  # pylint: disable=import-error
 from utils import check_cockpit_module_js_error
 
 
-class TestNetwork(VirtInstallMachineCase):
+class TestNetworkDestructive(VirtInstallMachineCase):
+    provision = {"machine1": {"memory_mb": INSTALLER_VM_MEMORY_MB}}
 
     def testCockpitConnectionsPreInstall(self):
         """
@@ -125,7 +126,9 @@ class TestNetwork(VirtInstallMachineCase):
             [con_name, "ipv4.dns", dns_server, None],
         ])
 
-    @nondestructive
+
+@nondestructive
+class TestNetwork(VirtInstallMachineCase):
     def testCockpitJsErrorHandling(self):
         """
         Description:

--- a/test/check-network-e2e
+++ b/test/check-network-e2e
@@ -3,7 +3,7 @@
 # Copyright (C) 2026 Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from anacondalib import VirtInstallMachineCase
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase
 from installer import Installer
 from network import SYSROOT_PATH, Network
 from progress import Progress
@@ -11,6 +11,7 @@ from testlib import test_main, timeout  # pylint: disable=import-error
 
 
 class TestNetwork_E2E(VirtInstallMachineCase):
+    provision = {"machine1": {"memory_mb": INSTALLER_VM_MEMORY_MB}}
 
     @timeout(1200)
     def testConnectionsE2E(self):

--- a/test/check-payload-dnf-e2e
+++ b/test/check-payload-dnf-e2e
@@ -3,7 +3,7 @@
 # Copyright (C) 2025 Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from anacondalib import VirtInstallMachineCase, disk_images
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images
 from installer import Installer
 from progress import Progress
 from testlib import test_main, timeout  # pylint: disable=import-error
@@ -11,7 +11,7 @@ from utils import get_pretty_name
 
 
 class TestPayloadDNF_E2E(VirtInstallMachineCase):
-    provision = {"machine1": {"payload_type": "dnf"}}
+    provision = {"machine1": {"payload_type": "dnf", "memory_mb": INSTALLER_VM_MEMORY_MB}}
 
     @disk_images([("", 15)])
     @timeout(1200)

--- a/test/check-progress
+++ b/test/check-progress
@@ -3,7 +3,7 @@
 # Copyright (C) 2022 Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from anacondalib import VirtInstallMachineCase
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase
 from installer import Installer
 from progress import Progress
 from storage import Storage
@@ -12,6 +12,7 @@ from utils import get_pretty_name
 
 
 class TestInstallationProgress(VirtInstallMachineCase):
+    provision = {"machine1": {"memory_mb": INSTALLER_VM_MEMORY_MB}}
 
     def testBasic(self):
         """

--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -12,6 +12,7 @@ from testlib import nondestructive, test_main  # pylint: disable=import-error
 from utils import pretend_live_workstation_iso
 
 
+@nondestructive
 class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
     def reachCockpitStorage(self):
         b = self.browser
@@ -38,7 +39,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         self.click_dropdown(self.card_row("Storage", 3), "Create partition")
         self.dialog({"size": 1070, "type": "ext4", "mount_point": "/boot"})
 
-    @nondestructive
     def testBasicLiveISO(self):
         """
         Description:
@@ -60,7 +60,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         s.check_disk_selected("vda")
         s.enter_cockpit_storage()
 
-    @nondestructive
     def testEncryptedUnlock(self):
         """
         Description:
@@ -166,7 +165,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         self.click_card_dropdown("Unformatted data", "Format")
         self.dialog({"type": "swap"})
 
-    @nondestructive
     def testLVM(self):
         """
         Description:
@@ -259,7 +257,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         self.assertTrue("/mnt/sysroot/boot auto noauto 0 0" in fstab)
         self.assertTrue("/mnt/sysroot auto noauto 0 0" in fstab)
 
-    @nondestructive
     def testStandardPartitionExt4(self):
         """
         Description:
@@ -270,7 +267,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         """
         self._testStandardPartition("ext4")
 
-    @nondestructive
     def testStandardPartitionXFS(self):
         """
         Description:
@@ -281,7 +277,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         """
         self._testStandardPartition("xfs")
 
-    @nondestructive
     def testPayloadSizeCheckExt4(self):
         """
         Description:
@@ -295,7 +290,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         """
         self._testPayloadSizeCheck("ext4")
 
-    @nondestructive
     def testPayloadSizeCheckXFS(self):
         """
         Description:
@@ -358,7 +352,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         s.wait_scenario_available("use-configured-storage")
 
-    @nondestructive
     def testPayloadSizeCheckBtrfs(self):
         """
         Description:
@@ -397,7 +390,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         i.check_next_disabled()
 
-    @nondestructive
     def testPayloadSizeCheckLVM(self):
         """
         Description:
@@ -436,7 +428,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         i.check_next_disabled()
 
-    @nondestructive
     @run_boot("efi")
     def testBtrfsTopLevelVolume(self):
         """
@@ -506,7 +497,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         browser.click(self.card_button("btrfs subvolume", "Create subvolume"))
         self.dialog({"name": "home", "mount_point": "/home"})
 
-    @nondestructive
     def testBtrfsSubvolumes(self):
         """
         Description:
@@ -545,7 +535,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         self.assertTrue("/mnt/sysroot btrfs noauto,subvol=root 0 0" in fstab)
         self.assertTrue("/mnt/sysroot/home btrfs noauto,subvol=home 0 0" in fstab)
 
-    @nondestructive
     def testBtrfsAndMountPointAssignment(self):
         """
         Description:
@@ -602,7 +591,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         self.assertTrue("/mnt/sysroot/home btrfs noauto,subvol=home 0 0" in fstab)
 
     @disk_images([("", 15), ("", 15), ("", 15)])
-    @nondestructive
     def testRAIDUnsupportedNesting(self):
         """
         Description:
@@ -668,7 +656,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         b.switch_to_top()
         s.return_to_installation("Invalid RAID configuration detected.")
 
-    @nondestructive
     @disk_images([("", 15), ("", 15), ("", 15)])
     @run_boot("bios", "efi")
     def testUnsupportedBootloaderOnMDRAID(self):
@@ -750,7 +737,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         b.wait_not_present(self.card_row("Storage", index))
 
-    @nondestructive
     @disk_images([("", 15), ("", 15), ("", 15)])
     def testCalculateSelectedDisksRAID(self):
         """
@@ -836,7 +822,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
 
     @disk_images([("", 15), ("", 15)])
-    @nondestructive
     def testFormattedDiskRootfs(self):
         """
         Description:
@@ -907,7 +892,6 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         s.select_mountpoint_row_device(3, "vdb")
         s.select_mountpoint_row_mountpoint(3, "/home")
 
-    @nondestructive
     def testMBRParttable(self):
         """
         Description:

--- a/test/check-storage-cockpit-e2e
+++ b/test/check-storage-cockpit-e2e
@@ -3,7 +3,7 @@
 # Copyright (C) 2025 Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from anacondalib import VirtInstallMachineCase, disk_images, run_boot
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images, run_boot
 from installer import Installer
 from review import Review
 from storage import Storage
@@ -12,6 +12,8 @@ from testlib import test_main, timeout  # pylint: disable=import-error
 
 
 class TestStorageCockpitIntegration_E2E(VirtInstallMachineCase, StorageCase):
+    provision = {"machine1": {"memory_mb": INSTALLER_VM_MEMORY_MB}}
+
     def cockpitCreateBootloaderPartitions(self):
         self.click_dropdown(self.card_row("Storage", 1), "Create partition table")
         self.confirm()

--- a/test/check-storage-erase-all-e2e
+++ b/test/check-storage-erase-all-e2e
@@ -5,7 +5,7 @@
 
 import os
 
-from anacondalib import VirtInstallMachineCase, disk_images
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images
 from installer import Installer
 from password import Password
 from progress import Progress
@@ -20,6 +20,8 @@ BOTS_DIR = f'{ROOT_DIR}/bots'
 
 
 class TestStorageEraseAll_E2E(VirtInstallMachineCase):
+    provision = {"machine1": {"memory_mb": INSTALLER_VM_MEMORY_MB}}
+
     @timeout(1200)
     def testGuidedEncrypted(self):
         """

--- a/test/check-storage-home-reuse
+++ b/test/check-storage-home-reuse
@@ -5,7 +5,7 @@
 
 import os
 
-from anacondalib import VirtInstallMachineCase, disk_images, run_boot
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images, run_boot
 from installer import Installer
 from review import Review
 from storage import BOOT_PARTITION_DEFAULT_SIZE, BOOT_PARTITION_DEFAULT_SIZE_GB, Storage
@@ -17,7 +17,7 @@ ROOT_DIR = os.path.dirname(TEST_DIR)
 BOTS_DIR = f'{ROOT_DIR}/bots'
 
 
-class TestStorageHomeReuse(VirtInstallMachineCase):
+class _TestStorageHomeReuseHelpers:
     def _remove_unknown_mountpoints(self, disk):
         # Remove the /var subvolume from the default btrfs layout
         # as /var/ is not default mount point in Fedora which results in
@@ -30,79 +30,6 @@ class TestStorageHomeReuse(VirtInstallMachineCase):
             sed -i '/var/d' /mnt/root/etc/fstab;
             umount /mnt
         """)
-
-    def _testBasic_partition_disk(self):
-        self._remove_unknown_mountpoints("vda")
-
-    # Reinstall option does not work with UEFI when /boot is on btrfs
-    # @run_boot("bios", "efi")
-    @disk_images([("fedora-rawhide", 15)])
-    @nondestructive
-    def testBasic(self):
-        """
-        Description:
-            Test the home reuse installation method with a pre-existing standard
-            Fedora installation
-
-        Expected results:
-            - The home reuse installation method is available
-            - The home reuse expected layout is shown in the review screen
-        """
-
-        b = self.browser
-        m = self.machine
-        i = Installer(b, m, scenario="home-reuse")
-        s = Storage(b, m)
-        r = Review(b, m)
-
-        pretend_default_scheme(self, "BTRFS")
-        dev="vda"
-
-        i.open()
-        i.reach(i.steps.INSTALLATION_METHOD)
-
-        s.check_scenario_selected("home-reuse")
-        s.check_scenario_index("home-reuse", 1)
-        i.reach(i.steps.REVIEW)
-
-        # check selected disks are shown
-        r.check_disk(dev, f"16.1 GB {dev} (Virtio Block Device)")
-        if self.is_efi:
-            r.check_disk_row(dev, parent=f"{dev}2", action="delete")
-        else:
-            r.check_disk_row(dev, parent=f"{dev}1", action="delete")
-
-        if self.is_efi:
-            r.check_disk_row(dev, "/boot/efi", f"{dev}2", "629 MB", True, "efi", is_encrypted=False)
-        r.check_disk_row(dev, "/boot", f"{dev}4", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
-        r.check_disk_row(dev, "/", f"{dev}3", "13.9 GB", True, "btrfs", is_encrypted=False)
-        r.check_disk_row(dev, "/home", f"{dev}3", "13.9 GB", False, "btrfs", is_encrypted=False,
-                         action="mount")
-
-    @disk_images([("fedora-rawhide", 15)])
-    @nondestructive
-    def testHidden(self):
-        """
-        Description:
-            Test the home reuse installation method with a pre-existing
-            Fedora installation with unexpected mount points
-
-        Expected results:
-            - The home reuse installation method is not available
-        """
-        b = self.browser
-        m = self.machine
-        i = Installer(b, m, scenario="home-reuse")
-        s = Storage(b, m)
-
-        pretend_default_scheme(self, "BTRFS")
-
-        i.open()
-        i.reach(i.steps.INSTALLATION_METHOD)
-
-        # The `Re-install Fedora` scenario should not be available
-        # when unexpected mount points are present
-        s.wait_scenario_visible("home-reuse", False)
 
     def move_standard_fedora_disk_to_encrypted(self, encrypted_disk, new_disk, password):
         b = self.browser
@@ -155,21 +82,26 @@ class TestStorageHomeReuse(VirtInstallMachineCase):
         umount -l /mnt
         """, timeout=90)
 
-    def _testHomeReuseFedoraEncrypted_partition_disk(self):
-        self._remove_unknown_mountpoints("vda")
-        self.move_standard_fedora_disk_to_encrypted("/dev/vda", "vdb", "einszwei")
 
-    @disk_images([("fedora-rawhide", 15), ("fedora-42", 15)])
-    def testHomeReuseFedoraEncrypted(self):
+@nondestructive
+class TestStorageHomeReuse(VirtInstallMachineCase, _TestStorageHomeReuseHelpers):
+    def _testBasic_partition_disk(self):
+        self._remove_unknown_mountpoints("vda")
+
+    # Reinstall option does not work with UEFI when /boot is on btrfs
+    # @run_boot("bios", "efi")
+    @disk_images([("fedora-rawhide", 15)])
+    def testBasic(self):
         """
         Description:
             Test the home reuse installation method with a pre-existing standard
-            Fedora installation layout with encrypted /.
+            Fedora installation
 
         Expected results:
-            - The home reuse installation method is available after the encrypted device is unlocked.
+            - The home reuse installation method is available
             - The home reuse expected layout is shown in the review screen
         """
+
         b = self.browser
         m = self.machine
         i = Installer(b, m, scenario="home-reuse")
@@ -177,30 +109,58 @@ class TestStorageHomeReuse(VirtInstallMachineCase):
         r = Review(b, m)
 
         pretend_default_scheme(self, "BTRFS")
+        dev="vda"
 
         i.open()
         i.reach(i.steps.INSTALLATION_METHOD)
-        s.select_disks([("vda", True), ("vdb", False)])
 
-        s.unlock_all_encrypted()
-        s.unlock_device("einszwei", ["vda4"], ["vda4"])
-        s.set_scenario("home-reuse")
+        s.check_scenario_selected("home-reuse")
+        s.check_scenario_index("home-reuse", 1)
         i.reach(i.steps.REVIEW)
 
         # check selected disks are shown
-        dev = "vda"
         r.check_disk(dev, f"16.1 GB {dev} (Virtio Block Device)")
-        r.check_disk_row(dev, parent=f"{dev}1", action="delete")
-        r.check_disk_row(dev, "/boot", f"{dev}3", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
-        r.check_disk_row(dev, "/", f"{dev}4", "13.9 GB", True, "btrfs", is_encrypted=True)
-        r.check_disk_row(dev, "/home", f"{dev}4", "13.9 GB", False, "btrfs", is_encrypted=True, action="mount")
+        if self.is_efi:
+            r.check_disk_row(dev, parent=f"{dev}2", action="delete")
+        else:
+            r.check_disk_row(dev, parent=f"{dev}1", action="delete")
+
+        if self.is_efi:
+            r.check_disk_row(dev, "/boot/efi", f"{dev}2", "629 MB", True, "efi", is_encrypted=False)
+        r.check_disk_row(dev, "/boot", f"{dev}4", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
+        r.check_disk_row(dev, "/", f"{dev}3", "13.9 GB", True, "btrfs", is_encrypted=False)
+        r.check_disk_row(dev, "/home", f"{dev}3", "13.9 GB", False, "btrfs", is_encrypted=False,
+                         action="mount")
+
+    @disk_images([("fedora-rawhide", 15)])
+    def testHidden(self):
+        """
+        Description:
+            Test the home reuse installation method with a pre-existing
+            Fedora installation with unexpected mount points
+
+        Expected results:
+            - The home reuse installation method is not available
+        """
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m, scenario="home-reuse")
+        s = Storage(b, m)
+
+        pretend_default_scheme(self, "BTRFS")
+
+        i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+
+        # The `Re-install Fedora` scenario should not be available
+        # when unexpected mount points are present
+        s.wait_scenario_visible("home-reuse", False)
 
     def _testMultipleRoots_partition_disk(self):
         self._remove_unknown_mountpoints("vda")
 
     @disk_images([("fedora-rawhide", 15), ("fedora-42", 15), ("ubuntu-stable", 15)])
     @skipImage("btrfs support missing on fedora-eln image", "fedora-eln-boot")
-    @nondestructive
     def testMultipleRoots(self):
         """
         Description:
@@ -258,6 +218,51 @@ class TestStorageHomeReuse(VirtInstallMachineCase):
         r.check_disk_row(dev_fedora1, "/home", f"{dev_fedora1}3", "13.9 GB", False, "btrfs", is_encrypted=False,
                          action="mount")
         r.check_disk_row(dev_fedora1, "/boot", f"{dev_fedora1}4", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
+
+
+# TODO: these tests should be made nondestructive
+class TestStorageHomeReuseDestructive(VirtInstallMachineCase, _TestStorageHomeReuseHelpers):
+    provision = {"machine1": {"memory_mb": INSTALLER_VM_MEMORY_MB}}
+
+    def _testHomeReuseFedoraEncrypted_partition_disk(self):
+        self._remove_unknown_mountpoints("vda")
+        self.move_standard_fedora_disk_to_encrypted("/dev/vda", "vdb", "einszwei")
+
+    @disk_images([("fedora-rawhide", 15), ("fedora-42", 15)])
+    def testHomeReuseFedoraEncrypted(self):
+        """
+        Description:
+            Test the home reuse installation method with a pre-existing standard
+            Fedora installation layout with encrypted /.
+
+        Expected results:
+            - The home reuse installation method is available after the encrypted device is unlocked.
+            - The home reuse expected layout is shown in the review screen
+        """
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m, scenario="home-reuse")
+        s = Storage(b, m)
+        r = Review(b, m)
+
+        pretend_default_scheme(self, "BTRFS")
+
+        i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+        s.select_disks([("vda", True), ("vdb", False)])
+
+        s.unlock_all_encrypted()
+        s.unlock_device("einszwei", ["vda4"], ["vda4"])
+        s.set_scenario("home-reuse")
+        i.reach(i.steps.REVIEW)
+
+        # check selected disks are shown
+        dev = "vda"
+        r.check_disk(dev, f"16.1 GB {dev} (Virtio Block Device)")
+        r.check_disk_row(dev, parent=f"{dev}1", action="delete")
+        r.check_disk_row(dev, "/boot", f"{dev}3", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
+        r.check_disk_row(dev, "/", f"{dev}4", "13.9 GB", True, "btrfs", is_encrypted=True)
+        r.check_disk_row(dev, "/home", f"{dev}4", "13.9 GB", False, "btrfs", is_encrypted=True, action="mount")
 
     def _testNonLinuxSystem_partition_disk(self):
         b = self.browser

--- a/test/check-storage-home-reuse-e2e
+++ b/test/check-storage-home-reuse-e2e
@@ -5,7 +5,7 @@
 
 import os
 
-from anacondalib import VirtInstallMachineCase, disk_images
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images
 from installer import Installer
 from progress import Progress
 from storage import Storage
@@ -18,6 +18,8 @@ BOTS_DIR = f'{ROOT_DIR}/bots'
 
 
 class TestStorageHomeReuse_E2E(VirtInstallMachineCase):
+    provision = {"machine1": {"memory_mb": INSTALLER_VM_MEMORY_MB}}
+
     def _remove_unknown_mountpoints(self):
         # Remove the /var subvolume from the default btrfs layout
         # as /var/ is not default mount point in Fedora which results in

--- a/test/check-storage-mountpoints
+++ b/test/check-storage-mountpoints
@@ -5,7 +5,7 @@
 
 import os
 
-from anacondalib import VirtInstallMachineCase, disk_images, pixel_tests_ignore, run_boot
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images, pixel_tests_ignore, run_boot
 from installer import Installer
 from review import Review
 from storage import Storage
@@ -18,13 +18,13 @@ ROOT_DIR = os.path.dirname(TEST_DIR)
 BOTS_DIR = f'{ROOT_DIR}/bots'
 
 
+@nondestructive
 class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
     # FIXME: Re-enable bios test, it's currently failing in CI to detect the BIOS boot partition
     # @run_boot("bios", "efi")
     @run_boot("efi")
     @disk_images([("", 15), ("fedora-42", "15")])
     @skipImage("btrfs support missing on fedora-eln image", "fedora-eln-boot")
-    @nondestructive
     def testBasic(self):
         """
         Description:
@@ -149,7 +149,6 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         disk = "/dev/vda"
         s.partition_disk(disk, [("1MiB", "biosboot"), ("1GiB", "ext4"), ("10GiB", "xfs"), ("", "ext4")])
 
-    @nondestructive
     def testNoRootMountPoint(self):
         """
         Description:
@@ -212,7 +211,6 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s.partition_disk(disk2, [("", "xfs")])
 
     @disk_images([("", 15), ("", 10)])
-    @nondestructive
     def testMultipleDisks(self):
         """
         Description:
@@ -294,7 +292,6 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s.partition_disk(disk1, [("1MiB", "biosboot"), ("1GiB", "xfs"), ("1GiB", "xfs"), ("1GiB", "xfs"), ("", "xfs")])
 
     @disk_images([("", 15)])
-    @nondestructive
     def testPayloadSizeCheck(self):
         """
         Description:
@@ -381,54 +378,6 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         b.click(f"#{i.steps.REVIEW}-next-confirmation-checkbox")
         i.check_next_disabled(False)
 
-    def _testMBRParttable_partition_disk(self):
-        storage = Storage(self.browser, self.machine)
-        move_standard_fedora_disk_to_MBR_disk(storage, self.machine, "vda", "vdb")
-
-    @disk_images([("", 15), ("fedora-rawhide", 15)])
-    def testMBRParttable(self):
-        """
-        Description:
-            Test the case when the disk is MBR partitioned.
-
-        Expected results:
-            - The mount point mapping scenario is available and can be used with
-              MBR partitioned disks.
-        """
-        b = self.browser
-        m = self.machine
-        i = Installer(b, m)
-        s = Storage(b, m)
-        r = Review(b, m)
-
-        # This is required for home-reuse availability check
-        pretend_default_scheme(self, "BTRFS")
-
-        i.open()
-        i.reach(i.steps.INSTALLATION_METHOD)
-
-        s.wait_scenario_available("mount-point-mapping", True)
-
-        s.select_mountpoint([("vda", True), ("vdb", False)])
-
-        s.select_mountpoint_row_device(1, "root")
-        s.select_mountpoint_row_device(2, "vda1")
-        s.add_mountpoint_row()
-        s.select_mountpoint_row_mountpoint(3, "/home")
-        s.select_mountpoint_row_device(3, "home")
-
-        s.select_mountpoint_row_reformat(2)
-
-        i.reach(i.steps.REVIEW)
-
-        # verify review screen
-        disk = "vda"
-        r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
-
-        r.check_disk_row(disk, "/boot", "vda1", "1.07 GB", True, "ext4")
-        r.check_disk_row(disk, "/", "vda2", "14.0 GB", True, "btrfs subvolume")
-        r.check_disk_row(disk, "/home", "vda2", "14.0 GB", False, "btrfs")
-
     def _testEncryptedUnlock_partition_disk(self):
         b = self.browser
         m = self.machine
@@ -443,7 +392,6 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s.create_luks_partition(f"{disk1}3", "einszweidrei", "encrypted-vol1", "xfs")
         s.create_luks_partition(f"{disk1}4", "einszweidreivier", "encrypted-vol2", "xfs")
 
-    @nondestructive
     def testEncryptedUnlock(self):
         """
         Description:
@@ -508,7 +456,6 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         i.reach(i.steps.REVIEW)
         r.check_disk_row(dev1, "/", "vda3", "", True, "xfs", True)
 
-    @nondestructive
     def testEncryptedUnlockCockpit(self):
         """
         Description:
@@ -616,7 +563,6 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         )
 
     @skipImage("btrfs support missing on fedora-eln image", "fedora-eln-boot")
-    @nondestructive
     def testDuplicateDeviceNames(self):
         """
         Description:
@@ -674,7 +620,6 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         disk = "/dev/vda"
         s.partition_disk(disk, [("1MiB", "biosboot"), ("1GiB", "ext4"), ("1GiB", None), ("1GiB", "lvmpv")])
 
-    @nondestructive
     def testUnusableFormats(self):
         """
         Description:
@@ -729,7 +674,6 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         """)
 
     @run_boot("efi")
-    @nondestructive
     def testExtendedPartition(self):
         """
         Description:
@@ -756,58 +700,6 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s.select_mountpoint_row_mountpoint(4, "/home")
         s.select_mountpoint_row_device(4, "home")
 
-    def _testWindowsSingleDiskHomeReuse_partition_disk(self):
-        storage = Storage(self.browser, self.machine)
-        move_standard_fedora_disk_to_win_disk(storage, self.machine, "vda", "vdb")
-
-    @run_boot("efi")
-    @disk_images([("", 35), ("fedora-rawhide", 15)])
-    def testWindowsSingleDiskHomeReuse(self):
-        """
-        Description:
-            Test home reuse via 'Mount point mapping' installation method with
-            a disk containig dual boot setup with Windows and Fedora (shared EFI partition).
-
-        Expected results:
-            - The mount point mapping scenario is available and can be used for reuse
-              of the home partition.
-            - The home reuse expected layout is shown in the review screen
-        """
-        b = self.browser
-        m = self.machine
-        i = Installer(b, m)
-        s = Storage(b, m)
-        r = Review(b, m)
-
-        i.open()
-        i.reach(i.steps.INSTALLATION_METHOD)
-
-        s.wait_scenario_available("mount-point-mapping", True)
-
-        s.select_mountpoint([("vda", True), ("vdb", False)])
-
-        s.select_mountpoint_row_device(1, "root")
-        s.select_mountpoint_row_device(2, "vda1")
-        s.select_mountpoint_row_device(3, "vda4")
-        s.select_mountpoint_row_reformat(3)
-        s.add_mountpoint_row()
-        s.select_mountpoint_row_mountpoint(4, "/home")
-        s.select_mountpoint_row_device(4, "home")
-        s.check_mountpoint_row_reformat(4, False)
-
-        i.next(should_fail=True)
-        i.reach(i.steps.REVIEW)
-
-        dev_win_fed = "vda"
-        r.check_disk(dev_win_fed, f"37.6 GB {dev_win_fed} (Virtio Block Device)")
-        r.check_disk_row(dev_win_fed, "/boot/efi", f"{dev_win_fed}1", "105 MB", False, "vfat", is_encrypted=False,
-                         action="mount")
-        r.check_disk_row(dev_win_fed, "/boot", f"{dev_win_fed}4", "1.07 GB", True, "ext4", is_encrypted=False)
-        r.check_disk_row(dev_win_fed, "/home", f"{dev_win_fed}5", "14.0 GB", False, "btrfs", is_encrypted=False,
-                         action="mount")
-        r.check_disk_row(dev_win_fed, "/", f"{dev_win_fed}5", "14.0 GB", True, "btrfs", is_encrypted=False)
-
-
     def _testEncryptedHomeSecondDisk_partition_disk(self):
         b = self.browser
         m = self.machine
@@ -823,7 +715,6 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
 
     @run_boot("efi")
     @disk_images([("", 15), ("", 10)])
-    @nondestructive
     def testEncryptedHomeSecondDisk(self):
         """
         Description:
@@ -884,6 +775,110 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
 
         r.check_disk(dev2, "10.7 GB vdb (Virtio Block Device)")
         r.check_disk_row(dev2, "/home", "", "10.7", False, "xfs", is_encrypted=True, action="mount")
+
+
+# TODO: these tests should be made nondestructive
+class TestStorageMountPointsDestructive(VirtInstallMachineCase, StorageCase):
+    provision = {"machine1": {"memory_mb": INSTALLER_VM_MEMORY_MB}}
+
+    def _testMBRParttable_partition_disk(self):
+        storage = Storage(self.browser, self.machine)
+        move_standard_fedora_disk_to_MBR_disk(storage, self.machine, "vda", "vdb")
+
+    @disk_images([("", 15), ("fedora-rawhide", 15)])
+    def testMBRParttable(self):
+        """
+        Description:
+            Test the case when the disk is MBR partitioned.
+
+        Expected results:
+            - The mount point mapping scenario is available and can be used with
+              MBR partitioned disks.
+        """
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m)
+        s = Storage(b, m)
+        r = Review(b, m)
+
+        # This is required for home-reuse availability check
+        pretend_default_scheme(self, "BTRFS")
+
+        i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+
+        s.wait_scenario_available("mount-point-mapping", True)
+
+        s.select_mountpoint([("vda", True), ("vdb", False)])
+
+        s.select_mountpoint_row_device(1, "root")
+        s.select_mountpoint_row_device(2, "vda1")
+        s.add_mountpoint_row()
+        s.select_mountpoint_row_mountpoint(3, "/home")
+        s.select_mountpoint_row_device(3, "home")
+
+        s.select_mountpoint_row_reformat(2)
+
+        i.reach(i.steps.REVIEW)
+
+        # verify review screen
+        disk = "vda"
+        r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
+
+        r.check_disk_row(disk, "/boot", "vda1", "1.07 GB", True, "ext4")
+        r.check_disk_row(disk, "/", "vda2", "14.0 GB", True, "btrfs subvolume")
+        r.check_disk_row(disk, "/home", "vda2", "14.0 GB", False, "btrfs")
+
+    def _testWindowsSingleDiskHomeReuse_partition_disk(self):
+        storage = Storage(self.browser, self.machine)
+        move_standard_fedora_disk_to_win_disk(storage, self.machine, "vda", "vdb")
+
+    @run_boot("efi")
+    @disk_images([("", 35), ("fedora-rawhide", 15)])
+    def testWindowsSingleDiskHomeReuse(self):
+        """
+        Description:
+            Test home reuse via 'Mount point mapping' installation method with
+            a disk containig dual boot setup with Windows and Fedora (shared EFI partition).
+
+        Expected results:
+            - The mount point mapping scenario is available and can be used for reuse
+              of the home partition.
+            - The home reuse expected layout is shown in the review screen
+        """
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m)
+        s = Storage(b, m)
+        r = Review(b, m)
+
+        i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+
+        s.wait_scenario_available("mount-point-mapping", True)
+
+        s.select_mountpoint([("vda", True), ("vdb", False)])
+
+        s.select_mountpoint_row_device(1, "root")
+        s.select_mountpoint_row_device(2, "vda1")
+        s.select_mountpoint_row_device(3, "vda4")
+        s.select_mountpoint_row_reformat(3)
+        s.add_mountpoint_row()
+        s.select_mountpoint_row_mountpoint(4, "/home")
+        s.select_mountpoint_row_device(4, "home")
+        s.check_mountpoint_row_reformat(4, False)
+
+        i.next(should_fail=True)
+        i.reach(i.steps.REVIEW)
+
+        dev_win_fed = "vda"
+        r.check_disk(dev_win_fed, f"37.6 GB {dev_win_fed} (Virtio Block Device)")
+        r.check_disk_row(dev_win_fed, "/boot/efi", f"{dev_win_fed}1", "105 MB", False, "vfat", is_encrypted=False,
+                         action="mount")
+        r.check_disk_row(dev_win_fed, "/boot", f"{dev_win_fed}4", "1.07 GB", True, "ext4", is_encrypted=False)
+        r.check_disk_row(dev_win_fed, "/home", f"{dev_win_fed}5", "14.0 GB", False, "btrfs", is_encrypted=False,
+                         action="mount")
+        r.check_disk_row(dev_win_fed, "/", f"{dev_win_fed}5", "14.0 GB", True, "btrfs", is_encrypted=False)
 
 
 if __name__ == '__main__':

--- a/test/check-storage-mountpoints-btrfs-e2e
+++ b/test/check-storage-mountpoints-btrfs-e2e
@@ -3,7 +3,7 @@
 # Copyright (C) 2025 Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from anacondalib import VirtInstallMachineCase, run_boot
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, run_boot
 from installer import Installer
 from review import Review
 from storage import Storage
@@ -11,6 +11,8 @@ from testlib import test_main, timeout  # pylint: disable=import-error
 
 
 class TestStorageMountPointsBtrfs_E2E(VirtInstallMachineCase):
+    provision = {"machine1": {"memory_mb": INSTALLER_VM_MEMORY_MB}}
+
     def _testPreserveHome_partition_disk(self):
         b = self.browser
         m = self.machine

--- a/test/check-storage-mountpoints-raid
+++ b/test/check-storage-mountpoints-raid
@@ -3,14 +3,17 @@
 # Copyright (C) 2024 Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from anacondalib import VirtInstallMachineCase, disk_images
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images
 from installer import Installer
 from review import Review
 from storage import Storage
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 
 
-class TestStorageMountPointsRAID(VirtInstallMachineCase):
+# TODO: these tests should be made nondestructive
+class TestStorageMountPointsRAIDDestructive(VirtInstallMachineCase):
+    provision = {"machine1": {"memory_mb": INSTALLER_VM_MEMORY_MB}}
+
     def _testEncryptedUnlockRAIDonLUKS_partition_disk(self):
         b = self.browser
         m = self.machine
@@ -130,6 +133,9 @@ class TestStorageMountPointsRAID(VirtInstallMachineCase):
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
         r.check_disk_row(dev, "/", "vda3, vda4, RAID", "5.35 GB", True, "xfs", True)
 
+
+@nondestructive
+class TestStorageMountPointsRAID(VirtInstallMachineCase):
     def _testRAID0Scenario_0_partition_disk(self):
         b = self.browser
         m = self.machine
@@ -154,7 +160,6 @@ class TestStorageMountPointsRAID(VirtInstallMachineCase):
         mkfs.ext4 -F /dev/md/SOMERAID1
         """, timeout=90)
 
-    @nondestructive
     @disk_images([("", 15), ("", 15), ("", 15)])
     def testRAID0Scenario_0(self):
         """

--- a/test/check-storage-mountpoints-raid-e2e
+++ b/test/check-storage-mountpoints-raid-e2e
@@ -3,13 +3,15 @@
 # Copyright (C) 2024 Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from anacondalib import VirtInstallMachineCase, disk_images
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images
 from installer import Installer
 from storage import Storage
 from testlib import test_main, timeout  # pylint: disable=import-error
 
 
 class TestStorageMountPointsRAID_E2E(VirtInstallMachineCase):
+    provision = {"machine1": {"memory_mb": INSTALLER_VM_MEMORY_MB}}
+
     def _testLVMOnRAID_partition_disk(self):
         b = self.browser
         m = self.machine

--- a/test/check-storage-reclaim-e2e
+++ b/test/check-storage-reclaim-e2e
@@ -3,7 +3,7 @@
 # Copyright (C) 2024 Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from anacondalib import VirtInstallMachineCase, disk_images
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images
 from installer import Installer
 from operating_systems import DualBootHelper_E2E
 from review import Review
@@ -12,6 +12,7 @@ from testlib import test_main, timeout  # pylint: disable=import-error
 
 
 class TestStorageReclaim_E2E(DualBootHelper_E2E, VirtInstallMachineCase):
+    provision = {"machine1": {"memory_mb": INSTALLER_VM_MEMORY_MB}}
 
     @disk_images([("debian-testing", 20)])
     @timeout(1200)

--- a/test/check-storage-use-free-space
+++ b/test/check-storage-use-free-space
@@ -3,15 +3,16 @@
 # Copyright (C) 2025 Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from anacondalib import VirtInstallMachineCase, disk_images
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images
 from installer import Installer
 from review import Review
 from storage import Storage
 from testlib import test_main  # pylint: disable=import-error
 
 
-# FIXME: add back @nondestructive
+# TODO: these tests should be made nondestructive
 class TestStorageUseFreeSpace(VirtInstallMachineCase):
+    provision = {"machine1": {"memory_mb": INSTALLER_VM_MEMORY_MB}}
 
     @disk_images([("debian-testing", 20)])
     def testBasic(self):

--- a/test/check-storage-use-free-space-e2e
+++ b/test/check-storage-use-free-space-e2e
@@ -3,7 +3,7 @@
 # Copyright (C) 2024 Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from anacondalib import VirtInstallMachineCase, disk_images, run_boot
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images, run_boot
 from installer import Installer
 from operating_systems import DualBootHelper_E2E
 from review import Review
@@ -12,6 +12,7 @@ from testlib import test_main, timeout  # pylint: disable=import-error
 
 
 class TestStorageUseFreeSpace_E2E(DualBootHelper_E2E, VirtInstallMachineCase):
+    provision = {"machine1": {"memory_mb": INSTALLER_VM_MEMORY_MB}}
 
     @disk_images([("debian-testing", 20)])
     @run_boot("bios", "efi")

--- a/test/machine_install.py
+++ b/test/machine_install.py
@@ -165,7 +165,7 @@ class VirtInstallMachine(VirtMachine):
                 f"{boot_arg} "
                 f"--name {self.label} "
                 f"--os-variant=detect=on "
-                "--memory 4096 "
+                f"--memory {self.memory_mb} "
                 "--noautoconsole "
                 f"--graphics vnc,listen={self.ssh_address} "
                 "--extra-args "

--- a/test/run
+++ b/test/run
@@ -114,7 +114,9 @@ echo "<pool type='dir'>
 virsh pool-define --file /tmp/storage-pool.xml
 
 export TEST_OS
-TEST_AUDIT_NO_SELINUX=1 test/common/run-tests --test-dir test/ $RUN_OPTS
+# Installer VMs need more RAM than typical Cockpit test guests
+RUN_TESTS_COMMON_OPTS="--nondestructive-memory-mb 4096"
+TEST_AUDIT_NO_SELINUX=1 test/common/run-tests $RUN_TESTS_COMMON_OPTS --test-dir test/ $RUN_OPTS
 exit_code=$?
 
 if [ -n "${TEST_COMPOSE-}" ] && [ "$TESTING_BRANCH" == "main" ]; then


### PR DESCRIPTION
Pass --nondestructive-memory-mb via run-tests for nondestructive jobs.

Add INSTALLER_VM_MEMORY_MB and set provision.machine1.memory_mb on destructive-only test classes; virt-install uses self.memory_mb from machine_install.

Split or mark tests so classes using @nondestructive do not set provision (cockpit testlib skips that combination).