### PR TITLE
storage: avoid UnknownDeviceError after disk removal and rescan

### DIFF
--- a/src/helpers/storage.js
+++ b/src/helpers/storage.js
@@ -323,3 +323,18 @@ export const selectDefaultDisks = ({ ignoredDisks, selectedDisks, usableDisks })
     }
     return [];
 };
+
+/**
+ * Selected disks that also appear in the module usable list. SelectedDisks can still name
+ * removed disks after a rescan.
+ *
+ * @param {string[]} selectedDisks
+ * @param {string[]} usableDisks
+ * @returns {string[]}
+ */
+export const intersectSelectedDisksWithUsable = (selectedDisks, usableDisks) => {
+    if (!usableDisks) {
+        return selectedDisks;
+    }
+    return selectedDisks.filter(disk => usableDisks.includes(disk));
+};

--- a/src/hooks/Storage.jsx
+++ b/src/hooks/Storage.jsx
@@ -28,7 +28,12 @@ import {
     resetPartitioning,
 } from "../apis/storage_partitioning.js";
 
-import { getDeviceAncestors, hasReusableFedoraWithWindowsOS, systemMountPoints } from "../helpers/storage.js";
+import {
+    getDeviceAncestors,
+    hasReusableFedoraWithWindowsOS,
+    intersectSelectedDisksWithUsable,
+    systemMountPoints,
+} from "../helpers/storage.js";
 
 import { PageContext, StorageContext, StorageDefaultsContext } from "../contexts/Common.jsx";
 
@@ -40,15 +45,17 @@ export const useDiskTotalSpace = () => {
     const devices = useOriginalDevices();
     const { diskSelection } = useContext(StorageContext);
     const selectedDisks = diskSelection.selectedDisks;
+    const usableDisks = diskSelection.usableDisks;
 
     useEffect(() => {
         const update = async () => {
-            const diskTotalSpace = await getDiskTotalSpace({ diskNames: selectedDisks });
+            const diskNames = intersectSelectedDisksWithUsable(selectedDisks, usableDisks);
+            const diskTotalSpace = await getDiskTotalSpace({ diskNames });
 
             setDiskTotalSpace(diskTotalSpace);
         };
         update();
-    }, [selectedDisks, devices]);
+    }, [selectedDisks, usableDisks, devices]);
 
     return diskTotalSpace;
 };
@@ -59,15 +66,17 @@ export const useDiskFreeSpace = () => {
     const devices = useOriginalDevices();
     const { diskSelection } = useContext(StorageContext);
     const selectedDisks = diskSelection.selectedDisks;
+    const usableDisks = diskSelection.usableDisks;
 
     useEffect(() => {
         const update = async () => {
-            const diskFreeSpace = await getDiskFreeSpace({ diskNames: selectedDisks });
+            const diskNames = intersectSelectedDisksWithUsable(selectedDisks, usableDisks);
+            const diskFreeSpace = await getDiskFreeSpace({ diskNames });
 
             setDiskFreeSpace(diskFreeSpace);
         };
         update();
-    }, [selectedDisks, devices]);
+    }, [selectedDisks, usableDisks, devices]);
 
     return diskFreeSpace;
 };
@@ -138,10 +147,12 @@ export const useMountPointConstraints = () => {
     const devices = useOriginalDevices();
     const { diskSelection } = useContext(StorageContext);
     const selectedDisks = diskSelection.selectedDisks;
+    const usableDisks = diskSelection.usableDisks;
 
     useEffect(() => {
         const update = async () => {
-            let _mountPointConstraints = await getMountPointConstraints({ diskNames: selectedDisks });
+            const diskNames = intersectSelectedDisksWithUsable(selectedDisks, usableDisks);
+            let _mountPointConstraints = await getMountPointConstraints({ diskNames });
             _mountPointConstraints = await Promise.all(_mountPointConstraints.map(async c => {
                 let description = "";
                 const formatType = c["required-filesystem-type"].v;
@@ -154,7 +165,7 @@ export const useMountPointConstraints = () => {
             setMountPointConstraints(_mountPointConstraints);
         };
         update();
-    }, [selectedDisks, devices]);
+    }, [selectedDisks, usableDisks, devices]);
 
     return mountPointConstraints;
 };

--- a/test/check-storage-basic
+++ b/test/check-storage-basic
@@ -31,6 +31,8 @@ class TestStorageBasic(VirtInstallMachineCase):
             - When the selected disk[s] does not have enough space for the installation,
               the installer should not allow the user to continue
             - The disk selection should be preserved when moving back and forth between screens
+            - Removing the second disk and rescanning should reflect only the remaining disk
+              (rhbz#2456923)
         """
         b = self.browser
         i = Installer(b, self.machine)
@@ -61,7 +63,7 @@ class TestStorageBasic(VirtInstallMachineCase):
         # the newly added disk, will not be visible in the UI,
         # until the test clicks on the re-scan button
         dev = "vdb"
-        self.add_disk(2, target=dev)
+        vdb_image = self.add_disk(2, target=dev)
         s.rescan_disks(["vda", dev])
 
         # Check the next button is disabled when not sufficient disk space is available
@@ -96,6 +98,13 @@ class TestStorageBasic(VirtInstallMachineCase):
         i.back()
         for disk in ["vda", dev]:
             s.check_disk_selected(disk)
+
+        # rhbz#2456923: unplug second disk while it remains in the installer's selection, then rescan
+        self.rem_disk(vdb_image)
+        s.rescan_disks(["vda"])
+        s.check_disk_selected("vda", selected=True)
+        s.check_disk_selected(dev, selected=False)
+        i.check_next_disabled(False)
 
     def testScenarioSelection(self):
         """


### PR DESCRIPTION
After a disk was removed from the VM and the user rescanned, D-Bus SelectedDisks could still list that device name for a while. The storage module's GetDiskTotalSpace, GetDiskFreeSpace, and GetMountPointConstraints resolve names against the current device tree only, so a stale id raised UnknownDeviceError (rhbz#2456923).

We now filter selectedDisks by usableDisks before calling any APIs. Usable disks are derived from the same module state as the tree after a scan, so a removed disk cannot be in usableDisks and is dropped before any viewer call.

Resolves: rhbz#2456923