### PR TITLE
Extract extlink URL handling into shared helper

### DIFF
--- a/src/components/Error.jsx
+++ b/src/components/Error.jsx
@@ -32,10 +32,10 @@ import {
     BUGZILLA_BASE_URL,
     buildBugDescription,
     buildBugSummary,
-    convertToExtlinkIfNeeded,
     createBugzillaEnterBug
 } from "../helpers/bugzilla.js";
 import { exitGui } from "../helpers/exit.js";
+import { convertToExtlinkIfNeeded } from "../helpers/extlink.js";
 import { debug, error } from "../helpers/log.js";
 
 import { AppVersionContext, NetworkContext, OsReleaseContext, SystemTypeContext } from "../contexts/Common.jsx";

--- a/src/components/HeaderKebab.jsx
+++ b/src/components/HeaderKebab.jsx
@@ -15,6 +15,8 @@ import { Stack, StackItem } from "@patternfly/react-core/dist/esm/layouts/Stack/
 import { EllipsisVIcon } from "@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon";
 import { ExternalLinkAltIcon } from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
 
+import { convertToExtlinkIfNeeded } from "../helpers/extlink.js";
+
 import { AppVersionContext, OsReleaseContext, SystemTypeContext } from "../contexts/Common.jsx";
 
 import { UserIssue } from "./Error.jsx";
@@ -70,7 +72,7 @@ const AnacondaAboutModal = ({ isModalOpen, setIsAboutModalOpen }) => {
                   id="anaconda-page-button"
                   variant="link"
                   icon={<ExternalLinkAltIcon />}
-                  href={(isBootIso ? "https://" : "extlink://") + "github.com/rhinstaller/anaconda"}
+                  href={convertToExtlinkIfNeeded("https://github.com/rhinstaller/anaconda", !isBootIso)}
                   target={isBootIso ? "_blank" : ""}
                   component="a">
                     {_("Anaconda project page")}

--- a/src/components/installation/Feedback.jsx
+++ b/src/components/installation/Feedback.jsx
@@ -8,6 +8,8 @@ import React, { useContext } from "react";
 import { Content } from "@patternfly/react-core/dist/esm/components/Content/index.js";
 import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 
+import { convertToExtlinkIfNeeded } from "../../helpers/extlink.js";
+
 import { SystemTypeContext } from "../../contexts/Common.jsx";
 
 import feedbackQRcode from "../../../images/qr-code-feedback.svg";
@@ -29,7 +31,7 @@ export const Feedback = () => {
                   component="a"
                   target={isBootIso ? "_blank" : ""}
                   rel={isBootIso ? "noreferrer" : ""}
-                  href={(isBootIso ? "https://" : "extlink://") + "discussion.fedoraproject.org/tag/anaconda"}>
+                  href={convertToExtlinkIfNeeded("https://discussion.fedoraproject.org/tag/anaconda", !isBootIso)}>
                     https://discussion.fedoraproject.org/tag/anaconda
                 </Content>
             </Content>

--- a/src/helpers/bugzilla.js
+++ b/src/helpers/bugzilla.js
@@ -6,19 +6,6 @@
 export const BUGZILLA_BASE_URL = "https://bugzilla.redhat.com";
 
 /**
- * Convert an HTTPS URL to extlink:// protocol if needed for non-boot ISO environments
- * @param {String} url - The URL to convert
- * @param {Boolean} useExtlink - Whether to use extlink:// protocol (true for non-boot ISO)
- * @returns {String} - The converted URL
- */
-export const convertToExtlinkIfNeeded = (url, useExtlink) => {
-    if (useExtlink && url.startsWith("https://")) {
-        return url.replace("https://", "extlink://");
-    }
-    return url;
-};
-
-/**
  * Create a Bugzilla URL for entering a bug report
  * @param {Object} osReleaseData - { product, version }
  * @param {String} component - Bugzilla component (defaults to "anaconda")

--- a/src/helpers/extlink.js
+++ b/src/helpers/extlink.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+/**
+ * Convert an HTTPS URL to extlink:// protocol if needed for non-boot ISO environments
+ * @param {String} url - The URL to convert
+ * @param {Boolean} useExtlink - Whether to use extlink:// protocol (true for non-boot ISO)
+ * @returns {String} - The converted URL
+ */
+export const convertToExtlinkIfNeeded = (url, useExtlink) => {
+    if (useExtlink && url.startsWith("https://")) {
+        return url.replace("https://", "extlink://");
+    }
+    return url;
+};


### PR DESCRIPTION
Move convertToExtlinkIfNeeded to a dedicated extlink helper module and reuse it in all flows so external link behavior is centralized.