### PR TITLE
storage: always try applying configured layout when storage editor has mount points

### DIFF
--- a/src/components/storage/cockpit-storage-integration/CheckStorageDialog.jsx
+++ b/src/components/storage/cockpit-storage-integration/CheckStorageDialog.jsx
@@ -508,8 +508,9 @@ const CheckStorageDialogLoadingNewPartitioning = ({
         }
         mounted.current = true;
 
-        // If "Use configured storage" is not available, skip Manual partitioning creation
-        if (!useConfiguredStorage) {
+        // If "Use configured storage" is not available and no mount points were
+        // specified, skip Manual partitioning creation
+        if (!useConfiguredStorage && Object.keys(newMountPoints).length === 0) {
             if (useFreeSpace) {
                 dispatch(setStorageScenarioAction("use-free-space"));
             } else {
@@ -518,8 +519,10 @@ const CheckStorageDialogLoadingNewPartitioning = ({
             setNotification(null);
             setNeedsNewPartitioning(false);
             return;
-        } else {
+        } else if (useConfiguredStorage) {
             dispatch(setStorageScenarioAction("use-configured-storage"));
+        } else {
+            dispatch(setStorageScenarioAction(""));
         }
 
         const onFail = (exc) => {
@@ -577,7 +580,7 @@ const CheckStorageDialogLoaded = ({
     const selectedDisks = diskSelection.selectedDisks;
 
     const useConfiguredStorage = useAvailabilityConfiguredStorage({ newMountPoints })?.available;
-    const useFreeSpace = useAvailabilityUseFreeSpace({ allowReclaim: false });
+    const useFreeSpace = useAvailabilityUseFreeSpace({ allowReclaim: false })?.available;
 
     const mdArrays = useMemo(() => {
         return Object.keys(devices).filter(device => devices[device].type.v === "mdarray");

--- a/test/check-storage-cockpit
+++ b/test/check-storage-cockpit
@@ -276,6 +276,36 @@ class TestStorageCockpitIntegration(VirtInstallMachineCase, StorageCase):
         """
         self._testStandardPartition("xfs")
 
+    def testMissingBootEfiPartition(self):
+        """
+        Description:
+            Test that a storage layout without /boot/efi shows a backend validation
+            error
+
+        Expected results:
+            - The check storage dialog shows backend validation errors
+
+        References:
+            - https://bugzilla.redhat.com/show_bug.cgi?id=2406021
+        """
+        b = self.browser
+        s = Storage(b, self.machine)
+
+        self.reachCockpitStorage()
+
+        self.click_dropdown(self.card_row("Storage", 1), "Create partition table")
+        self.confirm()
+
+        self.click_dropdown(self.card_row("Storage", 2), "Create partition")
+        self.dialog({"size": 1070, "type": "ext4", "mount_point": "/boot"})
+
+        self.click_dropdown(self.card_row("Storage", 3), "Create partition")
+        self.dialog({"type": "ext4", "mount_point": "/"})
+
+        b.switch_to_top()
+        s.return_to_installation("EFI System Partition must be mounted on one of /boot/efi")
+        b.wait_in_text("#cockpit-storage-integration-check-storage-dialog", "Storage requirements not met")
+
     def testPayloadSizeCheckExt4(self):
         """
         Description:


### PR DESCRIPTION
When the user configures partitions in the storage editor, try applying the layout and show backend validation errors instead of silently falling back to use free space.

Also check `available` attribute when checking the hook that calculates useFreeSpace. This was missing before.

Resolves: rhbz#2406021