### PR TITLE
storage: block Next when destination has insufficient disk space

### DIFF
--- a/src/components/storage/installation-method/InstallationDestination.jsx
+++ b/src/components/storage/installation-method/InstallationDestination.jsx
@@ -236,10 +236,22 @@ export const InstallationDestination = ({
     }, [diskSelection]);
 
     const selectedDisksCnt = diskSelection.selectedDisks.length;
+    const diskTotalSpace = useDiskTotalSpace();
+    const requiredSize = useRequiredSize();
 
     useEffect(() => {
-        setIsDestinationValid(selectedDisksCnt > 0);
-    }, [selectedDisksCnt, setIsDestinationValid]);
+        if (selectedDisksCnt === 0) {
+            setIsDestinationValid(false);
+            return;
+        }
+
+        if (diskTotalSpace == null || requiredSize == null) {
+            setIsDestinationValid(undefined);
+            return;
+        }
+
+        setIsDestinationValid(diskTotalSpace >= requiredSize);
+    }, [selectedDisksCnt, diskTotalSpace, requiredSize, setIsDestinationValid]);
 
     const headingLevel = isFirstScreen ? "h3" : "h2";
 

--- a/src/components/storage/installation-method/InstallationMethod.jsx
+++ b/src/components/storage/installation-method/InstallationMethod.jsx
@@ -43,7 +43,7 @@ export const InstallationMethod = ({
 }) => {
     const { setIsFormValid } = useContext(PageContext) ?? {};
     const [isReclaimSpaceCheckboxChecked, setIsReclaimSpaceCheckboxChecked] = useState();
-    const [isDestinationValid, setIsDestinationValid] = useState(false);
+    const [isDestinationValid, setIsDestinationValid] = useState(undefined);
     const [isScenarioValid, setIsScenarioValid] = useState(false);
 
     // Calculate overall form validity based on both children's validation states
@@ -181,7 +181,7 @@ const CustomFooter = ({ isReclaimSpaceCheckboxChecked }) => {
 const InstallationMethodFooterHelper = () => {
     const { isFormValid } = useContext(PageContext) ?? {};
 
-    if (isFormValid) {
+    if (isFormValid !== false) {
         return null;
     }
 

--- a/test/check-storage-basic
+++ b/test/check-storage-basic
@@ -68,8 +68,7 @@ class TestStorageBasic(VirtInstallMachineCase):
 
         # Check the next button is disabled when not sufficient disk space is available
         s.select_disks([("vda", False), (dev, True)])
-        # FIXME INSTALLER-4770
-        #i.check_next_disabled()
+        i.check_next_disabled()
 
         # Check that the disk selection persists when moving next and back
         s.select_disks([("vda", True), (dev, False)])


### PR DESCRIPTION
Treat insufficient space like no disks selected for destination validation, and keep the form pending until required size and total disk space are known.


Resolves: INSTALLER-4770