### PR TITLE
review: block auto-proceed when warnings are displayed

### DIFF
--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -89,7 +89,11 @@ export const ReviewConfiguration = ({ automatedInstall, pauseAtSummary }) => {
     const softwarePageHidden =
         payloadType !== "DNF" || hiddenScreens.includes("anaconda-screen-software-selection");
     const softwareSelectionComplete = useSoftwarePageComplete({ automatedInstall, isHidden: softwarePageHidden });
-    const storageComplete = useStorageInstallationPageComplete();
+    const {
+        complete: storageComplete,
+        hasWarnings: hasStorageWarnings,
+        validationPending: storageValidationPending,
+    } = useStorageInstallationPageComplete();
     const accountsPageHidden = hiddenScreens.includes("anaconda-screen-accounts");
     const usersComplete = useUsersPageComplete({ isHidden: accountsPageHidden });
 
@@ -117,10 +121,12 @@ export const ReviewConfiguration = ({ automatedInstall, pauseAtSummary }) => {
 
     // Auto-proceed to installation when kickstart is used without inst.pauseatsummary
     useEffect(() => {
-        if (automatedInstall && !pauseAtSummary && allReviewPagesComplete) {
+        if (automatedInstall && !pauseAtSummary && allReviewPagesComplete &&
+            !storageValidationPending && !hasStorageWarnings) {
             cockpit.location.go(["anaconda-screen-progress"]);
         }
-    }, [automatedInstall, pauseAtSummary, allReviewPagesComplete]);
+    }, [automatedInstall, pauseAtSummary, allReviewPagesComplete, storageValidationPending,
+        hasStorageWarnings]);
 
     // Display custom footer
     const getFooter = useMemo(() => (

--- a/src/components/storage/installation-method/usePageComplete.jsx
+++ b/src/components/storage/installation-method/usePageComplete.jsx
@@ -5,7 +5,7 @@
 
 import cockpit from "cockpit";
 
-import React, { useContext, useEffect, useRef } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { useWizardContext } from "@patternfly/react-core/dist/esm/components/Wizard/index.js";
 
@@ -97,6 +97,8 @@ const useApplyDefaultDisksOnReview = () => {
 };
 
 const useApplyStorageOnReview = () => {
+    const [validationPending, setValidationPending] = useState(false);
+    const [validationReport, setValidationReport] = useState(null);
     const { appliedPartitioning, partitioning } = useContext(StorageContext);
     const { setStepNotification } = useContext(PageContext) ?? {};
     const partitioningPath = partitioning?.path;
@@ -108,15 +110,21 @@ const useApplyStorageOnReview = () => {
 
         const step = REVIEW_STEP_ID;
 
+        setValidationPending(true);
         (async () => {
             try {
                 const { validationReport } = await applyStorage({ partitioning: partitioningPath });
+                setValidationReport(validationReport);
                 setStepNotification?.(createStorageValidationNotification(validationReport, step));
             } catch (ex) {
                 setStepNotification?.({ step, ...ex });
+            } finally {
+                setValidationPending(false);
             }
         })();
     }, [appliedPartitioning, partitioningPath, setStepNotification]);
+
+    return { validationPending, validationReport };
 };
 
 const useStorageSpaceNotification = (status, freeSpace, requiredSize) => {
@@ -178,14 +186,20 @@ export const usePageComplete = () => {
     const spaceState = useStorageComplete();
 
     useApplyDefaultDisksOnReview();
-    useApplyStorageOnReview();
+    const { validationPending, validationReport } = useApplyStorageOnReview();
     useStorageSpaceNotification(spaceState.status, spaceState.freeSpace, spaceState.requiredSize);
 
+    const warningMessages = validationReport?.["warning-messages"]?.v || [];
+    const hasWarnings = !validationPending && warningMessages.length > 0;
+
+    let complete;
     if (spaceState.status === StorageCompleteStatus.PENDING) {
-        return undefined;
+        complete = undefined;
+    } else if (spaceState.status === StorageCompleteStatus.INSUFFICIENT) {
+        complete = false;
+    } else {
+        complete = true;
     }
-    if (spaceState.status === StorageCompleteStatus.INSUFFICIENT) {
-        return false;
-    }
-    return true;
+
+    return { complete, hasWarnings, validationPending };
 };

--- a/test/check-kickstart-automated
+++ b/test/check-kickstart-automated
@@ -123,6 +123,41 @@ class TestKickstartAutomatedPause(VirtInstallMachineCase):
         b.wait_visible("#anaconda-screen-accounts-create-account-set-user-account:not(:disabled)")
 
 
+class TestKickstartAutomatedWarning(VirtInstallMachineCase):
+    """Destructive tests for kickstart-driven automated installations."""
+
+    provision = {
+        "machine1": {
+            "kickstart_file_name": "TestKickstartAutomatedWarning-testBasic.ks",
+            "payload_type": "dnf",
+            "memory_mb": INSTALLER_VM_MEMORY_MB,
+        },
+    }
+
+    def testBasic(self):
+        """
+        Description:
+            Boot with ``inst.ks=TestKickstartAutomatedWarning-testBasic.ks``
+
+        Expected results:
+            - Automated install stops on the review step with the install action enabled.
+            - Storage validation warnings are shown on the review page.
+        """
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m, scenario="use-configured-storage-kickstart")
+
+        b.open("/cockpit/@localhost/anaconda-webui/index.html")
+        b.wait_visible("#installation-next-btn:not([aria-disabled=true])")
+
+        # Wait for warning notification about /boot partition size
+        b.wait_in_text(f"#{i.steps.REVIEW}-step-notification",
+                       "Your /boot partition is less than 1024 MiB which is lower than recommended for a normal Fedora install.")
+
+        i.check_next_disabled(disabled=False)
+        b.assert_pixels(".anaconda-wizard-step-anaconda-screen-review", "review-kickstarted", ignore=pixel_tests_ignore)
+
+
 class TestKickstartAutomated(VirtInstallMachineCase):
     """Destructive tests for kickstart-driven automated installations."""
 

--- a/test/kickstarts/TestKickstartAutomatedWarning-testBasic.ks
+++ b/test/kickstarts/TestKickstartAutomatedWarning-testBasic.ks
@@ -1,0 +1,22 @@
+bootloader --timeout=1
+zerombr
+clearpart --all
+part /boot/efi --fstype=efi --size=500  # EFI_PARTITION_KICKSTART_SIZE_MB
+# Too small partitions raises a warning in UI
+part /boot --fstype=xfs --size=500
+part swap --size=1024
+part / --fstype=xfs --grow
+part /home --fstype=xfs --size=2048
+
+rootpw testcase
+user --name=alice --gecos="Alice Admin" --groups=wheel
+user --name=bob --gecos="Bob User"
+user --name=carol --gecos="Carol Dev" --groups=wheel,adm
+
+timezone --utc Europe/Prague
+timesource --ntp-server ntp.cesnet.cz
+timesource --ntp-server nts-test.strangled.net --nts
+timesource --ntp-pool 0.pool.ntp.org
+
+%packages
+%end


### PR DESCRIPTION
Track storage validation state directly in useApplyStorageOnReview with validationPending (set synchronously before the async call) and validationReport (set on resolve). Expose hasWarnings and validationPending from usePageComplete so ReviewConfiguration can block auto-proceed until validation finishes and check for warnings.

This avoids a race condition where the D-Bus PropertiesChanged signal could update appliedPartitioning and trigger auto-proceed before the applyStorage() promise resolved and set stepNotification.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

Resolves: INSTALLER-4694