### PR TITLE
Fix auto-reboot/poweroff after kickstart installation

### DIFF
--- a/src/apis/runtime.js
+++ b/src/apis/runtime.js
@@ -13,6 +13,9 @@ import { _getProperty } from "./helpers.js";
 const OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Runtime/UserInterface";
 const INTERFACE_NAME = "org.fedoraproject.Anaconda.Modules.Runtime.UserInterface";
 
+const RUNTIME_OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Runtime";
+const RUNTIME_INTERFACE_NAME = "org.fedoraproject.Anaconda.Modules.Runtime";
+
 const getProperty = (...args) => {
     return _getProperty(RuntimeClient, OBJECT_PATH, INTERFACE_NAME, ...args);
 };
@@ -98,4 +101,11 @@ export const getIsFinal = async () => {
  */
 export const getPasswordPolicies = () => {
     return getProperty("PasswordPolicies");
+};
+
+/**
+ * @returns {Promise}           Returns the RebootData structure (action, eject, kexec)
+ */
+export const getRebootData = () => {
+    return _getProperty(RuntimeClient, RUNTIME_OBJECT_PATH, RUNTIME_INTERFACE_NAME, "Reboot");
 };

--- a/src/components/installation/InstallationProgress.jsx
+++ b/src/components/installation/InstallationProgress.jsx
@@ -23,6 +23,7 @@ import { OsReleaseContext, SystemTypeContext } from "../../contexts/Common.jsx";
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 import { Feedback } from "./Feedback.jsx";
+import { useAutoReboot } from "./useAutoReboot.js";
 
 import "./InstallationProgress.scss";
 
@@ -38,7 +39,7 @@ const progressStepsMap = {
     SYSTEM_CONFIGURATION: 3,
 };
 
-export const InstallationProgress = ({ onCritFail }) => {
+export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
     const [status, setStatus] = useState();
     const [statusMessage, setStatusMessage] = useState("");
     const [steps, setSteps] = useState();
@@ -46,6 +47,8 @@ export const InstallationProgress = ({ onCritFail }) => {
     const refStatusMessage = useRef("");
     const isBootIso = useContext(SystemTypeContext).systemType === "BOOT_ISO";
     const osRelease = useContext(OsReleaseContext);
+
+    useAutoReboot(status, automatedInstall);
 
     useEffect(() => {
         installWithTasks()

--- a/src/components/installation/useAutoReboot.js
+++ b/src/components/installation/useAutoReboot.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import { useEffect } from "react";
+
+import { getRebootData } from "../../apis/runtime.js";
+
+import { exitGui } from "../../helpers/exit.js";
+import { debug } from "../../helpers/log.js";
+
+const KS_REBOOT = 1;
+const KS_SHUTDOWN = 2;
+
+/**
+ * Automatically exit the GUI after a successful automated installation
+ * if the kickstart specifies a reboot or shutdown action.
+ *
+ * @param {string|undefined} status - current installation status
+ * @param {boolean} automatedInstall - whether this is a kickstart/automated install
+ */
+export const useAutoReboot = (status, automatedInstall) => {
+    useEffect(() => {
+        if (status !== "success" || !automatedInstall) {
+            return;
+        }
+
+        const autoReboot = async () => {
+            const rebootData = await getRebootData();
+            const action = rebootData?.action?.v;
+            if (action === KS_REBOOT || action === KS_SHUTDOWN) {
+                debug("Auto-exit: kickstart reboot/shutdown action detected, exiting GUI");
+                exitGui();
+            }
+        };
+
+        autoReboot();
+    }, [status, automatedInstall]);
+};


### PR DESCRIPTION
When a kickstart file specifies a reboot or poweroff command, the WebUI now automatically triggers the corresponding action after installation completes, matching the behavior of the GUI and TUI frontends.

After the installation task succeeds in automated mode, the progress screen reads the RebootData.action property from the Runtime D-Bus module. If KS_REBOOT (1) or KS_SHUTDOWN (2) is set, exitGui() is called automatically without waiting for user interaction.

Previously, the WebUI always showed the "Reboot" button and waited for a manual click, even when a kickstart reboot/poweroff command was present.