### PR TITLE
tests: add @payload_type decorator for DNF VM provisioning

### DIFF
--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -67,6 +67,14 @@ class VirtInstallMachineCase(MachineCase):
 
     def setUp(self):
         method = getattr(self, self._testMethodName)
+        payload_type = getattr(method, "payload_type", None)
+        if payload_type and not self.is_nondestructive():
+            provision = dict(self.provision or {"machine1": {}})
+            self.provision = {
+                key: {**dict(opts), "payload_type": payload_type}
+                for key, opts in provision.items()
+            }
+
         boot_modes = getattr(method, "boot_modes", ["bios"])
         self.run_on_vm_setups = getattr(method, "run_on_vm_setups", [""])
         self.disk_images = getattr(method, "disk_images", [("", 15)])
@@ -355,6 +363,16 @@ def disk_images(disks):
     """
     def decorator(func):
         func.disk_images = list(disks)
+        return func
+    return decorator
+
+
+def payload_type(mode):
+    """
+    Decorator to provision the installer VM with a specific payload (``liveimg`` or ``dnf``).
+    """
+    def decorator(func):
+        func.payload_type = mode.lower()
         return func
     return decorator
 

--- a/test/check-kickstart-automated
+++ b/test/check-kickstart-automated
@@ -3,7 +3,7 @@
 # Copyright (C) 2025 Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, pixel_tests_ignore
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, payload_type, pixel_tests_ignore
 from installer import Installer
 from payload_dnf import PayloadDNF
 from review import Review
@@ -19,11 +19,11 @@ class TestKickstartAutomated(VirtInstallMachineCase):
     provision = {
         "machine1": {
             "kickstart_file_name": "TestKickstartAutomated-testBasic.ks",
-            "payload_type": "dnf",
             "memory_mb": INSTALLER_VM_MEMORY_MB,
         },
     }
 
+    @payload_type("dnf")
     def testBasic(self):
         """
         Description:

--- a/test/check-payload-dnf
+++ b/test/check-payload-dnf
@@ -6,7 +6,7 @@
 import os
 import sys
 
-from anacondalib import VirtInstallMachineCase, pixel_tests_ignore
+from anacondalib import VirtInstallMachineCase, payload_type, pixel_tests_ignore
 from installer import Installer
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 
@@ -17,8 +17,8 @@ from payload_dnf import PayloadDNF
 
 @nondestructive
 class TestPayloadDNF(VirtInstallMachineCase):
-    provision = {"machine1": {"payload_type": "dnf"}}
 
+    @payload_type("dnf")
     def testEnvironmentPackages(self):
         """
         Description:

--- a/test/check-payload-dnf-e2e
+++ b/test/check-payload-dnf-e2e
@@ -3,7 +3,7 @@
 # Copyright (C) 2025 Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images, payload_type
 from installer import Installer
 from progress import Progress
 from testlib import test_main, timeout  # pylint: disable=import-error
@@ -11,8 +11,9 @@ from utils import get_pretty_name
 
 
 class TestPayloadDNF_E2E(VirtInstallMachineCase):
-    provision = {"machine1": {"payload_type": "dnf", "memory_mb": INSTALLER_VM_MEMORY_MB}}
+    provision = {"machine1": {"memory_mb": INSTALLER_VM_MEMORY_MB}}
 
+    @payload_type("dnf")
     @disk_images([("", 15)])
     @timeout(1200)
     def testDefaultClosestMirror(self):


### PR DESCRIPTION
That replaces the payload_type in the provision attribute. The custom provision is incompatible with non-destructive tests.

This fixes the Payload Basic test being skipped with: "Cannot provision multiple machines if a specific machine address is specified"

https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/pull-1151-de40b6ef-20260520-073235-fedora-rawhide-boot-dnf/log.html