### PR TITLE
webui-desktop: reuse desktop session on Live ISO

### DIFF
--- a/webui-desktop
+++ b/webui-desktop
@@ -186,8 +186,9 @@ else
     fi
 
     USER_GRAPHICAL_SESSION_AVAILABLE=0
-    if [ "$USER_SESSION_AVAILABLE" = "1" ]; then
-        if printf '%s\n' "${user_environment[@]}" | grep -q '^WAYLAND_DISPLAY='; then
+    if [ "$USER_SESSION_AVAILABLE" = "1" ] && [ -n "${PKEXEC_UID:-}" ]; then
+        # Live ISO only: reuse the desktop user's session when it has a display.
+        if printf '%s\n' "${user_environment[@]}" | grep -qE '^(WAYLAND_DISPLAY|DISPLAY)='; then
             USER_GRAPHICAL_SESSION_AVAILABLE=1
         fi
     fi


### PR DESCRIPTION
Commit d6f563e93a limited graphical session detection to WAYLAND_DISPLAY only, so X11 Live ISO desktops (e.g. i3) fell through to the Anaconda compositor path and failed with "root Wayland socket not found under /run/user/0".

On Live ISO (PKEXEC_UID set by liveinst), reuse the installer's systemd user session when it has DISPLAY or WAYLAND_DISPLAY. boot.iso always uses the compositor path below.

Resolves: rhbz#2477524