### PR TITLE
storage: show sizes in binary units and align tests

### DIFF
--- a/src/components/storage/StorageReview.jsx
+++ b/src/components/storage/StorageReview.jsx
@@ -11,6 +11,7 @@ import { Stack } from "@patternfly/react-core/dist/esm/layouts/Stack/index.js";
 
 import {
     checkDeviceOnStorageType,
+    formatBytes,
     getDeviceAncestors,
     getDeviceChildren,
     getParentPartitions,
@@ -81,14 +82,14 @@ const DeviceRow = ({ disk, isReviewScreen }) => {
     let insufficientSizeMessage = "";
     if (requiredSize > freeSpace) {
         if (Object.keys(plannedSystemMountPoints).length === 1) {
-            insufficientSizeMessage = cockpit.format(_("Needs at least $0"), cockpit.format_bytes(requiredSize));
+            insufficientSizeMessage = cockpit.format(_("Needs at least $0"), formatBytes(requiredSize));
         } else if (Object.keys(plannedSystemMountPoints).length > 1) {
             insufficientSizeMessage = _("May need more free space");
         }
     }
 
     const getDeviceRow = ([mount, device]) => {
-        const size = cockpit.format_bytes(devices[device].size.v);
+        const size = formatBytes(devices[device].size.v);
         const request = requests.find(request => request["device-spec"] === device);
         let format = devices[device].formatData.type.v;
         const isImplicitlyReusedMountPoint = originalDevices[device] && !reformattedMountPoints?.includes(mount) && !isDeviceDeleted({ actions, device }) && !isDeviceResized({ actions, device });
@@ -165,8 +166,8 @@ const DeviceRow = ({ disk, isReviewScreen }) => {
         if (actionType === "destroy") {
             actionDescriptionText = _("delete");
         } else if (actionType === "resize") {
-            const prevSize = cockpit.format_bytes(originalDevices[device].size.v);
-            sizeText = cockpit.format_bytes(devices[device].size.v);
+            const prevSize = formatBytes(originalDevices[device].size.v);
+            sizeText = formatBytes(devices[device].size.v);
 
             actionDescriptionText = cockpit.format(_("resized from $0"), prevSize);
         }
@@ -236,7 +237,7 @@ const DeviceRow = ({ disk, isReviewScreen }) => {
 
     return (
         <div>
-            <span id={`disk-${disk}`}>{cockpit.format_bytes(deviceData.size.v)} {disk} {"(" + deviceData.description.v + ")"}</span>
+            <span id={`disk-${disk}`}>{formatBytes(deviceData.size.v)} {disk} {"(" + deviceData.description.v + ")"}</span>
             <ListingTable
               aria-label={_("Device tree for $0", disk)}
               className={"pf-m-no-border-rows " + idPrefix + "-table"}

--- a/src/components/storage/cockpit-storage-integration/CockpitStorageIntegrationSidebar.jsx
+++ b/src/components/storage/cockpit-storage-integration/CockpitStorageIntegrationSidebar.jsx
@@ -12,6 +12,8 @@ import { PageSection } from "@patternfly/react-core/dist/esm/components/Page/ind
 import { Title } from "@patternfly/react-core/dist/esm/components/Title/index.js";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 
+import { formatBytes } from "../../../helpers/storage.js";
+
 import {
     useMountPointConstraints,
     useRequiredSize,
@@ -77,7 +79,7 @@ export const ModifyStorageSideBar = () => {
                             <Title headingLevel="h3" size="lg">{_("Requirements")}</Title>
                             <Content>
                                 <Content component="p" className={idPrefix + "-requirements-hint"}>
-                                    {cockpit.format(_("Fedora linux requires at least $0 of disk space."), cockpit.format_bytes(requiredSize))}
+                                    {cockpit.format(_("Fedora linux requires at least $0 of disk space."), formatBytes(requiredSize))}
                                 </Content>
                                 <Content component="p" className={idPrefix + "-requirements-hint-detail"}>
                                     {_("You can either free up enough space here and let the installer handle the rest or manually set up partitions.")}

--- a/src/components/storage/installation-method/InstallationDestination.jsx
+++ b/src/components/storage/installation-method/InstallationDestination.jsx
@@ -26,7 +26,7 @@ import { resetPartitioning } from "../../../apis/storage_partitioning.js";
 import { getDevicesAction, getDiskSelectionAction } from "../../../actions/storage-actions.js";
 
 import { debug as loggerDebug } from "../../../helpers/log.js";
-import { getDeviceChildren, selectDefaultDisks } from "../../../helpers/storage.js";
+import { formatBytes, getDeviceChildren, selectDefaultDisks } from "../../../helpers/storage.js";
 import { checkIfArraysAreEqual } from "../../../helpers/utils.js";
 
 import { StorageContext } from "../../../contexts/Common.jsx";
@@ -140,7 +140,7 @@ const LocalDisksSelect = ({
                                           <FlexItem>
                                               {cockpit.format(
                                                   _("$0 $1"),
-                                                  cockpit.format_bytes(devices[disk]?.total.v),
+                                                  formatBytes(devices[disk]?.total.v),
                                                   devices[disk]?.type.v
                                               )}
                                           </FlexItem>
@@ -261,7 +261,7 @@ export const InstallationDestination = ({
                             <FlexItem className={idPrefix + "-target-disk-size"}>
                                 {cockpit.format(
                                     _("$0 $1"),
-                                    cockpit.format_bytes(devices[disk]?.total.v),
+                                    formatBytes(devices[disk]?.total.v),
                                     devices[disk]?.type.v
                                 )}
                             </FlexItem>
@@ -294,7 +294,7 @@ const InsufficientSpace = () => {
           title={_("Insufficient disk space")}
           variant="warning"
         >
-            {cockpit.format(_("Minimum of $0 required"), cockpit.format_bytes(requiredSize))}
+            {cockpit.format(_("Minimum of $0 required"), formatBytes(requiredSize))}
         </Alert>
     );
 };

--- a/src/components/storage/installation-method/ReclaimSpaceModal.jsx
+++ b/src/components/storage/installation-method/ReclaimSpaceModal.jsx
@@ -30,7 +30,7 @@ import { UndoIcon } from "@patternfly/react-icons/dist/esm/icons/undo-icon";
 
 import { isDeviceShrinkable, removeDevice, shrinkDevice } from "../../../apis/storage_partitioning_automatic_resizable.js";
 
-import { getDeviceAncestors, getDeviceTypeInfo, unitMultiplier } from "../../../helpers/storage.js";
+import { formatBytes, getDeviceAncestors, getDeviceTypeInfo, unitMultiplier } from "../../../helpers/storage.js";
 
 import { PageContext, StorageContext } from "../../../contexts/Common.jsx";
 
@@ -198,8 +198,8 @@ const ReclaimFooter = ({ onClose, onReclaim, unappliedActions }) => {
                 <HelperTextItem id={idPrefix + "-hint"} variant={status}>
                     {fmtToFragments(
                         _("Available free space: $0. Installation requires: $1."),
-                        <b id={idPrefix + "-hint-available-free-space"}>{cockpit.format_bytes(diskFreeSpace + selectedSpaceToReclaim)}</b>,
-                        <b id={idPrefix + "-hint-required-free-space"}>{cockpit.format_bytes(requiredSize)}</b>
+                        <b id={idPrefix + "-hint-available-free-space"}>{formatBytes(diskFreeSpace + selectedSpaceToReclaim)}</b>,
+                        <b id={idPrefix + "-hint-required-free-space"}>{formatBytes(requiredSize)}</b>
                     )}
                 </HelperTextItem>
             </HelperText>
@@ -299,7 +299,7 @@ const getDeviceRow = (disk, devices, level = 0, unappliedActions, setUnappliedAc
         );
     }
 
-    const size = level < 2 && !isExtendedPartition ? cockpit.format_bytes(device.total.v) : "";
+    const size = level < 2 && !isExtendedPartition ? formatBytes(device.total.v) : "";
     const deviceActions = (
         <DeviceActions
           device={device}
@@ -416,7 +416,7 @@ const DeviceActionDelete = ({ device, hasBeenRemoved, newDeviceSize, onAction })
 
 const ShrinkText = ({ newDeviceSize }) => (
     <span className={idPrefix + "-device-action-shrink"}>
-        {cockpit.format(_("shrink to $0"), cockpit.format_bytes(newDeviceSize))}
+        {cockpit.format(_("shrink to $0"), formatBytes(newDeviceSize))}
     </span>
 );
 
@@ -440,7 +440,7 @@ const useIsDeviceShrinkable = ({ device }) => {
 };
 
 const DeviceActionShrink = ({ device, hasBeenRemoved, newDeviceSize, onAction }) => {
-    const onShrink = value => onAction("shrink", value);
+    const onShrink = value => onAction("shrink", Math.round(value));
     const isDeviceShrinkable = useIsDeviceShrinkable({ device: device["device-id"].v });
     const shrinkButton = <ShrinkPopover device={device} isAriaDisabled={!isDeviceShrinkable} onShrink={onShrink} />;
 
@@ -460,8 +460,7 @@ const ShrinkPopover = ({ device, isAriaDisabled, onShrink }) => {
     const shrinkButtonTooltipId = idPrefix + "-shrink-tooltip-" + device["device-id"].v;
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
     const [value, setValue] = useState(device.total.v);
-    const originalValue = cockpit.format_bytes(device.total.v, { separate: true })[0];
-    const originalUnit = cockpit.format_bytes(device.total.v, { separate: true })[1];
+    const [originalValue, originalUnit] = formatBytes(device.total.v, { separate: true });
     const [inputValue, setInputValue] = useState(originalValue);
 
     // Patternfly slider accepts only english locale for the input value
@@ -505,11 +504,11 @@ const ShrinkPopover = ({ device, isAriaDisabled, onShrink }) => {
                         onChange={(_, sliderValue) => {
                             const newValue = Math.round((sliderValue / 100) * device.total.v);
                             setValue(newValue);
-                            setInputValue(cockpit.format_bytes(newValue, originalUnit, { separate: true })[0]);
+                            setInputValue(formatBytes(newValue, originalUnit, { separate: true })[0]);
                         }}
                         customSteps={[
                             { label: "0", value: 0 },
-                            { label: cockpit.format_bytes(device.total.v), value: 100 },
+                            { label: `${originalValue} ${originalUnit}`, value: 100 },
                         ]}
                       />
                       <InputGroup>
@@ -518,13 +517,17 @@ const ShrinkPopover = ({ device, isAriaDisabled, onShrink }) => {
                                 value={inputValue}
                                 onChange={(_event, val) => setInputValue(val)}
                                 onBlur={() => {
-                                    const newValue = Math.min(device.total.v, Math.max(0, normalizedValue * unitMultiplier[originalUnit]));
-                                    if (Number.isNaN(newValue)) {
-                                        setInputValue(cockpit.format_bytes(value, originalUnit, { separate: true })[0]);
+                                    const parsed = parseFloat(normalizedValue);
+                                    const newValue = Math.min(
+                                        device.total.v,
+                                        Math.max(0, Math.round(parsed * unitMultiplier[originalUnit]))
+                                    );
+                                    if (Number.isNaN(parsed) || Number.isNaN(newValue)) {
+                                        setInputValue(formatBytes(value, originalUnit, { separate: true })[0]);
                                         return;
                                     }
                                     setValue(newValue);
-                                    setInputValue(cockpit.format_bytes(newValue, originalUnit, { separate: true })[0]);
+                                    setInputValue(formatBytes(newValue, originalUnit, { separate: true })[0]);
                                 }}
                                 id={idPrefix + "-shrink-input"}
                               />
@@ -563,7 +566,7 @@ const WindowsHint = () => {
             <Alert variant="warning" isInline title={_("Windows partitions with BitLocker encryption cannot be resized")}>
                 {cockpit.format(
                     _("Reboot into Windows to resize BitLocker-encrypted partitions. Make at least $0 of free space available for installation."),
-                    cockpit.format_bytes(requiredSize)
+                    formatBytes(requiredSize)
                 )}
             </Alert>
         );

--- a/src/components/storage/installation-method/usePageComplete.jsx
+++ b/src/components/storage/installation-method/usePageComplete.jsx
@@ -12,7 +12,7 @@ import { useWizardContext } from "@patternfly/react-core/dist/esm/components/Wiz
 import { setSelectedDisks } from "../../../apis/storage_disks_selection.js";
 import { applyStorage } from "../../../apis/storage_partitioning.js";
 
-import { selectDefaultDisks } from "../../../helpers/storage.js";
+import { formatBytes, selectDefaultDisks } from "../../../helpers/storage.js";
 import { checkIfArraysAreEqual } from "../../../helpers/utils.js";
 
 import { PageContext, StorageContext } from "../../../contexts/Common.jsx";
@@ -135,8 +135,8 @@ const useStorageSpaceNotification = (status, freeSpace, requiredSize) => {
             const title = _("Not enough available free space");
             const message = cockpit.format(
                 _("$0 is required, but only $1 is available."),
-                cockpit.format_bytes(requiredSize),
-                cockpit.format_bytes(freeSpace)
+                formatBytes(requiredSize),
+                formatBytes(freeSpace)
             );
             const actionLinks = (
                 <Button

--- a/src/components/storage/mount-point-mapping/MountPointMapping.jsx
+++ b/src/components/storage/mount-point-mapping/MountPointMapping.jsx
@@ -25,6 +25,7 @@ import {
 
 import {
     filterPartitioningRequests,
+    formatBytes,
     getDeviceAncestors,
     getDeviceChildren,
     getLockedLUKSDevices,
@@ -264,7 +265,7 @@ export const DeviceColumnSelect = ({
 
         const formatType = deviceData[device]?.formatData.type.v;
         const format = deviceData[device]?.formatData.description.v;
-        const size = cockpit.format_bytes(deviceData[device]?.total.v);
+        const size = formatBytes(deviceData[device]?.total.v);
         const description = (
             typeLabel && typeLabel !== deviceName
                 ? cockpit.format("$0 $1, used by $2", size, format, typeLabel)
@@ -302,7 +303,7 @@ export const DeviceColumnSelect = ({
         if (!device) return cockpit.gettext("Select a device");
 
         const name = deviceData[device]?.name.v;
-        const size = cockpit.format_bytes(deviceData[device]?.total.v);
+        const size = formatBytes(deviceData[device]?.total.v);
         const isAmbiguous = Object.values(deviceData).filter(d => d.name.v === name).length > 1;
 
         return isAmbiguous ? cockpit.format("$0 ($1)", name, size) : name;

--- a/src/components/storage/scenarios/erase-all/EraseAll.jsx
+++ b/src/components/storage/scenarios/erase-all/EraseAll.jsx
@@ -7,6 +7,7 @@ import cockpit from "cockpit";
 
 import { useContext, useEffect, useState } from "react";
 
+import { formatBytes } from "../../../../helpers/storage.js";
 import { AvailabilityState } from "../helpers.js";
 
 import {
@@ -43,7 +44,7 @@ export const useAvailabilityEraseAll = () => {
             availability.reason = _("Not enough space on selected disks.");
             availability.hint = cockpit.format(
                 _("The installation needs $0 of disk space; however, the capacity of the selected disks is only $1."),
-                cockpit.format_bytes(requiredSize), cockpit.format_bytes(diskTotalSpace));
+                formatBytes(requiredSize), formatBytes(diskTotalSpace));
         }
 
         return setScenarioAvailability(availability);

--- a/src/components/storage/scenarios/use-free-space/UseFreeSpace.jsx
+++ b/src/components/storage/scenarios/use-free-space/UseFreeSpace.jsx
@@ -8,6 +8,7 @@ import cockpit from "cockpit";
 import React, { useContext, useEffect, useState } from "react";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
 
+import { formatBytes } from "../../../../helpers/storage.js";
 import { AvailabilityState } from "../helpers.js";
 
 import {
@@ -51,7 +52,7 @@ export const useAvailabilityUseFreeSpace = (args) => {
             availability.reason = _("Not enough free space on the selected disks.");
             availability.hint = cockpit.format(
                 _("To use this option, resize or remove existing partitions to free up at least $0."),
-                cockpit.format_bytes(requiredSize)
+                formatBytes(requiredSize)
             );
             if (allowReclaim) {
                 availability.enforceAction = true;

--- a/src/helpers/storage.js
+++ b/src/helpers/storage.js
@@ -182,14 +182,33 @@ export const getDeviceTypeInfo = (device) => {
     return deviceType;
 };
 
+const isPlainObject = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
+
+/**
+ * Format a byte count (binary KiB/MiB/GiB).
+ * Wraps cockpit.format_bytes with base2: true by default.
+ */
+export const formatBytes = (number, ...args) => {
+    if (args.length === 0) {
+        return cockpit.format_bytes(number, { base2: true });
+    }
+    if (args.length === 1 && isPlainObject(args[0])) {
+        return cockpit.format_bytes(number, { base2: true, ...args[0] });
+    }
+    if (args.length === 1) {
+        return cockpit.format_bytes(number, args[0], { base2: true });
+    }
+    return cockpit.format_bytes(number, args[0], { base2: true, ...args[1] });
+};
+
 /* Match the units to their respective sizes */
 export const unitMultiplier = {
     B: 1,
-    KB: 1000,
-    MB: 1000000,
+    KiB: 1024,
+    MiB: 1024 ** 2,
     // eslint-disable-next-line sort-keys
-    GB: 1000000000,
-    TB: 1000000000000,
+    GiB: 1024 ** 3,
+    TiB: 1024 ** 4,
 };
 
 export const bootloaderTypes = ["efi", "biosboot", "appleboot", "prepboot"];

--- a/test/check-kickstart-automated
+++ b/test/check-kickstart-automated
@@ -7,7 +7,7 @@ from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, pixel_te
 from installer import Installer
 from payload_dnf import PayloadDNF
 from review import Review
-from storage import EFI_PARTITION_DEFAULT_SIZE_MB, Storage
+from storage import EFI_PARTITION_DEFAULT_SIZE_SPACE, Storage
 from testlib import test_main  # pylint: disable=import-error
 from timezone import DateAndTime
 from users import Users, override_user_interface_conf_keys
@@ -87,12 +87,12 @@ class TestKickstartAutomated(VirtInstallMachineCase):
 
         r.check_storage_config("Use configured storage")
         dev1 = "vda"
-        r.check_disk(dev1, "16.1 GB vda (Virtio Block Device)")
-        r.check_disk_row(dev1, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, True, "efi")
-        r.check_disk_row(dev1, "/", "vda5", "11.8 GB", True, "xfs")
-        r.check_disk_row(dev1, "/boot", "vda2", "524 MB", True, "xfs")
-        r.check_disk_row(dev1, "/home", "vda3", "2.15 GB", True, "xfs")
-        r.check_disk_row(dev1, "swap", "vda4", "1.07 GB", True, "swap")
+        r.check_disk(dev1, "15 GiB vda (Virtio Block Device)")
+        r.check_disk_row(dev1, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_SPACE, True, "efi")
+        r.check_disk_row(dev1, "/", "vda5", "11.0 GiB", True, "xfs")
+        r.check_disk_row(dev1, "/boot", "vda2", "500 MiB", True, "xfs")
+        r.check_disk_row(dev1, "/home", "vda3", "2 GiB", True, "xfs")
+        r.check_disk_row(dev1, "swap", "vda4", "1 GiB", True, "swap")
 
         # Wait for warning notification about /boot partition size
         b.wait_in_text(f"#{i.steps.REVIEW}-step-notification",

--- a/test/check-review
+++ b/test/check-review
@@ -8,7 +8,7 @@ from installer import Installer
 from network import Network
 from password import Password
 from review import Review
-from storage import BOOT_PARTITION_DEFAULT_SIZE_GB, Storage
+from storage import Storage
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 from utils import pretend_live_workstation_iso
 
@@ -51,9 +51,9 @@ class TestReview(VirtInstallMachineCase):
         r.check_language("English (United States)")
 
         # check selected disks are shown
-        r.check_disk("vda", "16.1 GB vda (Virtio Block Device)")
-        r.check_disk_row("vda", "/boot", "vda2", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs")
-        r.check_disk_row("vda", "/", "vda3, LVM", "13.3 GB", True, "xfs")
+        r.check_disk("vda", "15 GiB vda (Virtio Block Device)")
+        r.check_disk_row("vda", "/boot", "vda2", "2 GiB", True, "xfs")
+        r.check_disk_row("vda", "/", "vda3, LVM", "12.4 GiB", True, "xfs")
 
         # check storage configuration
         r.check_storage_config("Use entire disk")
@@ -79,10 +79,10 @@ class TestReview(VirtInstallMachineCase):
         i.reach(i.steps.REVIEW)
 
         # check selected disks are shown
-        r.check_disk("vda", "16.1 GB vda (Virtio Block Device)")
-        r.check_disk_row("vda", "/boot/efi", "vda1", "629 MB", True, "efi", is_encrypted=False)
-        r.check_disk_row("vda", "/boot", "vda2", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
-        r.check_disk_row("vda", "/", "vda3, LVM", "13.3 GB", True, "xfs", is_encrypted=True)
+        r.check_disk("vda", "15 GiB vda (Virtio Block Device)")
+        r.check_disk_row("vda", "/boot/efi", "vda1", "600 MiB", True, "efi", is_encrypted=False)
+        r.check_disk_row("vda", "/boot", "vda2", "2 GiB", True, "xfs", is_encrypted=False)
+        r.check_disk_row("vda", "/", "vda3, LVM", "12.4 GiB", True, "xfs", is_encrypted=True)
 
         # move the mouse away to avoid highlighting any UI element (pixel ref does not expect that)
         b.mouse("#app", "mouseenter")

--- a/test/check-storage-basic
+++ b/test/check-storage-basic
@@ -42,7 +42,7 @@ class TestStorageBasic(VirtInstallMachineCase):
         i.reach(i.steps.INSTALLATION_METHOD)
 
         # Check the auto-selected disk's details
-        s.check_disk_selected("vda", selected=True, size="16.1 GB")
+        s.check_disk_selected("vda", selected=True, size="15 GiB")
 
         # Wait for the form to be ready before taking a screenshot
         i.check_next_disabled(False)

--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -6,7 +6,7 @@
 from anacondalib import VirtInstallMachineCase, disk_images, pixel_tests_ignore, run_boot
 from installer import Installer
 from review import Review
-from storage import EFI_PARTITION_DEFAULT_SIZE_MB, Storage
+from storage import EFI_PARTITION_DEFAULT_SIZE_SPACE, Storage
 from storagelib import StorageCase  # pylint: disable=import-error
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 from utils import pretend_live_workstation_iso
@@ -102,7 +102,7 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         i.reach(i.steps.REVIEW)
 
-        r.check_disk_row(dev, "/", "vda3", "14.5 GB", False, None, True)
+        r.check_disk_row(dev, "/", "vda3", "13.5 GiB", False, None, True)
 
         # Exit the cockpit-storage iframe
         i.reach_on_sidebar(i.steps.INSTALLATION_METHOD)
@@ -183,12 +183,12 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         def checkStorageReview(prefix=""):
             disk = "vda"
-            r.check_disk(disk, "16.1 GB vda (Virtio Block Device)", prefix=prefix)
-            r.check_disk_row(disk, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False, "efi", prefix=prefix)
-            r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False, prefix=prefix)
-            r.check_disk_row(disk, "/", "vda3, LVM", "6.01 GB", False, prefix=prefix)
-            r.check_disk_row(disk, "/home", "vda3, LVM", "8.12 GB", False, prefix=prefix)
-            r.check_disk_row(disk, "swap", "vda3, LVM", "377 MB", False, prefix=prefix)
+            r.check_disk(disk, "15 GiB vda (Virtio Block Device)", prefix=prefix)
+            r.check_disk_row(disk, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_SPACE, False, "efi", prefix=prefix)
+            r.check_disk_row(disk, "/boot", "vda2", "1020 MiB", False, prefix=prefix)
+            r.check_disk_row(disk, "/", "vda3, LVM", "5.60 GiB", False, prefix=prefix)
+            r.check_disk_row(disk, "/home", "vda3, LVM", "7.56 GiB", False, prefix=prefix)
+            r.check_disk_row(disk, "swap", "vda3, LVM", "360 MiB", False, prefix=prefix)
 
         s.return_to_installation()
 
@@ -238,10 +238,10 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         b.switch_to_top()
 
         def checkStorageReview(prefix=""):
-            r.check_disk(dev, "16.1 GB vda (Virtio Block Device)", prefix=prefix)
-            r.check_disk_row(dev, "/boot/efi", "vda1", "99.6 MB", False, "efi", prefix=prefix)
-            r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False, prefix=prefix)
-            r.check_disk_row(dev, "/", "vda3", "14.9 GB", False, prefix=prefix)
+            r.check_disk(dev, "15 GiB vda (Virtio Block Device)", prefix=prefix)
+            r.check_disk_row(dev, "/boot/efi", "vda1", "95 MiB", False, "efi", prefix=prefix)
+            r.check_disk_row(dev, "/boot", "vda2", "1020 MiB", False, prefix=prefix)
+            r.check_disk_row(dev, "/", "vda3", "13.9 GiB", False, prefix=prefix)
 
         s.return_to_installation()
         checkStorageReview(prefix="#cockpit-storage-integration-check-storage-dialog")
@@ -340,8 +340,8 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         r.check_available_size_error_value("1")
 
         # check that there is a hint with required size beside the device
-        r.check_disk(dev, f"16.1 GB {dev} (Virtio Block Device)")
-        r.check_disk_row(dev, "/", f"{dev}3", "1.30 GB", False)
+        r.check_disk(dev, f"15 GiB {dev} (Virtio Block Device)")
+        r.check_disk_row(dev, "/", f"{dev}3", "1.21 GiB", False)
         r.check_disk_mount_point_helper_text(dev, "/", "Needs at least")
 
         i.check_next_disabled()
@@ -382,9 +382,9 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         # check that there is a hint with required size beside the device
         dev = "vda"
-        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
+        r.check_disk(dev, "15 GiB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/", "vda3", "1.70 GB", False)
+        r.check_disk_row(dev, "/", "vda3", "1.58 GiB", False)
         r.check_disk_mount_point_helper_text(dev, "/", "Needs at least")
 
         i.check_next_disabled()
@@ -420,9 +420,9 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         # check that there is a hint with required size beside the device
         dev = "vda"
-        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
+        r.check_disk(dev, "15 GiB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/", "vda3, LVM", "1.70 GB", False)
+        r.check_disk_row(dev, "/", "vda3, LVM", "1.58 GiB", False)
         r.check_disk_mount_point_helper_text(dev, "/", "Needs at least")
 
         i.check_next_disabled()
@@ -462,11 +462,11 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         # verify review screen
         dev = "vda"
-        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
+        r.check_disk(dev, "15 GiB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
-        r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False)
-        r.check_disk_row(dev, "/", "vda3", "14.5 GB", False)
+        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_SPACE, False)
+        r.check_disk_row(dev, "/boot", "vda2", "1020 MiB", False)
+        r.check_disk_row(dev, "/", "vda3", "13.5 GiB", False)
 
         # Check fstab
         fstab = m.execute("cat /etc/fstab")
@@ -521,12 +521,12 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         # verify review screen
         dev = "vda"
-        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
+        r.check_disk(dev, "15 GiB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
-        r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False)
-        r.check_disk_row(dev, "/", "vda3", "14.5 GB", False)
-        r.check_disk_row(dev, "/home", "vda3", "14.5 GB", False)
+        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_SPACE, False)
+        r.check_disk_row(dev, "/boot", "vda2", "1020 MiB", False)
+        r.check_disk_row(dev, "/", "vda3", "13.5 GiB", False)
+        r.check_disk_row(dev, "/home", "vda3", "13.5 GiB", False)
 
         # Check fstab
         fstab = m.execute("cat /etc/fstab")
@@ -579,12 +579,12 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         # verify review screen
         dev = "vda"
-        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
+        r.check_disk(dev, "15 GiB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
-        r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "ext4")
-        r.check_disk_row(dev, "/", "vda3", "14.5 GB", True, "btrfs subvolume")
-        r.check_disk_row(dev, "/home", "vda3", "14.5 GB", False)
+        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_SPACE, False)
+        r.check_disk_row(dev, "/boot", "vda2", "1020 MiB", True, "ext4")
+        r.check_disk_row(dev, "/", "vda3", "13.5 GiB", True, "btrfs subvolume")
+        r.check_disk_row(dev, "/home", "vda3", "13.5 GiB", False)
 
         # Check fstab
         fstab = m.execute("cat /etc/fstab")
@@ -872,13 +872,13 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
 
         # verify review screen
         dev = "vda"
-        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
-        r.check_disk_row(dev, "/boot/efi", "vda1", "99.6 MB", False)
-        r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False)
-        r.check_disk_row(dev, "/", "vda3", "14.9 GB", False)
+        r.check_disk(dev, "15 GiB vda (Virtio Block Device)")
+        r.check_disk_row(dev, "/boot/efi", "vda1", "95 MiB", False)
+        r.check_disk_row(dev, "/boot", "vda2", "1020 MiB", False)
+        r.check_disk_row(dev, "/", "vda3", "13.9 GiB", False)
         dev = "vdb"
-        r.check_disk(dev, "16.1 GB vdb (Virtio Block Device)")
-        r.check_disk_row(dev, "/home", "", "16.1 GB", False)
+        r.check_disk(dev, "15 GiB vdb (Virtio Block Device)")
+        r.check_disk_row(dev, "/home", "", "15 GiB", False)
 
         # Check fstab
         fstab = m.execute("cat /etc/fstab")
@@ -943,10 +943,10 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         i.reach(i.steps.REVIEW)
 
         # verify review screen
-        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
+        r.check_disk(dev, "15 GiB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/boot", "vda1", "1.07 GB", False)
-        r.check_disk_row(dev, "/", "vda2", "15.0 GB", False)
+        r.check_disk_row(dev, "/boot", "vda1", "1020 MiB", False)
+        r.check_disk_row(dev, "/", "vda2", "14.0 GiB", False)
 
         # Check fstab
         fstab = m.execute("cat /etc/fstab")

--- a/test/check-storage-cockpit-e2e
+++ b/test/check-storage-cockpit-e2e
@@ -96,8 +96,8 @@ class TestStorageCockpitIntegration_E2E(VirtInstallMachineCase, StorageCase):
         def checkStorageReview(prefix=""):
             with b.wait_timeout(30):
                 for disk in ("vda", "vdb", "vdc"):
-                    r.check_disk(disk, f"16.1 GB {disk} (Virtio Block Device)")
-                    r.check_disk_row(disk, "/", "vda3, vdc1, vdb1, RAID", "47.1 GB", False, prefix=prefix)
+                    r.check_disk(disk, f"15 GiB {disk} (Virtio Block Device)")
+                    r.check_disk_row(disk, "/", "vda3, vdc1, vdb1, RAID", "43.9 GiB", False, prefix=prefix)
 
         # verify review screen
         checkStorageReview()
@@ -180,14 +180,14 @@ class TestStorageCockpitIntegration_E2E(VirtInstallMachineCase, StorageCase):
         def checkStorageReview(prefix=""):
             with b.wait_timeout(30):
                 disk = "vda"
-                r.check_disk(disk, f"16.1 GB {disk} (Virtio Block Device)", prefix=prefix)
+                r.check_disk(disk, f"15 GiB {disk} (Virtio Block Device)", prefix=prefix)
                 if self.is_efi:
-                    r.check_disk_row(disk, "/boot/efi", "vda1", "99.6 MB", False, prefix=prefix)
-                r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False, prefix=prefix)
+                    r.check_disk_row(disk, "/boot/efi", "vda1", "95 MiB", False, prefix=prefix)
+                r.check_disk_row(disk, "/boot", "vda2", "1020 MiB", False, prefix=prefix)
 
                 disk = "MDRAID-SOMERAID"
-                r.check_disk(disk, f"32.2 GB {disk} (MDRAID set (stripe))", prefix=prefix)
-                r.check_disk_row(disk, "/", "SOMERAID1, RAID", "32.2 GB", False, prefix=prefix)
+                r.check_disk(disk, f"30.0 GiB {disk} (MDRAID set (stripe))", prefix=prefix)
+                r.check_disk_row(disk, "/", "SOMERAID1, RAID", "30.0 GiB", False, prefix=prefix)
 
         # Exit the cockpit-storage iframe and return to installation
         b.switch_to_top()
@@ -249,10 +249,10 @@ class TestStorageCockpitIntegration_E2E(VirtInstallMachineCase, StorageCase):
         s.check_scenario_selected("use-configured-storage")
 
         i.reach(i.steps.REVIEW)
-        r.check_disk("vda", "16.1 GB vda (Virtio Block Device)")
-        r.check_disk_row("vda", "/boot", "vda2", "1.07 GB", False)
-        r.check_disk_row("vda", "/", "vda3", "4.10 GB", False)
-        r.check_disk_row("vda", "swap", "vda4", "1.02 GB", False)
+        r.check_disk("vda", "15 GiB vda (Virtio Block Device)")
+        r.check_disk_row("vda", "/boot", "vda2", "1020 MiB", False)
+        r.check_disk_row("vda", "/", "vda3", "3.81 GiB", False)
+        r.check_disk_row("vda", "swap", "vda4", "977 MiB", False)
         self.install(needs_confirmation=False)
 
         # Check that the expected partition layout is created

--- a/test/check-storage-home-reuse
+++ b/test/check-storage-home-reuse
@@ -8,7 +8,13 @@ import os
 from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images, run_boot
 from installer import Installer
 from review import Review
-from storage import BOOT_PARTITION_DEFAULT_SIZE, BOOT_PARTITION_DEFAULT_SIZE_GB, EFI_PARTITION_DEFAULT_SIZE, Storage
+from storage import (
+    BOOT_PARTITION_DEFAULT_SIZE,
+    BOOT_PARTITION_DEFAULT_SIZE_SPACE,
+    EFI_PARTITION_DEFAULT_SIZE,
+    EFI_PARTITION_DEFAULT_SIZE_SPACE,
+    Storage,
+)
 from testlib import nondestructive, skipImage, test_main  # pylint: disable=import-error
 from utils import move_standard_fedora_disk_to_MBR_disk, move_standard_fedora_disk_to_win_disk, pretend_default_scheme, rsync_directory
 
@@ -119,17 +125,17 @@ class TestStorageHomeReuse(VirtInstallMachineCase, _TestStorageHomeReuseHelpers)
         i.reach(i.steps.REVIEW)
 
         # check selected disks are shown
-        r.check_disk(dev, f"16.1 GB {dev} (Virtio Block Device)")
+        r.check_disk(dev, f"15 GiB {dev} (Virtio Block Device)")
         if self.is_efi:
             r.check_disk_row(dev, parent=f"{dev}2", action="delete")
         else:
             r.check_disk_row(dev, parent=f"{dev}1", action="delete")
 
         if self.is_efi:
-            r.check_disk_row(dev, "/boot/efi", f"{dev}2", "629 MB", True, "efi", is_encrypted=False)
-        r.check_disk_row(dev, "/boot", f"{dev}4", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
-        r.check_disk_row(dev, "/", f"{dev}3", "13.9 GB", True, "btrfs subvolume", is_encrypted=False)
-        r.check_disk_row(dev, "/home", f"{dev}3", "13.9 GB", False, "btrfs subvolume", is_encrypted=False,
+            r.check_disk_row(dev, "/boot/efi", f"{dev}2", EFI_PARTITION_DEFAULT_SIZE_SPACE, True, "efi", is_encrypted=False)
+        r.check_disk_row(dev, "/boot", f"{dev}4", "2.00 GiB", True, "xfs", is_encrypted=False)
+        r.check_disk_row(dev, "/", f"{dev}3", "12.9 GiB", True, "btrfs subvolume", is_encrypted=False)
+        r.check_disk_row(dev, "/home", f"{dev}3", "12.9 GiB", False, "btrfs subvolume", is_encrypted=False,
                          action="mount")
 
     @disk_images([("fedora-rawhide", 15)])
@@ -215,12 +221,12 @@ class TestStorageHomeReuse(VirtInstallMachineCase, _TestStorageHomeReuseHelpers)
         i.reach(i.steps.REVIEW)
 
         # check selected disks are shown
-        r.check_disk(dev_fedora1, f"16.1 GB {dev_fedora1} (Virtio Block Device)")
+        r.check_disk(dev_fedora1, f"15 GiB {dev_fedora1} (Virtio Block Device)")
         r.check_disk_row(dev_fedora1, parent=f"{dev_fedora1}1", action="delete")
-        r.check_disk_row(dev_fedora1, "/", f"{dev_fedora1}3", "13.9 GB", True, "btrfs subvolume", is_encrypted=False)
-        r.check_disk_row(dev_fedora1, "/home", f"{dev_fedora1}3", "13.9 GB", False, "btrfs subvolume", is_encrypted=False,
+        r.check_disk_row(dev_fedora1, "/", f"{dev_fedora1}3", "12.9 GiB", True, "btrfs subvolume", is_encrypted=False)
+        r.check_disk_row(dev_fedora1, "/home", f"{dev_fedora1}3", "12.9 GiB", False, "btrfs subvolume", is_encrypted=False,
                          action="mount")
-        r.check_disk_row(dev_fedora1, "/boot", f"{dev_fedora1}4", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
+        r.check_disk_row(dev_fedora1, "/boot", f"{dev_fedora1}4", BOOT_PARTITION_DEFAULT_SIZE_SPACE, True, "xfs", is_encrypted=False)
 
 
 # TODO: these tests should be made nondestructive
@@ -261,11 +267,11 @@ class TestStorageHomeReuseDestructive(VirtInstallMachineCase, _TestStorageHomeRe
 
         # check selected disks are shown
         dev = "vda"
-        r.check_disk(dev, f"16.1 GB {dev} (Virtio Block Device)")
+        r.check_disk(dev, f"15 GiB {dev} (Virtio Block Device)")
         r.check_disk_row(dev, parent=f"{dev}1", action="delete")
-        r.check_disk_row(dev, "/boot", f"{dev}2", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
-        r.check_disk_row(dev, "/", f"{dev}3", "13.4 GB", True, "btrfs subvolume", is_encrypted=True)
-        r.check_disk_row(dev, "/home", f"{dev}3", "13.4 GB", False, "btrfs subvolume", is_encrypted=True, action="mount")
+        r.check_disk_row(dev, "/boot", f"{dev}2", "2 GiB", True, "xfs", is_encrypted=False)
+        r.check_disk_row(dev, "/", f"{dev}3", "12.5 GiB", True, "btrfs subvolume", is_encrypted=True)
+        r.check_disk_row(dev, "/home", f"{dev}3", "12.5 GiB", False, "btrfs subvolume", is_encrypted=True, action="mount")
 
     def _testNonLinuxSystem_partition_disk(self):
         b = self.browser
@@ -372,12 +378,12 @@ class TestStorageHomeReuseDestructive(VirtInstallMachineCase, _TestStorageHomeRe
         i.reach(i.steps.REVIEW)
 
         # check selected disks are shown
-        r.check_disk(dev_mbr, f"21.5 GB {dev_mbr} (Virtio Block Device)")
+        r.check_disk(dev_mbr, f"20 GiB {dev_mbr} (Virtio Block Device)")
         r.check_disk_row(dev_mbr, parent=f"{dev_mbr}1", action="delete")
-        r.check_disk_row(dev_mbr, "/home", f"{dev_mbr}2", "14.0 GB", False, "btrfs subvolume", is_encrypted=False,
+        r.check_disk_row(dev_mbr, "/home", f"{dev_mbr}2", "13 GiB", False, "btrfs subvolume", is_encrypted=False,
                          action="mount")
-        r.check_disk_row(dev_mbr, "/", f"{dev_mbr}2", "14.0 GB", True, "btrfs subvolume", is_encrypted=False)
-        r.check_disk_row(dev_mbr, "/boot", f"{dev_mbr}1", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
+        r.check_disk_row(dev_mbr, "/", f"{dev_mbr}2", "13 GiB", True, "btrfs subvolume", is_encrypted=False)
+        r.check_disk_row(dev_mbr, "/boot", f"{dev_mbr}1", "2 GiB", True, "xfs", is_encrypted=False)
 
     def _testWindowsSingleDisk_partition_disk(self):
         storage = Storage(self.browser, self.machine)
@@ -436,14 +442,14 @@ class TestStorageHomeReuseDestructive(VirtInstallMachineCase, _TestStorageHomeRe
         i.reach(i.steps.REVIEW)
 
         # check selected disks are shown
-        r.check_disk(dev_win_fed, f"37.6 GB {dev_win_fed} (Virtio Block Device)")
+        r.check_disk(dev_win_fed, f"35 GiB {dev_win_fed} (Virtio Block Device)")
         r.check_disk_row(dev_win_fed, parent=f"{dev_win_fed}4", action="delete")
-        r.check_disk_row(dev_win_fed, "/boot/efi", f"{dev_win_fed}1", "105 MB", False, "vfat", is_encrypted=False,
+        r.check_disk_row(dev_win_fed, "/boot/efi", f"{dev_win_fed}1", "100 MiB", False, "vfat", is_encrypted=False,
                          action="mount")
-        r.check_disk_row(dev_win_fed, "/home", f"{dev_win_fed}5", "14.0 GB", False, "btrfs subvolume", is_encrypted=False,
+        r.check_disk_row(dev_win_fed, "/home", f"{dev_win_fed}5", "13 GiB", False, "btrfs subvolume", is_encrypted=False,
                          action="mount")
-        r.check_disk_row(dev_win_fed, "/", f"{dev_win_fed}5", "14.0 GB", True, "btrfs subvolume", is_encrypted=False)
-        r.check_disk_row(dev_win_fed, "/boot", f"{dev_win_fed}4", BOOT_PARTITION_DEFAULT_SIZE_GB, True, "xfs", is_encrypted=False)
+        r.check_disk_row(dev_win_fed, "/", f"{dev_win_fed}5", "13 GiB", True, "btrfs subvolume", is_encrypted=False)
+        r.check_disk_row(dev_win_fed, "/boot", f"{dev_win_fed}4", "2 GiB", True, "xfs", is_encrypted=False)
 
 
 if __name__ == '__main__':

--- a/test/check-storage-mountpoints
+++ b/test/check-storage-mountpoints
@@ -8,7 +8,13 @@ import os
 from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images, pixel_tests_ignore, run_boot
 from installer import Installer
 from review import Review
-from storage import EFI_PARTITION_DEFAULT_SIZE, EFI_PARTITION_DEFAULT_SIZE_MB, Storage
+from storage import (
+    EFI_PARTITION_DEFAULT_SIZE,
+    EFI_PARTITION_DEFAULT_SIZE_SPACE,
+    PARTITION_1GiB_SIZE,
+    PARTITION_1GiB_SIZE_SPACE,
+    Storage,
+)
 from storagelib import StorageCase  # pylint: disable=import-error
 from testlib import nondestructive, skipImage, test_main  # pylint: disable=import-error
 from utils import move_standard_fedora_disk_to_MBR_disk, move_standard_fedora_disk_to_win_disk, pretend_default_scheme
@@ -94,15 +100,15 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         i.reach(i.steps.REVIEW)
 
         # verify review screen
-        r.check_disk(dev, "16.1 GB vdb (Virtio Block Device)")
+        r.check_disk(dev, "15 GiB vdb (Virtio Block Device)")
 
         next_idx = 2
         if self.is_efi:
-            r.check_disk_row(dev, "/boot/efi", f"vdb{next_idx}", "105 MB", True, "efi")
+            r.check_disk_row(dev, "/boot/efi", f"vdb{next_idx}", "100 MiB", True, "efi")
         next_idx += 1
-        r.check_disk_row(dev, "/boot", f"vdb{next_idx}", "1.05 GB", True, "ext4")
-        r.check_disk_row(dev, "/", f"vdb{next_idx + 1}", "12.8 GB", True, "btrfs subvolume")
-        r.check_disk_row(dev, "/home", f"vdb{next_idx + 1}", "12.8 GB", False)
+        r.check_disk_row(dev, "/boot", f"vdb{next_idx}", "1000 MiB", True, "ext4")
+        r.check_disk_row(dev, "/", f"vdb{next_idx + 1}", "11.9 GiB", True, "btrfs subvolume")
+        r.check_disk_row(dev, "/home", f"vdb{next_idx + 1}", "11.9 GiB", False)
 
         applied_partitioning = s.dbus_get_applied_partitioning()
 
@@ -145,7 +151,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
 
         # EFI system partition, /boot on ext4, / on xfs, /home on btrfs
         disk = "/dev/vda"
-        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "ext4"), ("10GiB", "xfs"), ("", "ext4")])
+        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), (PARTITION_1GiB_SIZE, "ext4"), ("10GiB", "xfs"), ("", "ext4")])
 
     def testNoRootMountPoint(self):
         """
@@ -205,7 +211,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
 
         # EFI system partition, /boot partition, /
         disk1 = "/dev/vda"
-        s.partition_disk(disk1, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "xfs"), ("", "xfs")])
+        s.partition_disk(disk1, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), (PARTITION_1GiB_SIZE, "xfs"), ("", "xfs")])
 
         # /dev/vdb1 /home partition
         disk2 = "/dev/vdb"
@@ -275,14 +281,14 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
 
         # verify review screen
         disk = "vda"
-        r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
-        r.check_disk_row(disk, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
-        r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False)
-        r.check_disk_row(disk, "/", "vda3", "14.5 GB", True, "xfs")
+        r.check_disk(disk, "15 GiB vda (Virtio Block Device)")
+        r.check_disk_row(disk, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_SPACE, False)
+        r.check_disk_row(disk, "/boot", "vda2", PARTITION_1GiB_SIZE_SPACE, False)
+        r.check_disk_row(disk, "/", "vda3", "13.5 GiB", True, "xfs")
 
         disk = "vdb"
-        r.check_disk(disk, "10.7 GB vdb (Virtio Block Device)")
-        r.check_disk_row(disk, "/home", "vdb1", "10.7 GB", False)
+        r.check_disk(disk, "10 GiB vdb (Virtio Block Device)")
+        r.check_disk_row(disk, "/home", "vdb1", "10.0 GiB", False)
 
         b.assert_pixels(
             "#app",
@@ -297,7 +303,16 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
 
         # EFI system partition, /boot partition, /
         disk1 = "/dev/vda"
-        s.partition_disk(disk1, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "xfs"), ("1GiB", "xfs"), ("1GiB", "xfs"), ("", "xfs")])
+        s.partition_disk(
+            disk1,
+            [
+                (EFI_PARTITION_DEFAULT_SIZE, "efi"),
+                (PARTITION_1GiB_SIZE, "xfs"),
+                (PARTITION_1GiB_SIZE, "xfs"),
+                (PARTITION_1GiB_SIZE, "xfs"),
+                ("", "xfs"),
+            ],
+        )
 
     @disk_images([("", 15)])
     def testPayloadSizeCheck(self):
@@ -334,7 +349,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         r.check_size_error()
 
         # check that there is a hint with required size beside the device
-        r.check_disk_row(dev, "/", f"{dev}3", "1.07 GB", True, "xfs", is_encrypted=False)
+        r.check_disk_row(dev, "/", f"{dev}3", PARTITION_1GiB_SIZE_SPACE, True, "xfs", is_encrypted=False)
         r.check_disk_mount_point_helper_text(dev, "/", "Needs at least")
 
         # check that it is not possible to continue on the next page (install)
@@ -360,9 +375,9 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         r.check_size_error()
 
         # check that there is a hint suitable for multiple devices
-        r.check_disk_row(dev, "/", f"{dev}3", "1.07 GB", True, "xfs", is_encrypted=False)
+        r.check_disk_row(dev, "/", f"{dev}3", PARTITION_1GiB_SIZE_SPACE, True, "xfs", is_encrypted=False)
         r.check_disk_mount_point_helper_text(dev, "/", "May need more free space")
-        r.check_disk_row(dev, "/usr", f"{dev}4", "1.07 GB", True, "xfs", is_encrypted=False)
+        r.check_disk_row(dev, "/usr", f"{dev}4", PARTITION_1GiB_SIZE_SPACE, True, "xfs", is_encrypted=False)
         r.check_disk_mount_point_helper_text(dev, "/usr", "May need more free space")
 
         # check that it is not possible to continue on the next page (install)
@@ -395,7 +410,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         disk1 = "/dev/vda"
         s.partition_disk(
             disk1,
-            [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", None), ("1GiB", None), ("1GiB", None), ("1GiB", "xfs")],
+            [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", None), ("1GiB", None), ("1GiB", None), (PARTITION_1GiB_SIZE, "xfs")],
         )
         s.create_luks_partition(f"{disk1}2", "einszwei", "encrypted-vol0", "xfs")
         s.create_luks_partition(f"{disk1}3", "einszweidrei", "encrypted-vol1", "xfs")
@@ -508,7 +523,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         self.click_dropdown(self.card_row("Storage", 2), "Create partition")
         self.dialog({"size": 524, "type": "efi", "mount_point": "/boot/efi"})
 
-        # FIXME: Cockpit uses MB/GB for units whereas anaconda uses MiB/GiB, so
+        # FIXME: Cockpit and anaconda may round partition sizes slightly differently, so
         # when anaconda backend recommends a 1GiB boot partition and Cockpit
         # creates a 1GB partition, it is rounded down to 931MiB and doesn't
         # meet the boot partition requirement, causing the test to fail. For
@@ -566,7 +581,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
             disk,
             [
                 (EFI_PARTITION_DEFAULT_SIZE, "efi"),
-                ("1GiB", "ext4"),
+                (PARTITION_1GiB_SIZE, "ext4"),
                 ("5GiB", "btrfs", "-f", "-L", "root"),
                 ("5GiB", "btrfs", "-f", "-L", btrfsname),
                 ("", "btrfs", "-f", "-L", btrfsname)
@@ -617,13 +632,13 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
 
         # verify review screen
         disk = "vda"
-        r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
+        r.check_disk(disk, "15 GiB vda (Virtio Block Device)")
 
-        r.check_disk_row(disk, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
-        r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", False)
-        r.check_disk_row(disk, "/", "vda3", "5.37 GB", True, "btrfs volume")
-        r.check_disk_row(disk, "/home/joe", "vda4", "5.37 GB", False, "btrfs volume")
-        r.check_disk_row(disk, "/home/alan", "vda5", "3.77 GB", False, "btrfs volume")
+        r.check_disk_row(disk, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_SPACE, False)
+        r.check_disk_row(disk, "/boot", "vda2", PARTITION_1GiB_SIZE_SPACE, False)
+        r.check_disk_row(disk, "/", "vda3", "5 GiB", True, "btrfs volume")
+        r.check_disk_row(disk, "/home/joe", "vda4", "5 GiB", False, "btrfs volume")
+        r.check_disk_row(disk, "/home/alan", "vda5", "3.51 GiB", False, "btrfs volume")
 
     def _testUnusableFormats_partition_disk(self):
         b = self.browser
@@ -631,7 +646,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s = Storage(b, m)
 
         disk = "/dev/vda"
-        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "ext4"), ("1GiB", None), ("1GiB", "lvmpv")])
+        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), (PARTITION_1GiB_SIZE, "ext4"), ("1GiB", None), ("1GiB", "lvmpv")])
 
     def testUnusableFormats(self):
         """
@@ -669,8 +684,8 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         s.partition_disk(
             disk,
             [
-                ("512MiB", "efi"),
-                ("1GiB", "ext4"),
+                (EFI_PARTITION_DEFAULT_SIZE, "efi"),
+                (PARTITION_1GiB_SIZE, "ext4"),
                 ("", "extended"),
                 ("10GiB", "logical")
             ],
@@ -757,7 +772,7 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
         disk1 = "/dev/vda"
         disk2 = "/dev/vdb"
         # On disk1: EFI, /boot (ext4), and root (xfs)
-        s.partition_disk(disk1, [("512MiB", "efi"), ("1GiB", "ext4"), ("", "xfs")])
+        s.partition_disk(disk1, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), (PARTITION_1GiB_SIZE, "ext4"), ("", "xfs")])
         # On disk2: whole-disk LUKS with xfs inside (no partition table)
         m.execute(f"wipefs -a {disk2}")
         s.create_luks_partition(disk2, "homepass", "encrypted-home", "xfs")
@@ -815,13 +830,13 @@ class TestStorageMountPoints(VirtInstallMachineCase, StorageCase):
 
         # Verify review shows /home as encrypted and mounted on disk2
         i.reach(i.steps.REVIEW)
-        r.check_disk(dev1, "16.1 GB vda (Virtio Block Device)")
-        r.check_disk_row(dev1, "/boot/efi", f"{dev1}1", "537 MB", False, "efi")
-        r.check_disk_row(dev1, "/boot", f"{dev1}2", "1.07 GB", False, "ext4")
-        r.check_disk_row(dev1, "/", f"{dev1}3", "14.5 GB", True, "xfs")
+        r.check_disk(dev1, "15 GiB vda (Virtio Block Device)")
+        r.check_disk_row(dev1, "/boot/efi", f"{dev1}1", EFI_PARTITION_DEFAULT_SIZE_SPACE, False, "efi")
+        r.check_disk_row(dev1, "/boot", f"{dev1}2", PARTITION_1GiB_SIZE_SPACE, False, "ext4")
+        r.check_disk_row(dev1, "/", f"{dev1}3", "13.5 GiB", True, "xfs")
 
-        r.check_disk(dev2, "10.7 GB vdb (Virtio Block Device)")
-        r.check_disk_row(dev2, "/home", "", "10.7 GB", False, "xfs", is_encrypted=True, action="mount")
+        r.check_disk(dev2, "10 GiB vdb (Virtio Block Device)")
+        r.check_disk_row(dev2, "/home", "", "9.98 GiB", False, "xfs", is_encrypted=True, action="mount")
 
 
 # TODO: these tests should be made nondestructive
@@ -873,11 +888,11 @@ class TestStorageMountPointsDestructive(VirtInstallMachineCase, StorageCase):
 
         # verify review screen
         disk = "vda"
-        r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
+        r.check_disk(disk, "15 GiB vda (Virtio Block Device)")
 
-        r.check_disk_row(disk, "/boot", "vda1", "1.07 GB", True, "ext4")
-        r.check_disk_row(disk, "/", "vda2", "14.0 GB", True, "btrfs subvolume")
-        r.check_disk_row(disk, "/home", "vda2", "14.0 GB", False, "btrfs subvolume")
+        r.check_disk_row(disk, "/boot", "vda1", PARTITION_1GiB_SIZE_SPACE, True, "ext4")
+        r.check_disk_row(disk, "/", "vda2", "13 GiB", True, "btrfs subvolume")
+        r.check_disk_row(disk, "/home", "vda2", "13 GiB", False, "btrfs subvolume")
 
     def _testWindowsSingleDiskHomeReuse_partition_disk(self):
         storage = Storage(self.browser, self.machine)
@@ -921,13 +936,13 @@ class TestStorageMountPointsDestructive(VirtInstallMachineCase, StorageCase):
         i.reach(i.steps.REVIEW)
 
         dev_win_fed = "vda"
-        r.check_disk(dev_win_fed, f"37.6 GB {dev_win_fed} (Virtio Block Device)")
-        r.check_disk_row(dev_win_fed, "/boot/efi", f"{dev_win_fed}1", "105 MB", False, "vfat", is_encrypted=False,
+        r.check_disk(dev_win_fed, f"35 GiB {dev_win_fed} (Virtio Block Device)")
+        r.check_disk_row(dev_win_fed, "/boot/efi", f"{dev_win_fed}1", "100 MiB", False, "vfat", is_encrypted=False,
                          action="mount")
-        r.check_disk_row(dev_win_fed, "/boot", f"{dev_win_fed}4", "1.07 GB", True, "ext4", is_encrypted=False)
-        r.check_disk_row(dev_win_fed, "/home", f"{dev_win_fed}5", "14.0 GB", False, "btrfs subvolume", is_encrypted=False,
+        r.check_disk_row(dev_win_fed, "/boot", f"{dev_win_fed}4", PARTITION_1GiB_SIZE_SPACE, True, "ext4", is_encrypted=False)
+        r.check_disk_row(dev_win_fed, "/home", f"{dev_win_fed}5", "13 GiB", False, "btrfs subvolume", is_encrypted=False,
                          action="mount")
-        r.check_disk_row(dev_win_fed, "/", f"{dev_win_fed}5", "14.0 GB", True, "btrfs subvolume", is_encrypted=False)
+        r.check_disk_row(dev_win_fed, "/", f"{dev_win_fed}5", "13 GiB", True, "btrfs subvolume", is_encrypted=False)
 
 
 if __name__ == '__main__':

--- a/test/check-storage-mountpoints-btrfs
+++ b/test/check-storage-mountpoints-btrfs
@@ -6,7 +6,13 @@
 from anacondalib import VirtInstallMachineCase
 from installer import Installer
 from review import Review
-from storage import EFI_PARTITION_DEFAULT_SIZE, EFI_PARTITION_DEFAULT_SIZE_MB, Storage
+from storage import (
+    EFI_PARTITION_DEFAULT_SIZE,
+    EFI_PARTITION_DEFAULT_SIZE_SPACE,
+    PARTITION_1GiB_SIZE,
+    PARTITION_1GiB_SIZE_SPACE,
+    Storage,
+)
 from testlib import nondestructive, skipImage, test_main  # pylint: disable=import-error
 
 
@@ -19,7 +25,7 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase):
 
         disk = "/dev/vda"
         tmp_mount = "/tmp/btrfs-mount-test"
-        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "ext4"), ("", "btrfs")])
+        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), (PARTITION_1GiB_SIZE, "ext4"), ("", "btrfs")])
         m.execute(f"""
         mkdir -p {tmp_mount}
         mount {disk}3 {tmp_mount}
@@ -85,12 +91,12 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase):
         i.reach(i.steps.REVIEW)
 
         # verify review screen
-        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
+        r.check_disk(dev, "15 GiB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False, "efi")
-        r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "ext4")
-        r.check_disk_row(dev, "/", "vda3", "14.5 GB", True, "btrfs subvolume")
-        r.check_disk_row(dev, "/home", "vda3", "14.5 GB", False)
+        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_SPACE, False, "efi")
+        r.check_disk_row(dev, "/boot", "vda2", PARTITION_1GiB_SIZE_SPACE, True, "ext4")
+        r.check_disk_row(dev, "/", "vda3", "13.5 GiB", True, "btrfs subvolume")
+        r.check_disk_row(dev, "/home", "vda3", "13.5 GiB", False)
         r.check_disk_row_not_present(dev, "unused")
 
         i.reach_on_sidebar(i.steps.INSTALLATION_METHOD)
@@ -158,7 +164,7 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase):
 
         disk = "/dev/vda"
         tmp_mount = "/tmp/btrfs-mount-test"
-        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "ext4"), ("", "btrfs")])
+        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), (PARTITION_1GiB_SIZE, "ext4"), ("", "btrfs")])
         s.create_luks_partition(f"{disk}3", "einszweidrei", "encrypted-vol", "btrfs", close_luks=False)
         m.execute(f"""
         mkdir -p {tmp_mount}
@@ -206,9 +212,9 @@ class TestStorageMountPointsBtrfs (VirtInstallMachineCase):
 
         # Verify the review page
         i.reach(i.steps.REVIEW)
-        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
-        r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False)
-        r.check_disk_row(dev, "/", "vda3", "14.5 GB", True, "btrfs subvolume", True)
+        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_SPACE, False)
+        r.check_disk_row(dev, "/boot", "vda2", PARTITION_1GiB_SIZE_SPACE, False)
+        r.check_disk_row(dev, "/", "vda3", "13.5 GiB", True, "btrfs subvolume", True)
 
 
 if __name__ == '__main__':

--- a/test/check-storage-mountpoints-btrfs-e2e
+++ b/test/check-storage-mountpoints-btrfs-e2e
@@ -92,10 +92,10 @@ class TestStorageMountPointsBtrfs_E2E(VirtInstallMachineCase):
         i.next(should_fail=True)
         i.reach(i.steps.REVIEW)
 
-        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
-        r.check_disk_row(dev, "/boot/efi", f"{dev}1", "105 MB", False)
-        r.check_disk_row(dev, "/", f"{dev}2", "16.0 GB", True, "btrfs subvolume")
-        r.check_disk_row(dev, "/home", f"{dev}2", "16.0 GB", False)
+        r.check_disk(dev, "15 GiB vda (Virtio Block Device)")
+        r.check_disk_row(dev, "/boot/efi", f"{dev}1", "100 MiB", False)
+        r.check_disk_row(dev, "/", f"{dev}2", "14.9 GiB", True, "btrfs subvolume")
+        r.check_disk_row(dev, "/home", f"{dev}2", "14.9 GiB", False)
 
         self.install(button_text="Apply mount point assignment and install", needs_confirmation=True)
 

--- a/test/check-storage-mountpoints-lvm
+++ b/test/check-storage-mountpoints-lvm
@@ -6,7 +6,13 @@
 from anacondalib import VirtInstallMachineCase
 from installer import Installer
 from review import Review
-from storage import EFI_PARTITION_DEFAULT_SIZE, EFI_PARTITION_DEFAULT_SIZE_MB, Storage
+from storage import (
+    EFI_PARTITION_DEFAULT_SIZE,
+    EFI_PARTITION_DEFAULT_SIZE_SPACE,
+    PARTITION_1GiB_SIZE,
+    PARTITION_1GiB_SIZE_SPACE,
+    Storage,
+)
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 
 
@@ -20,7 +26,7 @@ class TestStorageMountPointsLVM(VirtInstallMachineCase):
         disk = "/dev/vda"
         vgname = "fedoravg"
 
-        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "ext4"), ("", None)])
+        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), (PARTITION_1GiB_SIZE, "ext4"), ("", None)])
         m.execute(f"""
         vgcreate -y -f {vgname} {disk}3
         lvcreate -y -l40%FREE -n root {vgname}
@@ -85,13 +91,13 @@ class TestStorageMountPointsLVM(VirtInstallMachineCase):
 
         # verify review screen
         disk = "vda"
-        r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
+        r.check_disk(disk, "15 GiB vda (Virtio Block Device)")
 
-        r.check_disk_row(disk, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
-        r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", True, "ext4")
-        r.check_disk_row(disk, "/", "vda3, LVM", "5.80 GB", True, "ext4")
-        r.check_disk_row(disk, "/home", "vda3, LVM", "7.83 GB", False)
-        r.check_disk_row(disk, "swap", "vda3, LVM", "872 MB", False)
+        r.check_disk_row(disk, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_SPACE, False)
+        r.check_disk_row(disk, "/boot", "vda2", PARTITION_1GiB_SIZE_SPACE, True, "ext4")
+        r.check_disk_row(disk, "/", "vda3, LVM", "5.40 GiB", True, "ext4")
+        r.check_disk_row(disk, "/home", "vda3, LVM", "7.29 GiB", False)
+        r.check_disk_row(disk, "swap", "vda3, LVM", "832 MiB", False)
 
         i.reach_on_sidebar(i.steps.CUSTOM_MOUNT_POINT)
 
@@ -104,12 +110,12 @@ class TestStorageMountPointsLVM(VirtInstallMachineCase):
 
         # verify review screen
         disk = "vda"
-        r.check_disk(disk, "16.1 GB vda (Virtio Block Device)")
+        r.check_disk(disk, "15 GiB vda (Virtio Block Device)")
 
-        r.check_disk_row(disk, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
-        r.check_disk_row(disk, "/boot", "vda2", "1.07 GB", True, "ext4")
-        r.check_disk_row(disk, "/", "vda3, LVM", "5.80 GB", True, "ext4")
-        r.check_disk_row(disk, "swap", "vda3, LVM", "872 MB", False)
+        r.check_disk_row(disk, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_SPACE, False)
+        r.check_disk_row(disk, "/boot", "vda2", PARTITION_1GiB_SIZE_SPACE, True, "ext4")
+        r.check_disk_row(disk, "/", "vda3, LVM", "5.40 GiB", True, "ext4")
+        r.check_disk_row(disk, "swap", "vda3, LVM", "832 MiB", False)
 
 
 if __name__ == '__main__':

--- a/test/check-storage-mountpoints-raid
+++ b/test/check-storage-mountpoints-raid
@@ -6,7 +6,15 @@
 from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images
 from installer import Installer
 from review import Review
-from storage import EFI_PARTITION_DEFAULT_SIZE, EFI_PARTITION_DEFAULT_SIZE_MB, Storage
+from storage import (
+    EFI_PARTITION_DEFAULT_SIZE,
+    EFI_PARTITION_DEFAULT_SIZE_SPACE,
+    PARTITION_1GB_SIZE,
+    PARTITION_1GB_SIZE_SPACE,
+    PARTITION_1GiB_SIZE,
+    PARTITION_1GiB_SIZE_SPACE,
+    Storage,
+)
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 
 
@@ -21,7 +29,7 @@ class TestStorageMountPointsRAIDDestructive(VirtInstallMachineCase):
 
         # EFI system partition, /boot partition, / on RAID
         disk = "/dev/vda"
-        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "xfs"), ("5GiB", None), ("5GiB", None)])
+        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), (PARTITION_1GiB_SIZE, "xfs"), ("5GiB", None), ("5GiB", None)])
         s.create_luks_partition(f"{disk}3", "einszweidrei", "encrypted-vol", close_luks=False)
         s.create_luks_partition(f"{disk}4", "einszweidrei", "encrypted-vol2", close_luks=False)
         s.create_raid_device("encryptedraid", "raid1", ["/dev/mapper/encrypted-vol", "/dev/mapper/encrypted-vol2"])
@@ -70,11 +78,11 @@ class TestStorageMountPointsRAIDDestructive(VirtInstallMachineCase):
 
         i.reach(i.steps.REVIEW)
 
-        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
+        r.check_disk(dev, "15 GiB vda (Virtio Block Device)")
 
-        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False, "efi")
-        r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", True, "xfs")
-        r.check_disk_row(dev, "/", "vda3, vda4, RAID", "5.35 GB", True, "xfs", True)
+        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_SPACE, False, "efi")
+        r.check_disk_row(dev, "/boot", "vda2", PARTITION_1GiB_SIZE_SPACE, True, "xfs")
+        r.check_disk_row(dev, "/", "vda3, vda4, RAID", "4.98 GiB", True, "xfs", True)
 
     def _testEncryptedUnlockLUKSonRAID_partition_disk(self):
         b = self.browser
@@ -83,7 +91,7 @@ class TestStorageMountPointsRAIDDestructive(VirtInstallMachineCase):
 
         disk = "/dev/vda"
 
-        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "xfs"), ("5GiB", None), ("5GiB", None)])
+        s.partition_disk(disk, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), (PARTITION_1GiB_SIZE, "xfs"), ("5GiB", None), ("5GiB", None)])
         s.create_raid_device("encryptedraid", "raid1", [f"{disk}3", f"{disk}4"])
         s.create_luks_partition("/dev/md/encryptedraid", "einszweidrei", "encrypted-vol", "xfs")
 
@@ -135,10 +143,10 @@ class TestStorageMountPointsRAIDDestructive(VirtInstallMachineCase):
         s.check_mountpoint_row_format_type(1, "xfs")
 
         i.reach(i.steps.REVIEW)
-        r.check_disk(dev, "16.1 GB vda (Virtio Block Device)")
-        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False, "efi")
-        r.check_disk_row(dev, "/boot", "vda2", "1.07 GB", False, "xfs")
-        r.check_disk_row(dev, "/", "vda3, vda4, RAID", "5.35 GB", True, "xfs", True)
+        r.check_disk(dev, "15 GiB vda (Virtio Block Device)")
+        r.check_disk_row(dev, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_SPACE, False, "efi")
+        r.check_disk_row(dev, "/boot", "vda2", PARTITION_1GiB_SIZE_SPACE, False, "xfs")
+        r.check_disk_row(dev, "/", "vda3, vda4, RAID", "4.98 GiB", True, "xfs", True)
 
 
 @nondestructive
@@ -149,7 +157,7 @@ class TestStorageMountPointsRAID(VirtInstallMachineCase):
         s = Storage(b, m)
 
         # EFI system partition, /boot partition, / on RAID
-        s.partition_disk("/dev/vda", [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GB", "xfs")])
+        s.partition_disk("/dev/vda", [(EFI_PARTITION_DEFAULT_SIZE, "efi"), (PARTITION_1GB_SIZE, "xfs")])
         self.addCleanup(
             lambda: m.execute(
             """
@@ -202,11 +210,11 @@ class TestStorageMountPointsRAID(VirtInstallMachineCase):
         i.next(should_fail=True)
         i.reach(i.steps.REVIEW)
 
-        r.check_disk("vda", "16.1 GB vda (Virtio Block Device)")
-        r.check_disk_row("vda", "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, False)
-        r.check_disk_row("vda", "/boot", "vda2", "1.00 GB", False)
-        r.check_disk("MDRAID-SOMERAID", "32.2 GB MDRAID-SOMERAID (MDRAID set (stripe))")
-        r.check_disk_row("MDRAID-SOMERAID", "/", "SOMERAID1, RAID", "32.2 GB", False)
+        r.check_disk("vda", "15 GiB vda (Virtio Block Device)")
+        r.check_disk_row("vda", "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_SPACE, False)
+        r.check_disk_row("vda", "/boot", "vda2", PARTITION_1GB_SIZE_SPACE, False)
+        r.check_disk("MDRAID-SOMERAID", "30.0 GiB MDRAID-SOMERAID (MDRAID set (stripe))")
+        r.check_disk_row("MDRAID-SOMERAID", "/", "SOMERAID1, RAID", "30.0 GiB", False)
 
 
 if __name__ == '__main__':

--- a/test/check-storage-mountpoints-raid-e2e
+++ b/test/check-storage-mountpoints-raid-e2e
@@ -5,7 +5,7 @@
 
 from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, disk_images
 from installer import Installer
-from storage import EFI_PARTITION_DEFAULT_SIZE, Storage
+from storage import EFI_PARTITION_DEFAULT_SIZE, PARTITION_1GiB_SIZE, Storage
 from testlib import test_main, timeout  # pylint: disable=import-error
 
 
@@ -21,8 +21,8 @@ class TestStorageMountPointsRAID_E2E(VirtInstallMachineCase):
         disk2 = "/dev/vdb"
         raid_name = "raid1"
 
-        s.partition_disk(disk1, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "xfs"), ("", None)])
-        s.partition_disk(disk2, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), ("1GiB", "xfs"), ("", None)])
+        s.partition_disk(disk1, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), (PARTITION_1GiB_SIZE, "xfs"), ("", None)])
+        s.partition_disk(disk2, [(EFI_PARTITION_DEFAULT_SIZE, "efi"), (PARTITION_1GiB_SIZE, "xfs"), ("", None)])
 
         # RAID1 on partition level for /boot and /
         s.create_raid_device(f"{raid_name}-boot", "raid1", [f"{disk1}2", f"{disk2}2"])

--- a/test/check-storage-reclaim
+++ b/test/check-storage-reclaim
@@ -7,7 +7,7 @@ from anacondalib import VirtInstallMachineCase, disk_images
 from installer import Installer
 from language import Language
 from review import Review
-from storage import BOOT_PARTITION_DEFAULT_SIZE, EFI_PARTITION_DEFAULT_SIZE, EFI_PARTITION_DEFAULT_SIZE_MB, Storage
+from storage import BOOT_PARTITION_DEFAULT_SIZE, EFI_PARTITION_DEFAULT_SIZE, EFI_PARTITION_DEFAULT_SIZE_SPACE, Storage
 from testlib import (
     nondestructive,
     test_main,
@@ -84,7 +84,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
 
         i.reach(i.steps.REVIEW)
 
-        r.check_disk_row(dev, "/", "vda5, LVM", "5.91 GB", True, "xfs")
+        r.check_disk_row(dev, "/", "vda5, LVM", "5.51 GiB", True, "xfs")
 
     def _testReclaimSpaceDeleteBtrfsSubvolumes_partition_disk(self):
         b = self.browser
@@ -119,28 +119,28 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         s.reclaim_check_checkbox(True, True)
         i.next(next_page=i.steps.INSTALLATION_METHOD)
 
-        s.reclaim_check_available_space("2.06 MB")
+        s.reclaim_check_available_space("1.97 MiB")
 
         # Check that all partitions are present
-        s.reclaim_check_device_row("vda", deviceType="disk", space="16.1 GB")
-        s.reclaim_check_device_row("vda1", deviceType="efi", space=EFI_PARTITION_DEFAULT_SIZE_MB)
-        s.reclaim_check_device_row("vda2", deviceType="ext4", space="6.44 GB")
-        s.reclaim_check_device_row("vda3", deviceType="btrfs", space="5.37 GB")
-        s.reclaim_check_device_row("vda4", deviceType="btrfs", space="3.77 GB")
+        s.reclaim_check_device_row("vda", deviceType="disk", space="15 GiB")
+        s.reclaim_check_device_row("vda1", deviceType="efi", space=EFI_PARTITION_DEFAULT_SIZE_SPACE)
+        s.reclaim_check_device_row("vda2", deviceType="ext4", space="6 GiB")
+        s.reclaim_check_device_row("vda3", deviceType="btrfs", space="5 GiB")
+        s.reclaim_check_device_row("vda4", deviceType="btrfs", space="3.51 GiB")
 
         # Check that deleting a disk will delete all contained partitions
         s.reclaim_remove_device("vda")
         for device in ["vda1", "vda2", "vda3"]:
             s.reclaim_check_action_present(device, "delete")
 
-        s.reclaim_check_available_space("16.1 GB")
+        s.reclaim_check_available_space("15 GiB")
 
         # Undo disk device deletion
         s.reclaim_undo_action("vda")
         for device in ["vda1", "vda2", "vda3"]:
             s.reclaim_check_action_present(device, "delete", present=False)
 
-        s.reclaim_check_available_space("2.06 MB")
+        s.reclaim_check_available_space("1.97 MiB")
 
         # Check that actions for devices whose parents are marked for deletion are not sent to blivet
         s.reclaim_remove_device("vda4")
@@ -154,14 +154,14 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         # Remove one partition and allocate enough space for the installation
         s.reclaim_remove_device("vda2")
         s.reclaim_check_action_present("vda2", "delete")
-        s.reclaim_check_available_space("6.44 GB")
+        s.reclaim_check_available_space("6.00 GiB")
 
         # Check that deleting a parent disk which contains partitions marked for deletion
         # correctly calculates the available space
         s.reclaim_remove_device("vda")
-        s.reclaim_check_available_space("16.1 GB")
+        s.reclaim_check_available_space("15 GiB")
         s.reclaim_undo_action("vda")
-        s.reclaim_check_available_space("6.44 GB")
+        s.reclaim_check_available_space("6.00 GiB")
 
         s.reclaim_modal_submit()
         i.reach(i.steps.REVIEW)
@@ -199,7 +199,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         s.set_scenario("use-free-space")
         i.next(next_page=i.steps.INSTALLATION_METHOD)
 
-        s.reclaim_check_available_space("2.06 MB")
+        s.reclaim_check_available_space("1.97 MiB")
 
         # Check that shrinking action is only available for partitions
         s.reclaim_check_action_button_present("vda", "shrink", present=False)
@@ -212,28 +212,28 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
             s.reclaim_check_action_button_present(device, "shrink", disabled=True)
 
         # Shrink a partition too much and expect a warning
-        s.reclaim_shrink_device("vda2", "0.100", "6.44")
+        s.reclaim_shrink_device("vda2", "0.100", "6")
         s.reclaim_modal_submit_and_check_warning("Unable to schedule resizing of vda2")
         s.reclaim_undo_action("vda2")
 
         # Shrink a partition
-        s.reclaim_shrink_device("vda2", "1", "6.44")
-        s.reclaim_check_available_space("5.44 GB")
+        s.reclaim_shrink_device("vda2", "1", "6")
+        s.reclaim_check_available_space("5.00 GiB")
 
         # Undo the shrink actions
         for device in ["vda2"]:
             s.reclaim_undo_action(device)
             s.reclaim_check_action_present(device, "shrink", present=False)
 
-        s.reclaim_check_available_space("2.06 MB")
+        s.reclaim_check_available_space("1.97 MiB")
 
         # Shrink one partition and allocate enough space for the installation
-        s.reclaim_shrink_device("vda2", "1", "6.44")
+        s.reclaim_shrink_device("vda2", "1", "6")
 
         s.reclaim_modal_submit()
         i.reach(i.steps.REVIEW)
 
-        r.check_disk_row("vda", parent="vda2", size="1.00 GB", action="resized from 6.44 GB")
+        r.check_disk_row("vda", parent="vda2", size="1 GiB", action="resized from 6 GiB")
 
     def _testExtendedPartitionEFI_partition_disk(self):
         b = self.browser
@@ -245,11 +245,11 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         s.partition_disk(
             disk,
             [
-                ("512MB", "efi"),
-                ("2GB", "swap"),
-                ("8GB", "ext4"),
+                (EFI_PARTITION_DEFAULT_SIZE, "efi"),
+                ("2GiB", "swap"),
+                ("8GiB", "ext4"),
                 ("", "extended"),
-                ("2.5GB", "logical"),
+                ("2.5GiB", "logical"),
             ],
             is_mbr=True
         )
@@ -274,15 +274,15 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         i.reach(i.steps.INSTALLATION_METHOD)
 
         s.set_scenario("use-free-space")
-        s.reclaim_set_checkbox(True)
+        s.reclaim_check_checkbox(True, True)
         i.next(next_page=i.steps.INSTALLATION_METHOD)
 
-        s.reclaim_check_device_row("vda", deviceType="disk", space="16.1 GB")
-        s.reclaim_check_device_row("vda1", deviceType="vfat", space="512 MB")
-        s.reclaim_check_device_row("vda2", deviceType="swap", space="2.00 GB")
-        s.reclaim_check_device_row("vda3", deviceType="ext4", space="8.00 GB")
+        s.reclaim_check_device_row("vda", deviceType="disk", space="15 GiB")
+        s.reclaim_check_device_row("vda1", deviceType="vfat", space=EFI_PARTITION_DEFAULT_SIZE_SPACE)
+        s.reclaim_check_device_row("vda2", deviceType="swap", space="2 GiB")
+        s.reclaim_check_device_row("vda3", deviceType="ext4", space="8 GiB")
         s.reclaim_check_device_row("vda4", deviceType="extended partition")
-        s.reclaim_check_device_row("vda5", deviceType="btrfs", space="2.50 GB")
+        s.reclaim_check_device_row("vda5", deviceType="btrfs", space="2.50 GiB")
         s.reclaim_check_device_row("BTRFS", name="BTRFS", deviceType="btrfs volume")
         s.reclaim_check_device_row("@subvol1", name="@subvol1", deviceType="btrfs subvolume")
         s.reclaim_check_device_row("@subvol2", name="@subvol2", deviceType="btrfs subvolume")
@@ -347,7 +347,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
             ignore=["#reclaim-space-modal-hint"],
         )
 
-        s.reclaim_check_device_row("vda1", deviceType="luks", space="4.29 GB", locked=True)
+        s.reclaim_check_device_row("vda1", deviceType="luks", space="4 GiB", locked=True)
         s.reclaim_check_action_button_present("vda1", "shrink", disabled=True)
         s.reclaim_check_action_button_present("vda1", "delete")
 
@@ -454,7 +454,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
 
         i.reach(i.steps.REVIEW)
         # Don't specify the exact original size as this might change with image refreshes
-        r.check_disk_row("vda", parent="vda1", size="7.00 GB", action="resized from 11.2 GB")
+        r.check_disk_row("vda", parent="vda1", size="7 GiB", action="resized from 10.4 GiB")
         r.check_resized_system("Ubuntu", ["vda1"])
 
         i.reach_on_sidebar(i.steps.LANGUAGE)
@@ -470,7 +470,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         i.next(next_page=i.steps.STORAGE_CONFIGURATION)
 
         i.reach(i.steps.REVIEW)
-        r.check_disk_row("vda", parent="vda1", size="7,10 GB", action="změněna velikost z 11,2 GB")
+        r.check_disk_row("vda", parent="vda1", size="7,10 GiB", action="změněna velikost z 10,4 GiB")
 
 
 if __name__ == '__main__':

--- a/test/check-storage-reclaim-e2e
+++ b/test/check-storage-reclaim-e2e
@@ -46,12 +46,12 @@ class TestStorageReclaim_E2E(DualBootHelper_E2E, VirtInstallMachineCase):
         i.reach(i.steps.REVIEW)
         r.check_some_resized_checkbox_label()
         vda1_original_size_bytes = m.execute("blockdev --getsize64 /dev/vda1").strip()
-        vda1_original_size_gb = round(int(vda1_original_size_bytes) / 1000 / 1000 / 1000, 1)
-        r.check_disk_row("vda", parent="vda1", size="7.00 GB", action=f"resized from {vda1_original_size_gb} GB")
+        vda1_original_size_gib = round(int(vda1_original_size_bytes) / 1024 / 1024 / 1024, 1)
+        r.check_disk_row("vda", parent="vda1", size="7 GiB", action=f"resized from {vda1_original_size_gib} GiB")
         r.check_resized_system("Debian", ["vda1"])
 
         self.install(needs_confirmation=True)
-        self.verifyDualBootDebian(root_one_size=11.4, root_two_size=6.5)
+        self.verifyDualBootDebian(root_one_size=10.9, root_two_size=7)
 
 
 if __name__ == '__main__':

--- a/test/check-storage-use-free-space
+++ b/test/check-storage-use-free-space
@@ -48,9 +48,9 @@ class TestStorageUseFreeSpace(VirtInstallMachineCase):
         i.next(next_page=i.steps.STORAGE_CONFIGURATION)
         i.reach(i.steps.REVIEW)
         r.check_storage_config("Share disk with other operating systems: Debian GNU/Linux")
-        r.check_disk_row("vda", "/", "vda3, LVM", "7.51 GB", True, "xfs")
-        r.check_disk_row("vda", "/boot/efi", "vda15", "130 MB", False)
-        r.check_disk_row("vda", "", "vda14", "3.15 MB", False, action="biosboot")
+        r.check_disk_row("vda", "/", "vda3, LVM", "7.00 GiB", True, "xfs")
+        r.check_disk_row("vda", "/boot/efi", "vda15", "124 MiB", False)
+        r.check_disk_row("vda", "", "vda14", "3 MiB", False, action="biosboot")
 
 
 if __name__ == '__main__':

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -26,13 +26,22 @@ DISK_INITIALIZATION_OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Storage/D
 
 # Default boot partition size for partition preparation (GiB format)
 BOOT_PARTITION_DEFAULT_SIZE = '2GiB'
-# Default boot partition size for review display (GB format)
-BOOT_PARTITION_DEFAULT_SIZE_GB = '2.15 GB'
+# Default boot partition size as shown in the UI (binary units)
+BOOT_PARTITION_DEFAULT_SIZE_SPACE = '2.00 GiB'
 
 # Default EFI system partition size for partition preparation (MiB format)
 EFI_PARTITION_DEFAULT_SIZE = '500MiB'
-# Default EFI system partition size for review display (MB format)
-EFI_PARTITION_DEFAULT_SIZE_MB = '524 MB'
+# Default EFI system partition size as shown in the UI (binary units)
+EFI_PARTITION_DEFAULT_SIZE_SPACE = '500 MiB'
+
+# Typical 1 GiB partition size in mount-point mapping tests
+PARTITION_1GiB_SIZE = '1GiB'
+# Typical 1 GiB partition size as shown in the UI (binary units)
+PARTITION_1GiB_SIZE_SPACE = '1 GiB'
+
+# ~1 GB (decimal) partition; shown as 954 MiB in the UI (binary units)
+PARTITION_1GB_SIZE = '954MiB'
+PARTITION_1GB_SIZE_SPACE = '954 MiB'
 
 class StorageDestination():
     def __init__(self, browser, machine):

--- a/test/helpers/utils.py
+++ b/test/helpers/utils.py
@@ -3,6 +3,8 @@
 
 import os
 
+from storage import PARTITION_1GiB_SIZE
+
 
 def add_public_key(machine):
     with open(f'{machine.identity_file}.pub', 'r') as pub:
@@ -105,7 +107,7 @@ def move_standard_fedora_disk_to_disk(machine, src_disk, dst_disk,
 def move_standard_fedora_disk_to_MBR_disk(storage, machine, mbr_disk, fedora_disk):
     """Partition a disk with msdos table and copy Fedora system from another disk on it."""
     storage.partition_disk(f"/dev/{mbr_disk}", [
-        ("1GiB", "ext4"),
+        (PARTITION_1GiB_SIZE, "ext4"),
         ("13GiB", "btrfs"),
     ], is_mbr=True)
     boot_part = 1
@@ -123,7 +125,7 @@ def move_standard_fedora_disk_to_win_disk(storage, machine, win_disk, fedora_dis
         ("128MiB", "microsoft-reserved"),
         ("11.5GiB", "basic-data"),
         # Fedora
-        ("1GiB", "ext4"),
+        (PARTITION_1GiB_SIZE, "ext4"),
         ("13GiB", "btrfs"),
         # Windows
         ("530MiB", "microsoft-recovery"),


### PR DESCRIPTION
Add formatBytes() with base2 sizing matching blivet and Anaconda Backend. Update integration test expectations to MiB/GiB and use  EFI_PARTITION_DEFAULT_SIZE_SPACE (500 MiB) for default EFI rows.
Note: cockpit-storaged still uses decimal units
