### PR TITLE
review: show hostname on Live ISO installations

### DIFF
--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -20,7 +20,6 @@ import {
     PageContext,
     PayloadContext,
     StorageContext,
-    SystemTypeContext,
     UserInterfaceContext,
 } from "../../contexts/Common.jsx";
 
@@ -81,7 +80,6 @@ export const ReviewConfiguration = ({ automatedInstall }) => {
     const osRelease = useContext(OsReleaseContext);
     const userInterfaceConfig = useContext(UserInterfaceContext);
     const hiddenScreens = userInterfaceConfig.hidden_webui_pages || [];
-    const isBootIso = useContext(SystemTypeContext).systemType === "BOOT_ISO";
     const { goToStepById } = useWizardContext();
     const languagePageHidden = hiddenScreens.includes("anaconda-screen-language");
     const localizationComplete = useLocalizationPageComplete({ isHidden: languagePageHidden });
@@ -234,10 +232,9 @@ export const ReviewConfiguration = ({ automatedInstall }) => {
                                       description={accountDescription}
                                     />
                                 </ReviewDescriptionList>}
-                                {isBootIso &&
-                                    <ReviewDescriptionList>
-                                        <HostnameRow />
-                                    </ReviewDescriptionList>}
+                                <ReviewDescriptionList>
+                                    <HostnameRow />
+                                </ReviewDescriptionList>
                             </ReviewDescriptionList>
                         </FlexItem>
                         <FlexItem>

--- a/test/check-review
+++ b/test/check-review
@@ -25,7 +25,7 @@ class TestReview(VirtInstallMachineCase):
             - The review step is shown
             - The review step shows the correct information
             - The review step shows the correct information after setting encryption
-            - The hostname is not shown for Live ISO
+            - The hostname is shown for Live ISO
             - The timezone is not shown for Live ISO
             - The UI elements for accessing network configuration are not present
         """
@@ -58,8 +58,8 @@ class TestReview(VirtInstallMachineCase):
         # check storage configuration
         r.check_storage_config("Use entire disk")
 
-        # check hostname is not visible for Live ISO
-        r.check_hostname_not_present()
+        # check hostname is visible for Live ISO with DHCP default
+        r.check_hostname("transient, will use DHCP")
 
         # check timezone is not visible for Live ISO
         r.check_timezone_not_present()

--- a/test/helpers/review.py
+++ b/test/helpers/review.py
@@ -25,9 +25,6 @@ class Review(NetworkDBus, StorageDBus):
     def check_hostname(self, hostname):
         self.browser.wait_in_text(f"#{self._step}-target-system-hostname > .pf-v6-c-description-list__text", hostname)
 
-    def check_hostname_not_present(self):
-        self.browser.wait_not_present(f"#{self._step}-target-system-hostname")
-
     @log_step()
     def check_language(self, lang):
         self.browser.wait_in_text(f"#{self._step}-target-system-language > .pf-v6-c-description-list__text", lang)


### PR DESCRIPTION
NOTE: given the current status of tests failing (INSTALLER-4528), I couldn't run the tests... I did try it manually with `test/webui_testvm.py fedora-rawhide-boot` and it worked, but that's not a live ISO either. 