### PR TITLE
storage: show specific error when /boot/efi is on vfat without ESP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ ignore_names = [
    "_testReclaimSpaceShrinkBtrfsSubvolumes_partition_disk",
    "_testReclaimSpaceWindows_partition_disk",
    "_testUnusableFormats_partition_disk",
+   "_testVfatWithoutESP_partition_disk",
    "_testWindows_partition_disk",
    "_testWindowsSingleDisk_partition_disk",
    "_testWindowsSingleDiskHomeReuse_partition_disk",

--- a/src/components/storage/mount-point-mapping/MountPointMapping.jsx
+++ b/src/components/storage/mount-point-mapping/MountPointMapping.jsx
@@ -28,6 +28,7 @@ import {
     getDeviceAncestors,
     getDeviceChildren,
     getLockedLUKSDevices,
+    getMountPointFormatConstraintError,
     hasDuplicateFields,
     isDuplicateRequestField,
     requestsFromDbus,
@@ -172,12 +173,14 @@ const isDeviceMountPointInvalid = (deviceData, mountPointConstraints, request) =
         return [false, ""];
     }
 
-    // we have constraints for filesystem type for required and recommended mount points from the backend) {
-    if (constrainedMountPointData && constrainedMountPointData["required-filesystem-type"].v !== "" &&
-        deviceData[device].formatData.type.v !== constrainedMountPointData["required-filesystem-type"].v) {
-        return [true,
-            cockpit.format(_("'$0' must be on a device formatted to '$1'"),
-                           request["mount-point"], constrainedMountPointData["required-filesystem-type"].v)];
+    const [formatInvalid, formatError] = getMountPointFormatConstraintError({
+        constraint: constrainedMountPointData,
+        device,
+        devices: deviceData,
+        mountPoint: request["mount-point"],
+    });
+    if (formatInvalid) {
+        return [true, formatError];
     }
     if (constrainedMountPointData && !constrainedMountPointData["encryption-allowed"].v &&
         deviceData[device].type.v === "luks/dm-crypt") {
@@ -362,7 +365,11 @@ const DeviceColumn = ({ deviceData, devices, handleRequestChange, idPrefix, isRe
     const [deviceInvalid, errorMessage] = isDeviceMountPointInvalid(deviceData, mountPointConstraints, request);
 
     return (
-        <Flex direction={{ default: "column" }} spaceItems={{ default: "spaceItemsNone" }}>
+        <Flex
+          direction={{ default: "column" }}
+          id={idPrefix}
+          spaceItems={{ default: "spaceItemsNone" }}
+        >
             <DeviceColumnSelect
               deviceData={deviceData}
               devices={devices}

--- a/src/helpers/storage.js
+++ b/src/helpers/storage.js
@@ -194,6 +194,46 @@ export const unitMultiplier = {
 
 export const bootloaderTypes = ["efi", "biosboot", "appleboot", "prepboot"];
 
+const _ = cockpit.gettext;
+
+/* Blivet reports plain FAT without ESP flags as "vfat", not "efi". */
+const VFAT_FORMAT_TYPE = "vfat";
+
+/**
+ * Check whether a device satisfies the format constraint for a mount point.
+ *
+ * The backend's required-filesystem-type field actually carries blivet format
+ * types (efi, biosboot, ext4, ...). Bootloader format types such as "efi" are
+ * not filesystem types; use constraint.description (from GetFormatTypeData)
+ * when presenting them to the user.
+ *
+ * @returns {[boolean, string]} [invalid, errorMessage]
+ */
+export const getMountPointFormatConstraintError = ({ constraint, device, devices, mountPoint }) => {
+    const requiredFormatType = constraint?.["required-filesystem-type"]?.v;
+    const deviceFormatType = devices[device]?.formatData?.type?.v;
+
+    if (!requiredFormatType || !deviceFormatType || deviceFormatType === requiredFormatType) {
+        return [false, ""];
+    }
+
+    const formatLabel = constraint.description || requiredFormatType;
+
+    if (requiredFormatType === "efi" && deviceFormatType === VFAT_FORMAT_TYPE) {
+        return [true,
+            cockpit.format(
+                _("'$0' must be on an EFI System Partition. The selected partition uses a FAT filesystem, but is not marked as an ESP. Set the partition type to EFI System and enable the esp flag."),
+                mountPoint
+            )];
+    }
+
+    if (bootloaderTypes.includes(requiredFormatType)) {
+        return [true, cockpit.format(_("'$0' must be assigned to $1"), mountPoint, formatLabel)];
+    }
+
+    return [true, cockpit.format(_("'$0' must be on a device formatted to '$1'"), mountPoint, formatLabel)];
+};
+
 /* Filter requests to remove devices that should not be sent to the backend.
  * Keeps:
  * - Requests with reformat set to true or with specified mount points

--- a/test/check-storage-mountpoints
+++ b/test/check-storage-mountpoints
@@ -712,6 +712,43 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s.select_mountpoint_row_mountpoint(4, "/home")
         s.select_mountpoint_row_device(4, "home")
 
+    def _testVfatWithoutESP_partition_disk(self):
+        b = self.browser
+        m = self.machine
+        s = Storage(b, m)
+
+        disk = "/dev/vda"
+        # Vfat partition, /boot on ext4, / on xfs
+        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "vfat"), ("1GiB", "ext4"), ("", "xfs")])
+
+    def testVfatWithoutESP(self):
+        """
+        Description:
+            Test that assigning /boot/efi to a vfat partition without the ESP
+            flag shows an appropriate error message.
+
+        Expected results:
+            - When a vfat partition without ESP type is selected for /boot/efi,
+              an error about missing ESP marking is shown.
+        """
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m)
+        s = Storage(b, m)
+
+        dev = "vda"
+
+        i.open()
+        i.reach(i.steps.INSTALLATION_METHOD)
+
+        s.select_mountpoint([(dev, True)])
+
+        s.select_mountpoint_row_device(2, f"{dev}1")
+        s.select_mountpoint_row_device(1, f"{dev}3")
+        s.select_mountpoint_row_device(3, f"{dev}2")
+
+        s.wait_mountpoint_table_column_helper(2, "device", text="must be on an EFI System Partition")
+
     def _testEncryptedHomeSecondDisk_partition_disk(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
vfat partitions without the EFI System type are reported as vfat, not efi. Show a clearer validation message instead of requiring format type efi.