### PR TITLE
storage: show PRETTY_NAME for installed OS on destination screen

### DIFF
--- a/src/components/storage/StorageReview.jsx
+++ b/src/components/storage/StorageReview.jsx
@@ -13,6 +13,7 @@ import {
     checkDeviceOnStorageType,
     getDeviceAncestors,
     getDeviceChildren,
+    getOSDisplayName,
     getParentPartitions,
     hasEncryptedAncestor,
     isBootloaderDevice,
@@ -284,8 +285,8 @@ const DeletedSystems = () => {
     );
 
     return deletedSystems.map(system => (
-        <ListItem key={system["os-name"].v}>
-            {cockpit.format(_("$0 will be deleted"), system["os-name"].v)}
+        <ListItem key={getOSDisplayName(system)}>
+            {cockpit.format(_("$0 will be deleted"), getOSDisplayName(system))}
         </ListItem>
     ));
 };
@@ -344,18 +345,18 @@ const AffectedSystems = ({ type }) => {
 
     const deleteText = system => cockpit.format(
         _("Deletion of certain partitions may prevent $0 from booting: $1"),
-        system["os-name"].v,
+        getOSDisplayName(system),
         getAffectedDevicesText(system)
     );
 
     const resizeText = system => cockpit.format(
         _("Resizing the following partitions from $0: $1"),
-        system["os-name"].v,
+        getOSDisplayName(system),
         getAffectedDevicesText(system)
     );
 
     return affectedSystems.map(system => (
-        <ListItem key={system["os-name"].v}>
+        <ListItem key={getOSDisplayName(system)}>
             {type === "delete" && deleteText(system)}
             {type === "resize" && resizeText(system)}
         </ListItem>

--- a/src/components/storage/installation-method/InstallationDestination.jsx
+++ b/src/components/storage/installation-method/InstallationDestination.jsx
@@ -26,7 +26,7 @@ import { resetPartitioning } from "../../../apis/storage_partitioning.js";
 import { getDevicesAction, getDiskSelectionAction } from "../../../actions/storage-actions.js";
 
 import { debug as loggerDebug } from "../../../helpers/log.js";
-import { getDeviceChildren, selectDefaultDisks } from "../../../helpers/storage.js";
+import { getDeviceChildren, getOSDisplayName, selectDefaultDisks } from "../../../helpers/storage.js";
 import { checkIfArraysAreEqual } from "../../../helpers/utils.js";
 
 import { StorageContext } from "../../../contexts/Common.jsx";
@@ -63,7 +63,7 @@ const DeviceExistingInstallation = ({ device }) => {
     return (
         cockpit.format(
             _("Currently installed: $0"),
-            existingSystemsOnDevice.map(system => system["os-name"].v).join(", ")
+            existingSystemsOnDevice.map(getOSDisplayName).join(", ")
         )
     );
 };

--- a/src/components/storage/scenarios/use-free-space/UseFreeSpace.jsx
+++ b/src/components/storage/scenarios/use-free-space/UseFreeSpace.jsx
@@ -8,6 +8,7 @@ import cockpit from "cockpit";
 import React, { useContext, useEffect, useState } from "react";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
 
+import { getOSDisplayName } from "../../../../helpers/storage.js";
 import { AvailabilityState } from "../helpers.js";
 
 import {
@@ -88,7 +89,10 @@ const LabelUserFreeSpace = ({ isReview }) => {
     const existingSystems = usePlannedExistingSystems();
 
     if (isReview && existingSystems?.length) {
-        return cockpit.format(_("Share disk with other operating systems: $0"), existingSystems?.map((system) => system["os-name"].v).join(", "));
+        return cockpit.format(
+            _("Share disk with other operating systems: $0"),
+            existingSystems?.map(getOSDisplayName).join(", ")
+        );
     }
 
     return _("Share disk with other operating systems");

--- a/src/helpers/storage.js
+++ b/src/helpers/storage.js
@@ -7,6 +7,15 @@ import cockpit from "cockpit";
 
 import { checkIfArraysAreEqual } from "./utils.js";
 
+/**
+ * Get the user-facing name of an existing OS installation.
+ * @param {Object} osData - the existing OS data object
+ * @returns {string}
+ */
+export const getOSDisplayName = (osData) => {
+    return osData["os-pretty-name"]?.v || osData["os-name"].v;
+};
+
 export const requestsFromDbus = (requests) => {
     return requests.map(request => Object.entries(request).reduce((acc, [key, value]) => ({ ...acc, [key]: value.v }), {}));
 };

--- a/test/check-storage-reclaim
+++ b/test/check-storage-reclaim
@@ -455,7 +455,7 @@ class TestStorageReclaimSpace(VirtInstallMachineCase):
         i.reach(i.steps.REVIEW)
         # Don't specify the exact original size as this might change with image refreshes
         r.check_disk_row("vda", parent="vda1", size="7.00 GB", action="resized from 11.2 GB")
-        r.check_resized_system("Ubuntu", ["vda1"])
+        r.check_resized_system("Ubuntu 25.10", ["vda1"])
 
         i.reach_on_sidebar(i.steps.LANGUAGE)
         l.select_locale("cs_CZ", is_common=False)

--- a/test/check-storage-use-free-space
+++ b/test/check-storage-use-free-space
@@ -40,14 +40,14 @@ class TestStorageUseFreeSpace(VirtInstallMachineCase):
         # so we need to click 'Next' twice to move past the storage configuration step
         i.next(next_page=i.steps.STORAGE_CONFIGURATION)
         i.reach(i.steps.REVIEW)
-        r.check_storage_config("Share disk with other operating systems: Debian GNU/Linux")
+        r.check_storage_config("Share disk with other operating systems: Debian GNU/Linux forky/sid")
 
         i.reach_on_sidebar(i.steps.STORAGE_CONFIGURATION)
         # debian's efi partition is smaller than the recommended 500 MiB
         # so we need to click 'Next' twice to move past the storage configuration step
         i.next(next_page=i.steps.STORAGE_CONFIGURATION)
         i.reach(i.steps.REVIEW)
-        r.check_storage_config("Share disk with other operating systems: Debian GNU/Linux")
+        r.check_storage_config("Share disk with other operating systems: Debian GNU/Linux forky/sid")
         r.check_disk_row("vda", "/", "vda3, LVM", "7.51 GB", True, "xfs")
         r.check_disk_row("vda", "/boot/efi", "vda15", "130 MB", False)
         r.check_disk_row("vda", "", "vda14", "3.15 MB", False, action="biosboot")


### PR DESCRIPTION
Use os-pretty-name from GetExistingSystems when displaying the currently installed system, falling back to os-name.

Resolves: rhbz#2478244