### PR TITLE
Support kickstart installation without 'pauseatsummary' option.

### DIFF
--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -16,7 +16,7 @@ import { AnacondaPage } from "./AnacondaPage.jsx";
 import { AnacondaWizardFooter } from "./AnacondaWizardFooter.jsx";
 import { getSteps } from "./steps.js";
 
-export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFetching, onCritFail, setCurrentStepId, showStorage }) => {
+export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFetching, onCritFail, pauseAtSummary, setCurrentStepId, showStorage }) => {
     /**
      * Wizard step page state (reset in `AnacondaWizard` `goToStep` on step change).
      * - **isFormValid** / **setIsFormValid** — Required fields satisfied; reset when the step changes in the wizard.
@@ -37,6 +37,7 @@ export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFe
         automatedInstall,
         dispatch,
         onCritFail,
+        pauseAtSummary,
     };
 
     const pageContextValue = {

--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -6,7 +6,7 @@ import cockpit from "cockpit";
 
 import { usePageLocation } from "hooks";
 
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import { PageSection, PageSectionTypes } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Wizard, WizardStep } from "@patternfly/react-core/dist/esm/components/Wizard/index.js";
 
@@ -33,7 +33,10 @@ export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFe
     const userInterfaceConfig = useContext(UserInterfaceContext);
     const { path } = usePageLocation();
 
+    const autoProceedBlockedRef = useRef(false);
+
     const componentProps = {
+        autoProceedBlockedRef,
         automatedInstall,
         dispatch,
         onCritFail,

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -39,6 +39,7 @@ export const Application = ({ conf, dispatch, isFetching, onCritFail, osRelease,
     const [currentStepId, setCurrentStepId] = useState();
     const address = useAddress(onCritFail);
     const automatedInstall = parseAnacondaConfBool(getInstallerConfValue(conf, "Runtime", "automated_install"));
+    const pauseAtSummary = parseAnacondaConfBool(getInstallerConfValue(conf, "Runtime", "pause_at_summary"));
 
     useEffect(() => {
         if (!address) {
@@ -102,6 +103,7 @@ export const Application = ({ conf, dispatch, isFetching, onCritFail, osRelease,
               currentStepId={currentStepId}
               isFetching={isFetching}
               onCritFail={onCritFail}
+              pauseAtSummary={pauseAtSummary}
               title={title}
               dispatch={dispatch}
               setCurrentStepId={setCurrentStepId}

--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -77,7 +77,7 @@ const ReviewDescriptionList = ({ children }) => {
     );
 };
 
-export const ReviewConfiguration = ({ automatedInstall }) => {
+export const ReviewConfiguration = ({ automatedInstall, pauseAtSummary }) => {
     const osRelease = useContext(OsReleaseContext);
     const userInterfaceConfig = useContext(UserInterfaceContext);
     const hiddenScreens = userInterfaceConfig.hidden_webui_pages || [];
@@ -116,6 +116,14 @@ export const ReviewConfiguration = ({ automatedInstall }) => {
         cockpit.location.go([firstIncompleteStepId]);
         goToStepById(firstIncompleteStepId);
     };
+
+    // Auto-proceed to installation when kickstart is used without inst.pauseatsummary
+    useEffect(() => {
+        if (automatedInstall && !pauseAtSummary &&
+            allReviewPagesComplete && !reviewValidationPending) {
+            cockpit.location.go(["anaconda-screen-progress"]);
+        }
+    }, [automatedInstall, pauseAtSummary, allReviewPagesComplete, reviewValidationPending]);
 
     // Display custom footer
     const getFooter = useMemo(() => (

--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -77,7 +77,7 @@ const ReviewDescriptionList = ({ children }) => {
     );
 };
 
-export const ReviewConfiguration = ({ automatedInstall, pauseAtSummary }) => {
+export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, pauseAtSummary }) => {
     const osRelease = useContext(OsReleaseContext);
     const userInterfaceConfig = useContext(UserInterfaceContext);
     const hiddenScreens = userInterfaceConfig.hidden_webui_pages || [];
@@ -121,12 +121,22 @@ export const ReviewConfiguration = ({ automatedInstall, pauseAtSummary }) => {
         goToStepById(firstIncompleteStepId);
     };
 
-    // Auto-proceed to installation when kickstart is used without inst.pauseatsummary
+    // Auto-proceed to installation when kickstart is used without inst.pauseatsummary.
+    // This is a one-shot check: once validations complete and any issue is found
+    // (incomplete pages, storage warnings), auto-proceed is permanently disabled
+    // so the user must manually click "Begin installation" after fixing the issue.
     useEffect(() => {
-        if (automatedInstall && !pauseAtSummary &&
-            allReviewPagesComplete && !reviewValidationPending &&
-            !storageValidationPending && !hasStorageWarnings) {
+        if (!automatedInstall || pauseAtSummary || autoProceedBlockedRef.current) {
+            return;
+        }
+        // Wait until all validations have finished
+        if (reviewValidationPending || storageValidationPending) {
+            return;
+        }
+        if (allReviewPagesComplete && !hasStorageWarnings) {
             cockpit.location.go(["anaconda-screen-progress"]);
+        } else {
+            autoProceedBlockedRef.current = true;
         }
     }, [automatedInstall, pauseAtSummary, allReviewPagesComplete, reviewValidationPending,
         storageValidationPending, hasStorageWarnings]);

--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -91,7 +91,11 @@ export const ReviewConfiguration = ({ automatedInstall, pauseAtSummary }) => {
     const softwarePageHidden =
         payloadType !== "DNF" || hiddenScreens.includes("anaconda-screen-software-selection");
     const softwareSelectionComplete = useSoftwarePageComplete({ automatedInstall, isHidden: softwarePageHidden });
-    const storageComplete = useStorageInstallationPageComplete();
+    const {
+        complete: storageComplete,
+        hasWarnings: hasStorageWarnings,
+        validationPending: storageValidationPending,
+    } = useStorageInstallationPageComplete();
     const accountsPageHidden = hiddenScreens.includes("anaconda-screen-accounts");
     const usersComplete = useUsersPageComplete({ isHidden: accountsPageHidden });
 
@@ -120,10 +124,12 @@ export const ReviewConfiguration = ({ automatedInstall, pauseAtSummary }) => {
     // Auto-proceed to installation when kickstart is used without inst.pauseatsummary
     useEffect(() => {
         if (automatedInstall && !pauseAtSummary &&
-            allReviewPagesComplete && !reviewValidationPending) {
+            allReviewPagesComplete && !reviewValidationPending &&
+            !storageValidationPending && !hasStorageWarnings) {
             cockpit.location.go(["anaconda-screen-progress"]);
         }
-    }, [automatedInstall, pauseAtSummary, allReviewPagesComplete, reviewValidationPending]);
+    }, [automatedInstall, pauseAtSummary, allReviewPagesComplete, reviewValidationPending,
+        storageValidationPending, hasStorageWarnings]);
 
     // Display custom footer
     const getFooter = useMemo(() => (

--- a/src/components/storage/installation-method/usePageComplete.jsx
+++ b/src/components/storage/installation-method/usePageComplete.jsx
@@ -5,7 +5,7 @@
 
 import cockpit from "cockpit";
 
-import React, { useContext, useEffect, useRef } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { useWizardContext } from "@patternfly/react-core/dist/esm/components/Wizard/index.js";
 
@@ -97,6 +97,8 @@ const useApplyDefaultDisksOnReview = () => {
 };
 
 const useApplyStorageOnReview = () => {
+    const [validationPending, setValidationPending] = useState(false);
+    const [validationReport, setValidationReport] = useState(null);
     const { appliedPartitioning, partitioning } = useContext(StorageContext);
     const { setStepNotification } = useContext(PageContext) ?? {};
     const partitioningPath = partitioning?.path;
@@ -108,15 +110,21 @@ const useApplyStorageOnReview = () => {
 
         const step = REVIEW_STEP_ID;
 
+        setValidationPending(true);
         (async () => {
             try {
                 const { validationReport } = await applyStorage({ partitioning: partitioningPath });
+                setValidationReport(validationReport);
                 setStepNotification?.(createStorageValidationNotification(validationReport, step));
             } catch (ex) {
                 setStepNotification?.({ step, ...ex });
+            } finally {
+                setValidationPending(false);
             }
         })();
     }, [appliedPartitioning, partitioningPath, setStepNotification]);
+
+    return { validationPending, validationReport };
 };
 
 const useStorageSpaceNotification = (status, freeSpace, requiredSize) => {
@@ -178,14 +186,20 @@ export const usePageComplete = () => {
     const spaceState = useStorageComplete();
 
     useApplyDefaultDisksOnReview();
-    useApplyStorageOnReview();
+    const { validationPending, validationReport } = useApplyStorageOnReview();
     useStorageSpaceNotification(spaceState.status, spaceState.freeSpace, spaceState.requiredSize);
 
+    const warningMessages = validationReport?.["warning-messages"]?.v || [];
+    const hasWarnings = !validationPending && warningMessages.length > 0;
+
+    let complete;
     if (spaceState.status === StorageCompleteStatus.PENDING) {
-        return undefined;
+        complete = undefined;
+    } else if (spaceState.status === StorageCompleteStatus.INSUFFICIENT) {
+        complete = false;
+    } else {
+        complete = true;
     }
-    if (spaceState.status === StorageCompleteStatus.INSUFFICIENT) {
-        return false;
-    }
-    return true;
+
+    return { complete, hasWarnings, validationPending };
 };

--- a/test/check-kickstart-automated
+++ b/test/check-kickstart-automated
@@ -11,7 +11,7 @@ from review import Review
 from storage import EFI_PARTITION_DEFAULT_SIZE_MB, Storage
 from testlib import test_main  # pylint: disable=import-error
 from timezone import DateAndTime
-from users import Users, override_user_interface_conf_keys
+from users import create_user, Users, override_user_interface_conf_keys
 
 
 class TestKickstartAutomatedPause(VirtInstallMachineCase):
@@ -183,6 +183,56 @@ class TestKickstartAutomated(VirtInstallMachineCase):
         p.wait_done()
 
         self.handleReboot()
+
+
+class TestKickstartAutomatedIncomplete(VirtInstallMachineCase):
+    """Destructive tests for kickstart-driven automated installations."""
+
+    provision = {
+        "machine1": {
+            "kickstart_file_name": "TestKickstartAutomatedIncomplete-testBasic.ks",
+            "payload_type": "dnf",
+            "memory_mb": INSTALLER_VM_MEMORY_MB,
+        },
+    }
+
+    def testBasic(self):
+        """
+        Description:
+            Boot with ``inst.ks=TestKickstartAutomatedIncomplete-testBasic.ks``
+
+        Expected results:
+            - Automated installation starts.
+        """
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m, scenario="use-configured-storage-kickstart")
+        p = Progress(b)
+        u = Users(b, m)
+
+        b.open("/cockpit/@localhost/anaconda-webui/index.html")
+
+        # Wait for warning notification about incompleteness of accounts
+        # Note: also makes sure that the button state stabilizes for the next check
+        b.wait_in_text(f"#{i.steps.REVIEW}-incomplete-configuration",
+                       "Some installation steps still need to be completed before you can continue.")
+
+        i.check_next_disabled()
+
+        i.reach_on_sidebar(i.steps.ACCOUNTS)
+        create_user(b, self.machine)
+        # Workaround to stabilize the button state before calling the reach
+        # to prevent race condition on state flipping
+        u.enable_user_account(False)
+        u.enable_user_account(True)
+
+        i.reach(i.steps.REVIEW)
+
+        # Wait for completeness of accounts
+        # Note: also makes sure that the button state stabilizes for the next check
+        b.wait_in_text(f"#{i.steps.REVIEW}-target-system-account",
+                       "The following user will be created")
+        i.check_next_disabled(disabled=False)
 
 
 if __name__ == "__main__":

--- a/test/check-kickstart-automated
+++ b/test/check-kickstart-automated
@@ -6,6 +6,7 @@
 from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase, pixel_tests_ignore
 from installer import Installer
 from payload_dnf import PayloadDNF
+from progress import Progress
 from review import Review
 from storage import EFI_PARTITION_DEFAULT_SIZE_MB, Storage
 from testlib import test_main  # pylint: disable=import-error
@@ -13,24 +14,26 @@ from timezone import DateAndTime
 from users import Users, override_user_interface_conf_keys
 
 
-class TestKickstartAutomated(VirtInstallMachineCase):
+class TestKickstartAutomatedPause(VirtInstallMachineCase):
     """Destructive tests for kickstart-driven automated installations."""
 
     provision = {
         "machine1": {
-            "kickstart_file_name": "TestKickstartAutomated-testBasic.ks",
+            "kickstart_file_name": "TestKickstartAutomatedPause-testBasic.ks",
             "payload_type": "dnf",
             "memory_mb": INSTALLER_VM_MEMORY_MB,
+            "pause_at_summary": True,
         },
     }
 
     def testBasic(self):
         """
         Description:
-            Boot with ``inst.ks=TestKickstartAutomated-testBasic.ks``
+            Boot with ``inst.ks=TestKickstartAutomatedPause-testBasic.ks``
+            with inst.pauseatsummary option.
 
         Expected results:
-            - Automated install opens on the review step with the install action enabled.
+            - Automated install pause on the review step with the install action enabled.
             - Users specified in kickstart are correctly picked up on the Accounts step
               and cannot be changed.
             - Root settings cannot be changed when rootpw is in kickstart.
@@ -38,7 +41,6 @@ class TestKickstartAutomated(VirtInstallMachineCase):
               NTP servers, pool, and NTS options are visible in the Configure NTP servers modal.
             - Scenario is preset to 'Use configured storage' and the partitioning appears on the Review storage section.
             - Environment and groups from the ``%packages`` section in the kickstart appear on the Software selection step.
-            - Storage validation warnings are shown on the review page.
         """
         b = self.browser
         m = self.machine
@@ -89,17 +91,12 @@ class TestKickstartAutomated(VirtInstallMachineCase):
         dev1 = "vda"
         r.check_disk(dev1, "16.1 GB vda (Virtio Block Device)")
         r.check_disk_row(dev1, "/boot/efi", "vda1", EFI_PARTITION_DEFAULT_SIZE_MB, True, "efi")
-        r.check_disk_row(dev1, "/", "vda5", "11.8 GB", True, "xfs")
-        r.check_disk_row(dev1, "/boot", "vda2", "524 MB", True, "xfs")
+        r.check_disk_row(dev1, "/", "vda5", "11.2 GB", True, "xfs")
+        r.check_disk_row(dev1, "/boot", "vda2", "1.15 GB", True, "xfs")
         r.check_disk_row(dev1, "/home", "vda3", "2.15 GB", True, "xfs")
         r.check_disk_row(dev1, "swap", "vda4", "1.07 GB", True, "swap")
 
-        # Wait for warning notification about /boot partition size
-        b.wait_in_text(f"#{i.steps.REVIEW}-step-notification",
-                       "Your /boot partition is less than 1024 MiB which is lower than recommended for a normal Fedora install.")
-
         i.check_next_disabled(disabled=False)
-        b.assert_pixels(".anaconda-wizard-step-anaconda-screen-review", "review-kickstarted", ignore=pixel_tests_ignore)
 
     def testUserInterfaceCanChangeAccountsConf(self):
         """
@@ -123,6 +120,34 @@ class TestKickstartAutomated(VirtInstallMachineCase):
 
         b.wait_visible("#anaconda-screen-accounts-root-account-enable-root-account:not(:disabled)")
         b.wait_visible("#anaconda-screen-accounts-create-account-set-user-account:not(:disabled)")
+
+
+class TestKickstartAutomated(VirtInstallMachineCase):
+    """Destructive tests for kickstart-driven automated installations."""
+
+    provision = {
+        "machine1": {
+            "kickstart_file_name": "TestKickstartAutomated-testBasic.ks",
+            "payload_type": "dnf",
+            "memory_mb": INSTALLER_VM_MEMORY_MB,
+        },
+    }
+
+    def testBasic(self):
+        """
+        Description:
+            Boot with ``inst.ks=TestKickstartAutomated-testBasic.ks``
+
+        Expected results:
+            - Automated installation starts.
+        """
+        b = self.browser
+        p = Progress(b)
+
+        b.open("/cockpit/@localhost/anaconda-webui/index.html")
+        p.wait_done()
+
+        self.handleReboot()
 
 
 if __name__ == "__main__":

--- a/test/check-kickstart-automated
+++ b/test/check-kickstart-automated
@@ -122,6 +122,41 @@ class TestKickstartAutomatedPause(VirtInstallMachineCase):
         b.wait_visible("#anaconda-screen-accounts-create-account-set-user-account:not(:disabled)")
 
 
+class TestKickstartAutomatedWarning(VirtInstallMachineCase):
+    """Destructive tests for kickstart-driven automated installations."""
+
+    provision = {
+        "machine1": {
+            "kickstart_file_name": "TestKickstartAutomatedWarning-testBasic.ks",
+            "payload_type": "dnf",
+            "memory_mb": INSTALLER_VM_MEMORY_MB,
+        },
+    }
+
+    def testBasic(self):
+        """
+        Description:
+            Boot with ``inst.ks=TestKickstartAutomatedWarning-testBasic.ks``
+
+        Expected results:
+            - Automated install stops on the review step with the install action enabled.
+            - Storage validation warnings are shown on the review page.
+        """
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m, scenario="use-configured-storage-kickstart")
+
+        b.open("/cockpit/@localhost/anaconda-webui/index.html")
+        b.wait_visible("#installation-next-btn:not([aria-disabled=true])")
+
+        # Wait for warning notification about /boot partition size
+        b.wait_in_text(f"#{i.steps.REVIEW}-step-notification",
+                       "Your /boot partition is less than 1024 MiB which is lower than recommended for a normal Fedora install.")
+
+        i.check_next_disabled(disabled=False)
+        b.assert_pixels(".anaconda-wizard-step-anaconda-screen-review", "review-kickstarted", ignore=pixel_tests_ignore)
+
+
 class TestKickstartAutomated(VirtInstallMachineCase):
     """Destructive tests for kickstart-driven automated installations."""
 

--- a/test/helpers/installer.py
+++ b/test/helpers/installer.py
@@ -148,8 +148,10 @@ class Installer():
         :param disabled: True if Next button should be disabled, False if not
         :type disabled: bool, optional
         """
-        value = "false" if disabled else "true"
-        self.browser.wait_visible(f"#installation-next-btn:not([aria-disabled={value}])")
+        if disabled:
+            self.browser.wait_visible("#installation-next-btn[aria-disabled=true]")
+        else:
+            self.browser.wait_visible("#installation-next-btn:not([aria-disabled=true])")
 
     def check_sidebar_step_disabled(self, step, disabled=True):
         """Check if a sidebar step is disabled.

--- a/test/kickstarts/TestKickstartAutomatedIncomplete-testBasic.ks
+++ b/test/kickstarts/TestKickstartAutomatedIncomplete-testBasic.ks
@@ -1,0 +1,23 @@
+bootloader --timeout=1
+zerombr
+clearpart --all
+part /boot/efi --fstype=efi --size=500  # EFI_PARTITION_KICKSTART_SIZE_MB
+part /boot --fstype=xfs --size=1100
+part swap --size=1024
+part / --fstype=xfs --grow
+part /home --fstype=xfs --size=2048
+
+#rootpw testcase
+#user --name=alice --gecos="Alice Admin" --groups=wheel
+#user --name=bob --gecos="Bob User"
+#user --name=carol --gecos="Carol Dev" --groups=wheel,adm
+
+timezone --utc Europe/Prague
+timesource --ntp-server ntp.cesnet.cz
+timesource --ntp-server nts-test.strangled.net --nts
+timesource --ntp-pool 0.pool.ntp.org
+
+%packages
+@^workstation-product-environment
+@domain-client
+%end

--- a/test/kickstarts/TestKickstartAutomatedPause-testBasic.ks
+++ b/test/kickstarts/TestKickstartAutomatedPause-testBasic.ks
@@ -18,4 +18,6 @@ timesource --ntp-server nts-test.strangled.net --nts
 timesource --ntp-pool 0.pool.ntp.org
 
 %packages
+@^workstation-product-environment
+@domain-client
 %end

--- a/test/kickstarts/TestKickstartAutomatedWarning-testBasic.ks
+++ b/test/kickstarts/TestKickstartAutomatedWarning-testBasic.ks
@@ -1,0 +1,22 @@
+bootloader --timeout=1
+zerombr
+clearpart --all
+part /boot/efi --fstype=efi --size=500  # EFI_PARTITION_KICKSTART_SIZE_MB
+# Too small partitions raises a warning in UI
+part /boot --fstype=xfs --size=500
+part swap --size=1024
+part / --fstype=xfs --grow
+part /home --fstype=xfs --size=2048
+
+rootpw testcase
+user --name=alice --gecos="Alice Admin" --groups=wheel
+user --name=bob --gecos="Bob User"
+user --name=carol --gecos="Carol Dev" --groups=wheel,adm
+
+timezone --utc Europe/Prague
+timesource --ntp-server ntp.cesnet.cz
+timesource --ntp-server nts-test.strangled.net --nts
+timesource --ntp-pool 0.pool.ntp.org
+
+%packages
+%end

--- a/test/machine_install.py
+++ b/test/machine_install.py
@@ -39,6 +39,7 @@ class VirtInstallMachine(VirtMachine):
     def __init__(self, image, **kwargs):
         # From test ``provision`` / ``new_machine``; must not reach Machine.__init__.
         self.kickstart_file_name = kwargs.pop("kickstart_file_name", None)
+        self.pause_at_summary = kwargs.pop("pause_at_summary", False)
         self.payload_type = kwargs.pop("payload_type", "liveimg".lower())
         super().__init__(image, **kwargs)
 
@@ -143,8 +144,9 @@ class VirtInstallMachine(VirtMachine):
             self._write_interactive_defaults_ks(update_img_global_file, update_img_file)
             if self.kickstart_file_name:
                 inst_ks_url = f"http://10.0.2.2:{self.http_install_port}/test/kickstarts/{self.kickstart_file_name}"
-                # Web UI rejects kickstart-driven installs without inst.pauseatsummary.
-                inst_ks_arg = f" inst.ks={inst_ks_url} inst.pauseatsummary"
+                inst_ks_arg = f" inst.ks={inst_ks_url}"
+                if self.pause_at_summary:
+                    inst_ks_arg += " inst.pauseatsummary"
 
         # If custom compose if specified for fetching the image then use that
         # else get the image from the bots directory


### PR DESCRIPTION
Obsolete - split into:
- https://github.com/rhinstaller/anaconda-webui/pull/1335
- https://github.com/rhinstaller/anaconda-webui/pull/1340
- https://github.com/rhinstaller/anaconda-webui/pull/1342

Depends on https://github.com/rhinstaller/anaconda/pull/7090

This is still a draft, maybe usable for preliminary review.
- contains a separate tests fixup which needs tests to be run when they work again: https://github.com/rhinstaller/anaconda-webui/pull/1329
- the tests may be perhaps structured better wrt saving runner resources, not sure