### PR TITLE
users: support policy-allowed empty user passwords

### DIFF
--- a/src/components/Password.jsx
+++ b/src/components/Password.jsx
@@ -102,6 +102,7 @@ const passwordStrengthLabel = (idPrefix, strength, strengthLevels) => {
 export const PasswordFormFields = ({
     confirmPassword,
     confirmPasswordLabel,
+    emptyPasswordHelperText,
     idPrefix,
     password,
     passwordLabel,
@@ -131,7 +132,12 @@ export const PasswordFormFields = ({
         return getRuleResults(rules, policy, checkPassword);
     }, [policy, checkPassword, rules]);
 
-    const ruleConfirmMatches = checkPassword.length > 0 ? checkPassword === checkConfirmPassword : null;
+    const allowEmptyPassword = policy?.["allow-empty"]?.v ?? false;
+    const bothFieldsEmpty = (checkPassword?.length ?? 0) === 0 && (checkConfirmPassword?.length ?? 0) === 0;
+    const isEmptyPasswordAccepted = allowEmptyPassword && bothFieldsEmpty;
+    const ruleConfirmMatches = bothFieldsEmpty
+        ? (allowEmptyPassword ? true : null)
+        : checkPassword === checkConfirmPassword;
 
     const ruleHelperItems = ruleResults.map(rule => {
         let variant = rule.isSatisfied === null ? "indeterminate" : rule.isSatisfied ? "success" : "error";
@@ -168,12 +174,13 @@ export const PasswordFormFields = ({
     }, [checkPassword, strengthLevels]);
 
     useEffect(() => {
-        setIsValid(
-            rulesSatisfied(ruleResults) &&
+        setIsValid(!!(
+            isEmptyPasswordAccepted ||
+            (rulesSatisfied(ruleResults) &&
             ruleConfirmMatches &&
-            isValidStrength(passwordStrength, strengthLevels)
-        );
-    }, [setIsValid, ruleResults, ruleConfirmMatches, passwordStrength, strengthLevels]);
+            isValidStrength(passwordStrength, strengthLevels))
+        ));
+    }, [setIsValid, isEmptyPasswordAccepted, ruleResults, ruleConfirmMatches, passwordStrength, strengthLevels]);
 
     return (
         <FormSection>
@@ -206,6 +213,14 @@ export const PasswordFormFields = ({
                 <FormHelperText>
                     <HelperText component="ul" aria-live="polite" id={idPrefix + "-password-field-helper"}>
                         {ruleHelperItems}
+                        {allowEmptyPassword && emptyPasswordHelperText && (
+                            <HelperTextItem
+                              component="li"
+                              variant="default"
+                            >
+                                {emptyPasswordHelperText}
+                            </HelperTextItem>
+                        )}
                     </HelperText>
                 </FormHelperText>
             </FormGroup>

--- a/src/components/Password.jsx
+++ b/src/components/Password.jsx
@@ -174,13 +174,35 @@ export const PasswordFormFields = ({
     }, [checkPassword, strengthLevels]);
 
     useEffect(() => {
-        setIsValid(!!(
-            isEmptyPasswordAccepted ||
-            (rulesSatisfied(ruleResults) &&
-            ruleConfirmMatches &&
-            isValidStrength(passwordStrength, strengthLevels))
-        ));
-    }, [setIsValid, isEmptyPasswordAccepted, ruleResults, ruleConfirmMatches, passwordStrength, strengthLevels]);
+        const isStrict = policy?.["is-strict"]?.v ?? false;
+
+        if (isEmptyPasswordAccepted) {
+            setIsValid(true);
+            return;
+        }
+
+        if (!ruleConfirmMatches) {
+            setIsValid(false);
+            return;
+        }
+
+        if (isStrict) {
+            setIsValid(!!(rulesSatisfied(ruleResults) && isValidStrength(passwordStrength, strengthLevels)));
+            return;
+        }
+
+        // Non-strict: length/strength are shown but not required; only confirmation must match.
+        setIsValid((checkPassword?.length ?? 0) > 0);
+    }, [
+        checkPassword,
+        isEmptyPasswordAccepted,
+        policy,
+        ruleConfirmMatches,
+        ruleResults,
+        passwordStrength,
+        setIsValid,
+        strengthLevels,
+    ]);
 
     return (
         <FormSection>

--- a/src/components/users/Accounts.jsx
+++ b/src/components/users/Accounts.jsx
@@ -196,6 +196,7 @@ const CreateAccount = ({
           confirmPassword={confirmPassword}
           setConfirmPassword={setConfirmPassword}
           confirmPasswordLabel={_("Confirm passphrase")}
+          emptyPasswordHelperText={_("Leave both passphrase fields empty to use an empty password.")}
           rules={[ruleLength]}
           setIsValid={setIsPasswordValid}
         />

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -78,9 +78,17 @@ export const applyAccounts = async (accounts) => {
     if ((accounts.users?.length ?? 0) === 0) {
         await setUsers([]);
     } else if (accounts.canModifyUserConfiguration) {
-        const cryptedUserPw = await cryptUserPassword(accounts.password);
+        const password = typeof accounts.password === "string" ? accounts.password : "";
+        const hasUserPassword = password.length > 0;
+        const userPassword = hasUserPassword
+            ? await cryptUserPassword(password)
+            : "";
         const first = accounts.users?.[0] ?? {};
-        const firstUserDbus = firstUserToDbus({ ...first, password: cryptedUserPw });
+        const firstUserDbus = firstUserToDbus({
+            ...first,
+            isCrypted: hasUserPassword,
+            password: userPassword,
+        });
         const existing = accounts.users ?? [];
         const users = existing.length > 0
             ? [firstUserDbus, ...existing.slice(1).map(u => objectToDbus(u))]
@@ -103,7 +111,7 @@ const firstUserToDbus = (firstUser) => {
     return {
         gecos: cockpit.variant("s", firstUser.gecos ?? ""),
         groups: cockpit.variant("as", firstUser.groups ?? ["wheel"]),
-        "is-crypted": cockpit.variant("b", true),
+        "is-crypted": cockpit.variant("b", firstUser.isCrypted ?? true),
         name: cockpit.variant("s", firstUser.name ?? ""),
         password: cockpit.variant("s", firstUser.password ?? ""),
     };

--- a/test/check-users
+++ b/test/check-users
@@ -8,7 +8,7 @@ from installer import Installer
 from password import Password
 from review import Review
 from testlib import nondestructive, test_main  # pylint: disable=import-error
-from users import CREATE_ACCOUNT_ID_PREFIX, Users, create_user
+from users import CREATE_ACCOUNT_ID_PREFIX, Users, create_user, override_user_interface_conf_keys
 
 
 @nondestructive
@@ -195,18 +195,23 @@ class TestUsers(VirtInstallMachineCase):
         u.set_user_name(user_name)
 
         # Test password validation
-        # No password set
+        # No password set - allowed in the default policy
         p.set_password("")
         p.set_password_confirm("")
         p.check_pw_rule("length", "indeterminate")
-        p.check_pw_rule("match", "indeterminate")
-        i.check_next_disabled()
+        p.check_pw_rule("match", "success")
+        i.check_next_disabled(disabled=False)
         # Start which pw which is too short
         p.set_password("abcd")
         p.check_pw_strength(None)
         i.check_next_disabled()
         p.check_pw_rule("length", "error")
         p.check_pw_rule("match", "error")
+        # Default non-strict policy: length is advisory; confirmation must match
+        p.set_password_confirm("abcd")
+        p.check_pw_rule("match", "success")
+        p.check_pw_rule("length", "error")
+        i.check_next_disabled(disabled=False)
         # Make the pw 6 chars long
         p.set_password("ef", append=True, value_check=False)
         i.check_next_disabled()
@@ -235,6 +240,60 @@ class TestUsers(VirtInstallMachineCase):
         r = Review(b, self.machine)
         i.reach(i.steps.REVIEW)
         r.check_account(f"{full_name} ({user_name})")
+
+    def testStrictUserPasswordPolicy(self):
+        """
+        Description:
+            User password policy with empty passwords disallowed and strict
+            quality enforcement (via ``anaconda.conf``).
+
+        Expected results:
+            - Empty password keeps Next disabled
+            - Short or weak passwords keep Next disabled under strict policy
+            - A strong password that satisfies length and quality enables Next
+        """
+        override_user_interface_conf_keys(
+            self,
+            password_policies="""
+                root (quality 1, length 6)
+                user (quality 1, length 6, strict)
+                luks (quality 1, length 6)
+            """,
+        )
+
+        b = self.browser
+        i = Installer(b, self.machine)
+        p = Password(b, CREATE_ACCOUNT_ID_PREFIX)
+        u = Users(b, self.machine)
+
+        i.open()
+        i.reach(i.steps.ACCOUNTS)
+
+        u.set_user_name("tester")
+        u.set_full_name("Full Tester")
+
+        p.set_password("")
+        p.set_password_confirm("")
+        i.check_next_disabled()
+
+        p.set_password("abcd")
+        p.set_password_confirm("abcd")
+        p.check_pw_rule("length", "error")
+        i.check_next_disabled()
+
+        p.set_password("abcdef")
+        p.set_password_confirm("abcdef")
+        p.check_pw_rule("length", "success")
+        p.check_pw_strength("weak")
+        i.check_next_disabled()
+
+        strong_password = "Rwce82ybF7dXtCzFumanchu!!!!!!!!"
+        p.set_password(strong_password)
+        p.set_password_confirm(strong_password)
+        p.check_pw_strength("strong")
+        p.check_pw_rule("length", "success")
+        p.check_pw_rule("match", "success")
+        i.check_next_disabled(disabled=False)
 
 
 if __name__ == '__main__':

--- a/test/helpers/users.py
+++ b/test/helpers/users.py
@@ -28,10 +28,16 @@ ACCOUNTS_READONLY_USER_ROW = "accounts-users-readonly-user"
 
 def override_user_interface_conf_keys(test, **kwargs):
     """Patch `[User Interface]` boolean keys in `/run/anaconda/anaconda.conf` (single restore)."""
-    test.restore_file('/run/anaconda/anaconda.conf')
+    conf = '/run/anaconda/anaconda.conf'
+    test.restore_file(conf)
     for key, value in kwargs.items():
-        val = "True" if value else "False"
-        test.machine.execute(fr"sed -i 's/^{key} =.*/{key} = {val}/' /run/anaconda/anaconda.conf")
+        text = value if isinstance(value, str) else str(value)
+        if "\n" in text:
+            lines = [line.strip() for line in text.strip().splitlines() if line.strip()]
+            sed_text = "\\\n".join([f"{key} =", *[f"    {line}" for line in lines]])
+            test.machine.execute(f"sed -i '/^{key} =/,/^$/c\\\n{sed_text}' {conf}")
+        else:
+            test.machine.execute(f"sed -i '/^{key} =/c\\{key} = {text}' {conf}")
 
 
 class UsersDBus():


### PR DESCRIPTION
Allow the Accounts user form to accept both password fields empty when policy allows it, and send an actual empty password to backend with is-crypted=false. This remains distinct from kickstart user entries without --password, which default to locked accounts.