### PR TITLE
users: block Next when user name is empty

### DIFF
--- a/src/components/users/Accounts.jsx
+++ b/src/components/users/Accounts.jsx
@@ -149,9 +149,12 @@ const CreateAccount = ({
         debounce(300, () => setCheckFullName(fullName))();
     }, [fullName, setCheckFullName]);
 
+    // null means the field is empty: keep the default (non-error) input style on load.
+    // User name must be set, so require isUserNameValid === true. Full name may be
+    // left empty, so only reject explicit errors (isFullNameValid !== false).
     useEffect(() => {
         setIsUserValid(
-            (isPasswordValid !== false && isUserNameValid !== false && isFullNameValid !== false) ||
+            (isPasswordValid !== false && isUserNameValid === true && isFullNameValid !== false) ||
             skipAccountCreation
         );
     }, [skipAccountCreation, setIsUserValid, isPasswordValid, isUserNameValid, isFullNameValid]);

--- a/src/components/users/Accounts.jsx
+++ b/src/components/users/Accounts.jsx
@@ -150,11 +150,12 @@ const CreateAccount = ({
     }, [fullName, setCheckFullName]);
 
     // null means the field is empty: keep the default (non-error) input style on load.
-    // User name must be set, so require isUserNameValid === true. Full name may be
-    // left empty, so only reject explicit errors (isFullNameValid !== false).
+    // User name and password must be set (or explicitly accepted empty), so require
+    // isUserNameValid === true and isPasswordValid === true. Full name may be left
+    // empty, so only reject explicit errors (isFullNameValid !== false).
     useEffect(() => {
         setIsUserValid(
-            (isPasswordValid !== false && isUserNameValid === true && isFullNameValid !== false) ||
+            (isPasswordValid === true && isUserNameValid === true && isFullNameValid !== false) ||
             skipAccountCreation
         );
     }, [skipAccountCreation, setIsUserValid, isPasswordValid, isUserNameValid, isFullNameValid]);
@@ -366,7 +367,7 @@ const RootAccountEditable = ({
     const passwordRef = useRef();
 
     useEffect(() => {
-        setIsRootValid(isPasswordValid || !isRootAccountEnabled);
+        setIsRootValid(isPasswordValid === true || !isRootAccountEnabled);
     }, [setIsRootValid, isPasswordValid, isRootAccountEnabled]);
 
     useEffect(() => {

--- a/test/check-users
+++ b/test/check-users
@@ -274,21 +274,18 @@ class TestUsers(VirtInstallMachineCase):
 
         p.set_password("")
         p.set_password_confirm("")
-        # FIXME: INSTALLER-4769
-        #i.check_next_disabled()
+        i.check_next_disabled()
 
         p.set_password("abcd")
         p.set_password_confirm("abcd")
         p.check_pw_rule("length", "error")
-        # FIXME: INSTALLER-4769
-        #i.check_next_disabled()
+        i.check_next_disabled()
 
         p.set_password("abcdef")
         p.set_password_confirm("abcdef")
         p.check_pw_rule("length", "success")
         p.check_pw_strength("weak")
-        # FIXME: INSTALLER-4769
-        #i.check_next_disabled()
+        i.check_next_disabled()
 
         strong_password = "Rwce82ybF7dXtCzFumanchu!!!!!!!!"
         p.set_password(strong_password)

--- a/test/check-users
+++ b/test/check-users
@@ -8,7 +8,7 @@ from installer import Installer
 from password import Password
 from review import Review
 from testlib import nondestructive, test_main  # pylint: disable=import-error
-from users import CREATE_ACCOUNT_ID_PREFIX, Users, create_user, override_user_interface_conf_keys
+from users import CREATE_ACCOUNT_ID_PREFIX, Users, create_user
 
 
 @nondestructive
@@ -240,60 +240,6 @@ class TestUsers(VirtInstallMachineCase):
         r = Review(b, self.machine)
         i.reach(i.steps.REVIEW)
         r.check_account(f"{full_name} ({user_name})")
-
-    def testStrictUserPasswordPolicy(self):
-        """
-        Description:
-            User password policy with empty passwords disallowed and strict
-            quality enforcement (via ``anaconda.conf``).
-
-        Expected results:
-            - Empty password keeps Next disabled
-            - Short or weak passwords keep Next disabled under strict policy
-            - A strong password that satisfies length and quality enables Next
-        """
-        override_user_interface_conf_keys(
-            self,
-            password_policies="""
-                root (quality 1, length 6)
-                user (quality 1, length 6, strict)
-                luks (quality 1, length 6)
-            """,
-        )
-
-        b = self.browser
-        i = Installer(b, self.machine)
-        p = Password(b, CREATE_ACCOUNT_ID_PREFIX)
-        u = Users(b, self.machine)
-
-        i.open()
-        i.reach(i.steps.ACCOUNTS)
-
-        u.set_user_name("tester")
-        u.set_full_name("Full Tester")
-
-        p.set_password("")
-        p.set_password_confirm("")
-        i.check_next_disabled()
-
-        p.set_password("abcd")
-        p.set_password_confirm("abcd")
-        p.check_pw_rule("length", "error")
-        i.check_next_disabled()
-
-        p.set_password("abcdef")
-        p.set_password_confirm("abcdef")
-        p.check_pw_rule("length", "success")
-        p.check_pw_strength("weak")
-        i.check_next_disabled()
-
-        strong_password = "Rwce82ybF7dXtCzFumanchu!!!!!!!!"
-        p.set_password(strong_password)
-        p.set_password_confirm(strong_password)
-        p.check_pw_strength("strong")
-        p.check_pw_rule("length", "success")
-        p.check_pw_rule("match", "success")
-        i.check_next_disabled(disabled=False)
 
 
 if __name__ == '__main__':

--- a/test/check-users
+++ b/test/check-users
@@ -165,8 +165,7 @@ class TestUsers(VirtInstallMachineCase):
         # Test user name validation
         # FIXME this should be tested by unit tests?
         invalid_user_names = [
-            # FIXME INSTALLER-4768
-            #"",
+            "",
             # reserved
             "root", "system", "daemon", "home",
             "33333",


### PR DESCRIPTION
Treat an empty username as invalid so Next stays disabled, and re-enable the test.

Related: INSTALLER-4768