### PR TITLE
tests: robustify pixel test by waiting for the review screen to fully load

### DIFF
--- a/test/check-kickstart-automated
+++ b/test/check-kickstart-automated
@@ -93,6 +93,7 @@ class TestKickstartAutomated(VirtInstallMachineCase):
         r.check_disk_row(dev1, "/home", "vda3", "2.15 GB", True, "xfs")
         r.check_disk_row(dev1, "swap", "vda4", "1.07 GB", True, "swap")
 
+        i.check_next_disabled(disabled=False)
         b.assert_pixels(".anaconda-wizard-step-anaconda-screen-review", "review-kickstarted", ignore=pixel_tests_ignore)
 
     def testUserInterfaceCanChangeAccountsConf(self):

--- a/test/helpers/installer.py
+++ b/test/helpers/installer.py
@@ -149,7 +149,7 @@ class Installer():
         :type disabled: bool, optional
         """
         value = "false" if disabled else "true"
-        self.browser.wait_visible(f"#installation-next-btn:not([aria-disabled={value}]")
+        self.browser.wait_visible(f"#installation-next-btn:not([aria-disabled={value}])")
 
     def check_sidebar_step_disabled(self, step, disabled=True):
         """Check if a sidebar step is disabled.


### PR DESCRIPTION
This test's pixel test was sometimes failing with unexpected state of the footer buttons, seemingly by taking the screenshot before the screen initialization finished.