### PR TITLE
Handle non critical error installation prompts in WebUI

### DIFF
--- a/src/components/Error.jsx
+++ b/src/components/Error.jsx
@@ -828,6 +828,9 @@ export class ErrorBoundary extends React.Component {
         const { context } = arg || {};
 
         return async (_error) => {
+            if (this.state.hasError) {
+                return;
+            }
             const stateUpdate = await buildExceptionState(_error, { context });
             error("ErrorBoundary caught an error:", stateUpdate.frontendException ?? stateUpdate.backendException);
             this.setState(stateUpdate);

--- a/src/components/installation/InstallationNonCriticalErrorDialog.jsx
+++ b/src/components/installation/InstallationNonCriticalErrorDialog.jsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+import cockpit from "cockpit";
+
+import React from "react";
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
+import { Content } from "@patternfly/react-core/dist/esm/components/Content/index.js";
+import { Modal, ModalBody, ModalFooter, ModalHeader, ModalVariant } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
+
+const _ = cockpit.gettext;
+const SCREEN_ID = "anaconda-screen-progress";
+
+export const InstallationNonCriticalErrorDialog = ({ errorDialogData, onSubmitDecision }) => {
+    if (!errorDialogData) {
+        return null;
+    }
+
+    return (
+        <Modal
+          id={SCREEN_ID + "-installation-error-dialog"}
+          isOpen
+          variant={ModalVariant.small}
+          onClose={() => onSubmitDecision(false)}
+        >
+            <ModalHeader
+              title={_("Continue installation?")}
+              titleIconVariant="warning"
+            />
+            <ModalBody>
+                <Content component="p">
+                    {errorDialogData.message}
+                </Content>
+            </ModalBody>
+            <ModalFooter>
+                <Button
+                  id={SCREEN_ID + "-installation-error-continue-btn"}
+                  onClick={() => onSubmitDecision(true)}
+                >
+                    {_("Continue installation")}
+                </Button>
+                <Button
+                  id={SCREEN_ID + "-installation-error-abort-btn"}
+                  variant="secondary"
+                  onClick={() => onSubmitDecision(false)}
+                >
+                    {_("Abort installation")}
+                </Button>
+            </ModalFooter>
+        </Modal>
+    );
+};

--- a/src/components/installation/InstallationProgress.jsx
+++ b/src/components/installation/InstallationProgress.jsx
@@ -23,6 +23,7 @@ import { OsReleaseContext, SystemTypeContext } from "../../contexts/Common.jsx";
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 import { Feedback } from "./Feedback.jsx";
+import { InstallationNonCriticalErrorDialog } from "./InstallationNonCriticalErrorDialog.jsx";
 import { useAutoReboot } from "./useAutoReboot.js";
 
 import "./InstallationProgress.scss";
@@ -30,6 +31,7 @@ import "./InstallationProgress.scss";
 const _ = cockpit.gettext;
 const N_ = cockpit.noop;
 const SCREEN_ID = "anaconda-screen-progress";
+const DETAIL_TYPE_YESNO = "yesno";
 
 const progressStepsMap = {
     BOOTLOADER_INSTALLATION: 2,
@@ -44,6 +46,7 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
     const [statusMessage, setStatusMessage] = useState("");
     const [steps, setSteps] = useState();
     const [currentProgressStep, setCurrentProgressStep] = useState(0);
+    const [errorDialogData, setErrorDialogData] = useState(null);
     const refStatusMessage = useRef("");
     const isBootIso = useContext(SystemTypeContext).systemType === "BOOT_ISO";
     const osRelease = useContext(OsReleaseContext);
@@ -93,6 +96,18 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
                                 return current;
                             });
                         });
+                        categoryProxy.addEventListener("ErrorRaised", (_, message, detailType) => {
+                            if (detailType === DETAIL_TYPE_YESNO) {
+                                setErrorDialogData({
+                                    categoryProxy,
+                                    message,
+                                });
+                            } else {
+                                setStatus("danger");
+                                categoryProxy.RespondToError(false);
+                                onCritFail()({ message });
+                            }
+                        });
                         taskProxy.addEventListener("Succeeded", () => {
                             setStatus("success");
                             setCurrentProgressStep(4);
@@ -108,6 +123,17 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
                     context: _("Installation of the system failed"),
                 }));
     }, [onCritFail]);
+
+    const submitErrorDecision = (shouldContinue) => {
+        if (!errorDialogData) {
+            return;
+        }
+
+        errorDialogData.categoryProxy.RespondToError(shouldContinue)
+                .finally(() => {
+                    setErrorDialogData(null);
+                });
+    };
 
     if (steps === undefined) {
         return null;
@@ -222,6 +248,10 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
               }
               title={title}
               headingLevel="h2"
+            />
+            <InstallationNonCriticalErrorDialog
+              errorDialogData={errorDialogData}
+              onSubmitDecision={submitErrorDecision}
             />
             {(status === "success" || status === "danger") && <Feedback />}
         </Flex>

--- a/test/check-kickstart-automated
+++ b/test/check-kickstart-automated
@@ -151,5 +151,65 @@ class TestKickstartAutomated(VirtInstallMachineCase):
         self.handleReboot()
 
 
+class TestKickstartAutomatedNonCriticalError(VirtInstallMachineCase):
+    """Kickstart install with a missing package triggers a non-critical error dialog."""
+
+    provision = {
+        "machine1": {
+            "kickstart_file_name": "TestKickstartAutomated-testNonCriticalError.ks",
+            "payload_type": "dnf",
+            "memory_mb": INSTALLER_VM_MEMORY_MB,
+        },
+    }
+
+    def testMissingPackageAbort(self):
+        """
+        Description:
+            Boot with kickstart that requests a non-existent package during
+            ``%packages``.
+
+        Expected results:
+            - During installation the UI must show a continue/abort dialog.
+            - The dialog mentions the missing package.
+            - Choosing abort ends installation with a failure state.
+        """
+        b = self.browser
+        p = Progress(b)
+
+        b.open("/cockpit/@localhost/anaconda-webui/index.html")
+        p.wait_installation_error_dialog("domain-client-nonexisting")
+        b.wait_visible("#anaconda-screen-progress-installation-error-continue-btn")
+        p.respond_installation_error_abort()
+        p.wait_installation_failed()
+
+
+class TestKickstartAutomatedFatalError(VirtInstallMachineCase):
+    """Kickstart install with a fatal error shows the critical report dialog."""
+
+    provision = {
+        "machine1": {
+            "kickstart_file_name": "TestKickstartAutomated-testFatalError.ks",
+            "payload_type": "dnf",
+            "memory_mb": INSTALLER_VM_MEMORY_MB,
+        },
+    }
+
+    def testPreInstallScriptFailure(self):
+        """
+        Description:
+            Boot with kickstart whose ``%pre-install --erroronfail`` script fails.
+
+        Expected results:
+            - Installation does not show the non-critical continue/abort dialog.
+            - The critical error report dialog appears with script failure details.
+        """
+        b = self.browser
+        p = Progress(b)
+
+        b.open("/cockpit/@localhost/anaconda-webui/index.html")
+        p.wait_installation_failed("This is a fatal error", timeout=1200)
+        b.wait_not_present("#anaconda-screen-progress-installation-error-continue-btn")
+
+
 if __name__ == "__main__":
     test_main()

--- a/test/helpers/progress.py
+++ b/test/helpers/progress.py
@@ -36,3 +36,18 @@ class Progress():
     @log_step()
     def reboot(self):
         self.browser.click(self._reboot_selector)
+
+    def wait_installation_error_dialog(self, message_substring=None, timeout=600):
+        dialog = "#anaconda-screen-progress-installation-error-dialog"
+        with self.browser.wait_timeout(timeout):
+            self.browser.wait_in_text(dialog, message_substring)
+
+    def respond_installation_error_abort(self):
+        self.browser.click("#anaconda-screen-progress-installation-error-abort-btn")
+
+    def wait_installation_failed(self, message_substring=None, timeout=600):
+        dialog = "#critical-error-bz-report-modal"
+        with self.browser.wait_timeout(timeout):
+            self.browser.wait_in_text(f"{dialog} h1", "Installation failed")
+            if message_substring:
+                self.browser.wait_in_text(f"{dialog}-details", message_substring)

--- a/test/kickstarts/TestKickstartAutomated-testFatalError.ks
+++ b/test/kickstarts/TestKickstartAutomated-testFatalError.ks
@@ -1,0 +1,17 @@
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+rootpw testcase
+
+timezone --utc Europe/Prague
+
+%packages
+@^workstation-product-environment
+%end
+
+%pre-install --erroronfail
+echo "This is a fatal error" >&2
+exit 1
+%end

--- a/test/kickstarts/TestKickstartAutomated-testNonCriticalError.ks
+++ b/test/kickstarts/TestKickstartAutomated-testNonCriticalError.ks
@@ -1,0 +1,13 @@
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+rootpw testcase
+
+timezone --utc Europe/Prague
+
+%packages
+@^workstation-product-environment
+domain-client-nonexisting
+%end


### PR DESCRIPTION
Listen for Boss TaskCategory ErrorRaised(message, detail_type) during install and show a modal for yes/no or fatal errors, then call RespondToError so non-critical kickstart issues (e.g. missing packages) can continue instead of failing.