### PR TITLE
tests: adjust scenario trigger for compose testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,9 +233,9 @@ print-test-os:
 .PHONY: test-compose
 test-compose: bots
 	bots/tests-trigger --force "-" "${TEST_OS}/compose-${TEST_COMPOSE}"
-	bots/tests-trigger --force "-" "${TEST_OS}/efi-compose-${TEST_COMPOSE}"
+	bots/tests-trigger --force "-" "${TEST_OS}/bios-compose-${TEST_COMPOSE}"
 
 .PHONY: test-compose-staging
 test-compose-staging: bots
 	bots/tests-trigger --force "-" "${TEST_OS}/compose-${TEST_COMPOSE}-staging"
-	bots/tests-trigger --force "-" "${TEST_OS}/efi-compose-${TEST_COMPOSE}-staging"
+	bots/tests-trigger --force "-" "${TEST_OS}/bios-compose-${TEST_COMPOSE}-staging"

--- a/test/fedora-wiki/README-FEDORAWIKI.rst
+++ b/test/fedora-wiki/README-FEDORAWIKI.rst
@@ -45,9 +45,8 @@ limitations that need to be addressed:
   responsiveness in the future.
 - **Architecture**: Currently, tests are only run on `x86_64` architecture. Support for additional
   architectures will be added in the future.
-- **Firmware Boot Mode**: Not all tests are currently tested with UEFI, only tests that are considered
-  firmware-specific are run with UEFI firmware boot mode. This may need to change to better align with
-  Fedora's QA test matrix.
+- **Firmware Boot Mode**: Not all tests are currently tested with BIOS, only tests that are considered
+  firmware-specific are run with BIOS firmware boot mode.
 
 Workflow Summary
 ----------------


### PR DESCRIPTION
There is not `efi` scenario anymore, UEFI firmware test runs are now done by default and the extra scenario is `bios`.