### PR TITLE
tests: fix storage actions tests

### DIFF
--- a/src/components/storage/StorageReview.jsx
+++ b/src/components/storage/StorageReview.jsx
@@ -141,6 +141,7 @@ const DeviceRow = ({ disk, isReviewScreen }) => {
                     ...(isReviewScreen ? [{ title: helperText, width: 17 }] : []),
                 ],
                 props: {
+                    "data-action": action,
                     "data-device": deviceText,
                     "data-mount": mount,
                     "data-size": size,

--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -583,7 +583,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "ext4")
-        r.check_disk_row(dev, "/", "vda3", "14.5 GB", True, "btrfs")
+        r.check_disk_row(dev, "/", "vda3", "14.5 GB", True, "btrfs subvolume")
         r.check_disk_row(dev, "/home", "vda3", "14.5 GB", False)
 
         # Check fstab

--- a/test/check-storage-home-reuse
+++ b/test/check-storage-home-reuse
@@ -128,8 +128,8 @@ class TestStorageHomeReuse(VirtInstallMachineCase, _TestStorageHomeReuseHelpers)
         if self.is_efi:
             r.check_disk_row(dev, "/boot/efi", f"{dev}2", "629 MB", True, "efi", is_encrypted=False)
         r.check_disk_row(dev, "/boot", f"{dev}4", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
-        r.check_disk_row(dev, "/", f"{dev}3", "13.9 GB", True, "btrfs", is_encrypted=False)
-        r.check_disk_row(dev, "/home", f"{dev}3", "13.9 GB", False, "btrfs", is_encrypted=False,
+        r.check_disk_row(dev, "/", f"{dev}3", "13.9 GB", True, "btrfs subvolume", is_encrypted=False)
+        r.check_disk_row(dev, "/home", f"{dev}3", "13.9 GB", False, "btrfs subvolume", is_encrypted=False,
                          action="mount")
 
     @disk_images([("fedora-rawhide", 15)])
@@ -217,8 +217,8 @@ class TestStorageHomeReuse(VirtInstallMachineCase, _TestStorageHomeReuseHelpers)
         # check selected disks are shown
         r.check_disk(dev_fedora1, f"16.1 GB {dev_fedora1} (Virtio Block Device)")
         r.check_disk_row(dev_fedora1, parent=f"{dev_fedora1}1", action="delete")
-        r.check_disk_row(dev_fedora1, "/", f"{dev_fedora1}3", "13.9 GB", True, "btrfs", is_encrypted=False)
-        r.check_disk_row(dev_fedora1, "/home", f"{dev_fedora1}3", "13.9 GB", False, "btrfs", is_encrypted=False,
+        r.check_disk_row(dev_fedora1, "/", f"{dev_fedora1}3", "13.9 GB", True, "btrfs subvolume", is_encrypted=False)
+        r.check_disk_row(dev_fedora1, "/home", f"{dev_fedora1}3", "13.9 GB", False, "btrfs subvolume", is_encrypted=False,
                          action="mount")
         r.check_disk_row(dev_fedora1, "/boot", f"{dev_fedora1}4", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
 
@@ -264,8 +264,8 @@ class TestStorageHomeReuseDestructive(VirtInstallMachineCase, _TestStorageHomeRe
         r.check_disk(dev, f"16.1 GB {dev} (Virtio Block Device)")
         r.check_disk_row(dev, parent=f"{dev}1", action="delete")
         r.check_disk_row(dev, "/boot", f"{dev}2", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
-        r.check_disk_row(dev, "/", f"{dev}3", "13.4 GB", True, "btrfs", is_encrypted=True)
-        r.check_disk_row(dev, "/home", f"{dev}3", "13.4 GB", False, "btrfs", is_encrypted=True, action="mount")
+        r.check_disk_row(dev, "/", f"{dev}3", "13.4 GB", True, "btrfs subvolume", is_encrypted=True)
+        r.check_disk_row(dev, "/home", f"{dev}3", "13.4 GB", False, "btrfs subvolume", is_encrypted=True, action="mount")
 
     def _testNonLinuxSystem_partition_disk(self):
         b = self.browser
@@ -374,9 +374,9 @@ class TestStorageHomeReuseDestructive(VirtInstallMachineCase, _TestStorageHomeRe
         # check selected disks are shown
         r.check_disk(dev_mbr, f"21.5 GB {dev_mbr} (Virtio Block Device)")
         r.check_disk_row(dev_mbr, parent=f"{dev_mbr}1", action="delete")
-        r.check_disk_row(dev_mbr, "/home", f"{dev_mbr}2", "14.0 GB", False, "btrfs", is_encrypted=False,
+        r.check_disk_row(dev_mbr, "/home", f"{dev_mbr}2", "14.0 GB", False, "btrfs subvolume", is_encrypted=False,
                          action="mount")
-        r.check_disk_row(dev_mbr, "/", f"{dev_mbr}2", "14.0 GB", True, "btrfs", is_encrypted=False)
+        r.check_disk_row(dev_mbr, "/", f"{dev_mbr}2", "14.0 GB", True, "btrfs subvolume", is_encrypted=False)
         r.check_disk_row(dev_mbr, "/boot", f"{dev_mbr}1", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
 
     def _testWindowsSingleDisk_partition_disk(self):
@@ -440,9 +440,9 @@ class TestStorageHomeReuseDestructive(VirtInstallMachineCase, _TestStorageHomeRe
         r.check_disk_row(dev_win_fed, parent=f"{dev_win_fed}4", action="delete")
         r.check_disk_row(dev_win_fed, "/boot/efi", f"{dev_win_fed}1", "105 MB", False, "vfat", is_encrypted=False,
                          action="mount")
-        r.check_disk_row(dev_win_fed, "/home", f"{dev_win_fed}5", "14.0 GB", False, "btrfs", is_encrypted=False,
+        r.check_disk_row(dev_win_fed, "/home", f"{dev_win_fed}5", "14.0 GB", False, "btrfs subvolume", is_encrypted=False,
                          action="mount")
-        r.check_disk_row(dev_win_fed, "/", f"{dev_win_fed}5", "14.0 GB", True, "btrfs", is_encrypted=False)
+        r.check_disk_row(dev_win_fed, "/", f"{dev_win_fed}5", "14.0 GB", True, "btrfs subvolume", is_encrypted=False)
         r.check_disk_row(dev_win_fed, "/boot", f"{dev_win_fed}4", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
 
 

--- a/test/check-storage-mountpoints
+++ b/test/check-storage-mountpoints
@@ -621,9 +621,9 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
 
         r.check_disk_row(disk, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
         r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False)
-        r.check_disk_row(disk, "/", "vda3", "5.37 GB", True, "btrfs")
-        r.check_disk_row(disk, "/home/joe", "vda4", "5.37 GB", False, "btrfs")
-        r.check_disk_row(disk, "/home/alan", "vda5", "3.77 GB", False, "btrfs")
+        r.check_disk_row(disk, "/", "vda3", "5.37 GB", True, "btrfs volume")
+        r.check_disk_row(disk, "/home/joe", "vda4", "5.37 GB", False, "btrfs volume")
+        r.check_disk_row(disk, "/home/alan", "vda5", "3.77 GB", False, "btrfs volume")
 
     def _testUnusableFormats_partition_disk(self):
         b = self.browser
@@ -840,7 +840,7 @@ class TestStorageMountPointsDestructive(VirtInstallMachineCase, StorageCase):
 
         r.check_disk_row(disk, "/boot", "vda1", "1.07 GB", True, "ext4")
         r.check_disk_row(disk, "/", "vda2", "14.0 GB", True, "btrfs subvolume")
-        r.check_disk_row(disk, "/home", "vda2", "14.0 GB", False, "btrfs")
+        r.check_disk_row(disk, "/home", "vda2", "14.0 GB", False, "btrfs subvolume")
 
     def _testWindowsSingleDiskHomeReuse_partition_disk(self):
         storage = Storage(self.browser, self.machine)
@@ -888,9 +888,9 @@ class TestStorageMountPointsDestructive(VirtInstallMachineCase, StorageCase):
         r.check_disk_row(dev_win_fed, "/boot/efi", f"{dev_win_fed}1", "105 MB", False, "vfat", is_encrypted=False,
                          action="mount")
         r.check_disk_row(dev_win_fed, "/boot", f"{dev_win_fed}4", "1.07 GB", True, "ext4", is_encrypted=False)
-        r.check_disk_row(dev_win_fed, "/home", f"{dev_win_fed}5", "14.0 GB", False, "btrfs", is_encrypted=False,
+        r.check_disk_row(dev_win_fed, "/home", f"{dev_win_fed}5", "14.0 GB", False, "btrfs subvolume", is_encrypted=False,
                          action="mount")
-        r.check_disk_row(dev_win_fed, "/", f"{dev_win_fed}5", "14.0 GB", True, "btrfs", is_encrypted=False)
+        r.check_disk_row(dev_win_fed, "/", f"{dev_win_fed}5", "14.0 GB", True, "btrfs subvolume", is_encrypted=False)
 
 
 if __name__ == '__main__':

--- a/test/check-storage-mountpoints-btrfs
+++ b/test/check-storage-mountpoints-btrfs
@@ -87,7 +87,7 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase):
         # verify review screen
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, True, "efi")
+        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False, "efi")
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "ext4")
         r.check_disk_row(dev, "/", "vda3", "14.5 GB", True, "btrfs subvolume")
         r.check_disk_row(dev, "/home", "vda3", "14.5 GB", False)

--- a/test/check-storage-mountpoints-btrfs
+++ b/test/check-storage-mountpoints-btrfs
@@ -89,7 +89,7 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase):
 
         r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, True, "efi")
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "ext4")
-        r.check_disk_row(dev, "/", "vda3", "14.5 GB", True, "btrfs")
+        r.check_disk_row(dev, "/", "vda3", "14.5 GB", True, "btrfs subvolume")
         r.check_disk_row(dev, "/home", "vda3", "14.5 GB", False)
         r.check_disk_row_not_present(dev, "unused")
 
@@ -208,7 +208,7 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase):
         i.reach(i.steps.REVIEW)
         r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
         r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False)
-        r.check_disk_row(dev, "/", "vda3", "14.5 GB", True, "btrfs", True)
+        r.check_disk_row(dev, "/", "vda3", "14.5 GB", True, "btrfs subvolume", True)
 
 
 if __name__ == '__main__':

--- a/test/check-storage-mountpoints-btrfs-e2e
+++ b/test/check-storage-mountpoints-btrfs-e2e
@@ -94,7 +94,7 @@ class TestStorageMountPointsBtrfs_E2E(VirtInstallMachineCase):
 
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
         r.check_disk_row(dev, "/boot/efi", f"{dev}1", "105 MB", False)
-        r.check_disk_row(dev, "/", f"{dev}2", "16.0 GB", True, "btrfs")
+        r.check_disk_row(dev, "/", f"{dev}2", "16.0 GB", True, "btrfs subvolume")
         r.check_disk_row(dev, "/home", f"{dev}2", "16.0 GB", False)
 
         self.install(button_text="Apply mount point assignment and install", needs_confirmation=True)

--- a/test/check-storage-mountpoints-raid
+++ b/test/check-storage-mountpoints-raid
@@ -137,7 +137,7 @@ class TestStorageMountPointsRAIDDestructive(VirtInstallMachineCase):
         i.reach(i.steps.REVIEW)
         r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
         r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False, "efi")
-        r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "xfs")
+        r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False, "xfs")
         r.check_disk_row(dev, "/", "vda3, vda4, RAID", "5.35 GB", True, "xfs", True)
 
 

--- a/test/helpers/review.py
+++ b/test/helpers/review.py
@@ -63,13 +63,8 @@ class Review(NetworkDBus, StorageDBus):
         action_text = f"format as {fs_type}" if reformat else action or "mount"
         encrypt_text = "encrypted" if is_encrypted and not reformat else "encrypt" if is_encrypted and reformat else ""
 
-        # Action rows (delete/resize) have data-action and no data-mount;
-        # mount rows have data-mount and no data-action.
-        # Detect action rows: explicit non-default action, no mount_point, no reformat.
-        is_action_row = action and action not in ("mount", "biosboot", "efi") and not mount_point and not reformat
         row = f'{table} tr[data-device="{parent}"]'
-        if is_action_row:
-            row = f'{row}[data-action="{action_text}"]'
+        row = f'{row}[data-action="{action_text}"]'
         if mount_point:
             row = f'{row}[data-mount="{mount_point}"]'
         if is_encrypted:


### PR DESCRIPTION
With the https://github.com/rhinstaller/anaconda-webui/pull/1265 we effectively stopped testing format/mount/biosboot actions for DeviceRow review rows.

Related: INSTALLER-4736