### PR TITLE
webui: handle KeyboardConfigurationError via step notification

### DIFF
--- a/src/actions/localization-actions.js
+++ b/src/actions/localization-actions.js
@@ -72,12 +72,18 @@ export const getKeyboardLayoutsAction = () => {
     };
 };
 
-export const getKeyboardConfigurationAction = () => {
+export const getKeyboardConfigurationAction = ({ onError, onSuccess } = {}) => {
     return async (dispatch) => {
         const xlayouts = await getXLayouts();
         let resultDispatched = false;
 
         getKeyboardConfiguration({
+            onFail: (error) => {
+                // Handle KeyboardConfigurationError (e.g., live system has only non-XKB layouts)
+                if (onError) {
+                    onError(error?.toString());
+                }
+            },
             onSuccess: (keyboardConfiguration) => {
                 // The API triggers the onSuccess callback two times, we want to dispatch only once
                 if (resultDispatched) {
@@ -93,6 +99,10 @@ export const getKeyboardConfigurationAction = () => {
                     },
                     type: "GET_PLANNED_KEYBOARD_CONFIGURATION"
                 });
+
+                if (onSuccess) {
+                    onSuccess();
+                }
             }
         });
     };

--- a/src/components/localization/Keyboard.jsx
+++ b/src/components/localization/Keyboard.jsx
@@ -33,7 +33,7 @@ import {
 
 import { getLocaleById } from "../../helpers/localization.js";
 
-import { LanguageContext } from "../../contexts/Common.jsx";
+import { LanguageContext, PageContext } from "../../contexts/Common.jsx";
 
 import { MenuSearch } from "../common/MenuSearch.jsx";
 
@@ -44,16 +44,16 @@ const SCREEN_ID = "anaconda-screen-language";
 
 const SelectedKeyboards = ({ xlayouts }) => (
     <Content component="p" id={SCREEN_ID + "-selected-keyboards"}>
-        {xlayouts.length === 1
-            ? xlayouts[0]
-            : (
-                <span>
-                    <strong>{xlayouts[0]}</strong>
-                    {xlayouts.slice(1).map((layout, index) => (
-                        <span key={`${layout}-${index}`}>, {layout}</span>
-                    ))}
-                </span>
-            )}
+        {!xlayouts?.length && _("No keyboard layouts selected")}
+        {xlayouts?.length === 1 && xlayouts[0]}
+        {xlayouts?.length > 1 && (
+            <span>
+                <strong>{xlayouts[0]}</strong>
+                {xlayouts.slice(1).map((layout, index) => (
+                    <span key={`${layout}-${index}`}>, {layout}</span>
+                ))}
+            </span>
+        )}
     </Content>
 );
 
@@ -284,17 +284,17 @@ const KeyboardDialog = ({ currentLayouts = [], onClose, onSaved }) => {
     );
 };
 
-export const KeyboardGnome = ({ dispatch }) => {
+export const KeyboardGnome = ({ dispatch, onError, onSuccess }) => {
     const { plannedXlayouts } = useContext(LanguageContext);
 
     useEffect(() => {
         const onFocus = () => {
-            dispatch(getKeyboardConfigurationAction());
+            dispatch(getKeyboardConfigurationAction({ onError, onSuccess }));
         };
 
         window.addEventListener("focus", onFocus);
         return () => window.removeEventListener("focus", onFocus);
-    }, [dispatch]);
+    }, [dispatch, onError, onSuccess]);
 
     return (
         <>
@@ -378,12 +378,45 @@ const KeyboardNonGnome = () => {
 
 export const Keyboard = ({ dispatch, isGnome, setIsKeyboardValid }) => {
     const { plannedVconsole, plannedXlayouts } = useContext(LanguageContext);
+    const { setStepNotification } = useContext(PageContext) ?? {};
+    const [keyboardConfigError, setKeyboardConfigError] = useState();
 
     useEffect(() => {
-        setIsKeyboardValid((plannedVconsole ?? "") !== "" && (plannedXlayouts?.length > 0));
-    }, [plannedVconsole, plannedXlayouts, isGnome, setIsKeyboardValid]);
+        if (!keyboardConfigError) {
+            setStepNotification?.(null);
+            return;
+        }
+        setStepNotification?.({
+            message: keyboardConfigError,
+            step: "anaconda-screen-language",
+        });
+    }, [keyboardConfigError, setStepNotification]);
 
-    if (!plannedXlayouts?.length) {
+    // Fetch keyboard configuration when component mounts
+    useEffect(() => {
+        dispatch(getKeyboardConfigurationAction({
+            onError: setKeyboardConfigError,
+            onSuccess: () => {
+                setKeyboardConfigError();
+            }
+        }));
+    }, [dispatch]);
+
+    useEffect(() => {
+        setIsKeyboardValid(
+            (plannedVconsole ?? "") !== "" &&
+            (plannedXlayouts?.length > 0) &&
+            !keyboardConfigError
+        );
+    }, [
+        isGnome,
+        keyboardConfigError,
+        plannedVconsole,
+        plannedXlayouts,
+        setIsKeyboardValid
+    ]);
+
+    if (!plannedXlayouts?.length && !keyboardConfigError) {
         return null;
     }
 
@@ -397,7 +430,15 @@ export const Keyboard = ({ dispatch, isGnome, setIsKeyboardValid }) => {
     );
     const keyboard = (
         isGnome
-            ? <KeyboardGnome dispatch={dispatch} />
+            ? (
+                <KeyboardGnome
+                  dispatch={dispatch}
+                  onError={setKeyboardConfigError}
+                  onSuccess={() => {
+                      setKeyboardConfigError();
+                  }}
+                />
+            )
             : <KeyboardNonGnome />
     );
 


### PR DESCRIPTION
When the backend raises KeyboardConfigurationError (e.g., live system has only non-XKB layouts like IBus 'anthy' or 'libpinyin'), display it as a step notification on the language/localization screen.

User experience:
- Japanese user with only 'anthy' configured sees inline alert: "The live system has layout 'anthy' which can't be used for installation."
- User can click "Change system keyboard layout" to configure manually

Related: rhbz#2496409
Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<img width="1647" height="954" alt="Screenshot 2026-07-07 at 13-53-18 Virtual machines - kkoukiou@fedora" src="https://github.com/user-attachments/assets/4de7d499-411d-4c4e-8c85-0efda9c14800" />
