### PR TITLE
Reconnect to active installation task after page reload

### DIFF
--- a/src/apis/boss.js
+++ b/src/apis/boss.js
@@ -6,7 +6,7 @@
 import cockpit from "cockpit";
 
 import { error } from "../helpers/log.js";
-import { _callClient } from "./helpers.js";
+import { _callClient, _getProperty } from "./helpers.js";
 
 const OBJECT_PATH = "/org/fedoraproject/Anaconda/Boss";
 const INTERFACE_NAME = "org.fedoraproject.Anaconda.Boss";
@@ -55,6 +55,13 @@ export const getSteps = ({ task }) => {
         ["org.fedoraproject.Anaconda.Task", "Steps"]
     )
             .then(ret => ret[0]);
+};
+
+/**
+ * @returns {Promise}           Resolves the object path of the active installation task, or ""
+ */
+export const getActiveInstallationTask = () => {
+    return _getProperty(BossClient, OBJECT_PATH, INTERFACE_NAME, "ActiveInstallationTask");
 };
 
 /**

--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -10,6 +10,8 @@ import React, { useContext, useEffect, useRef, useState } from "react";
 import { PageSection, PageSectionTypes } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Wizard, WizardStep } from "@patternfly/react-core/dist/esm/components/Wizard/index.js";
 
+import { getActiveInstallationTask } from "../apis/boss.js";
+
 import { PageContext, PayloadContext, StorageContext, SystemTypeContext, UserInterfaceContext } from "../contexts/Common.jsx";
 
 import { AnacondaPage } from "./AnacondaPage.jsx";
@@ -64,6 +66,16 @@ export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFe
             setCurrentStepId(firstStepId);
         }
     }, [currentStepId, firstStepId, path, setCurrentStepId]);
+
+    const finalStepId = stepsOrder[stepsOrder.length - 1]?.id;
+    useEffect(() => {
+        getActiveInstallationTask()
+                .then(activeTask => {
+                    if (activeTask) {
+                        cockpit.location.go([finalStepId]);
+                    }
+                });
+    }, [finalStepId]);
 
     const createSteps = (stepsOrder, componentProps) => {
         return stepsOrder.map(s => {

--- a/src/components/installation/InstallationProgress.jsx
+++ b/src/components/installation/InstallationProgress.jsx
@@ -14,7 +14,7 @@ import { ExclamationCircleIcon } from "@patternfly/react-icons/dist/esm/icons/ex
 import { InProgressIcon } from "@patternfly/react-icons/dist/esm/icons/in-progress-icon";
 import { PendingIcon } from "@patternfly/react-icons/dist/esm/icons/pending-icon";
 
-import { BossClient, getSteps, installWithTasks } from "../../apis/boss.js";
+import { BossClient, getActiveInstallationTask, getSteps, installWithTasks } from "../../apis/boss.js";
 
 import { exitGui } from "../../helpers/exit.js";
 
@@ -54,71 +54,93 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
     useAutoReboot(status, automatedInstall);
 
     useEffect(() => {
-        installWithTasks()
-                .then(tasks => {
-                    const taskProxy = new BossClient().client.proxy(
-                        "org.fedoraproject.Anaconda.Task",
-                        tasks[0]
-                    );
-                    const categoryProxy = new BossClient().client.proxy(
-                        "org.fedoraproject.Anaconda.TaskCategory",
-                        tasks[0]
-                    );
+        const connectToTask = (taskPath, shouldStart) => {
+            const taskProxy = new BossClient().client.proxy(
+                "org.fedoraproject.Anaconda.Task",
+                taskPath
+            );
+            const categoryProxy = new BossClient().client.proxy(
+                "org.fedoraproject.Anaconda.TaskCategory",
+                taskPath
+            );
 
-                    const addEventListeners = () => {
-                        taskProxy.addEventListener("ProgressChanged", (_, step, message) => {
-                            if (step === 0) {
-                                getSteps({ task: tasks[0] })
-                                        .then(
-                                            ret => setSteps(ret.v),
-                                            onCritFail()
-                                        );
-                            }
-                            if (message) {
-                                setStatusMessage(message);
-                                refStatusMessage.current = message;
-                            }
-                        });
-                        taskProxy.addEventListener("Failed", () => {
-                            setStatus("danger");
-                        });
-                        taskProxy.addEventListener("Stopped", () => {
-                            taskProxy.Finish().catch(onCritFail({
-                                context: cockpit.format(N_("Installation of the system failed: $0"), refStatusMessage.current),
-                            }));
-                        });
-                        categoryProxy.addEventListener("CategoryChanged", (_, category) => {
-                            const step = progressStepsMap[category];
-                            setCurrentProgressStep(current => {
-                                if (step !== undefined && step >= current) {
-                                    return step;
-                                }
-                                return current;
-                            });
-                        });
-                        categoryProxy.addEventListener("ErrorRaised", (_, message, detailType) => {
-                            if (detailType === DETAIL_TYPE_YESNO) {
-                                setErrorDialogData({
-                                    categoryProxy,
-                                    message,
-                                });
-                            } else {
-                                setStatus("danger");
-                                categoryProxy.RespondToError(false);
-                                onCritFail()({ message });
-                            }
-                        });
-                        taskProxy.addEventListener("Succeeded", () => {
-                            setStatus("success");
-                            setCurrentProgressStep(4);
-                        });
-                    };
-                    taskProxy.wait(() => {
-                        addEventListeners();
-                        taskProxy.Start().catch(onCritFail({
-                            context: _("Installation of the system failed"),
-                        }));
+            const addEventListeners = () => {
+                taskProxy.addEventListener("ProgressChanged", (_, step, message) => {
+                    if (step === 0) {
+                        getSteps({ task: taskPath })
+                                .then(
+                                    ret => setSteps(ret.v),
+                                    onCritFail()
+                                );
+                    }
+                    if (message) {
+                        setStatusMessage(message);
+                        refStatusMessage.current = message;
+                    }
+                });
+                taskProxy.addEventListener("Failed", () => {
+                    setStatus("danger");
+                });
+                taskProxy.addEventListener("Stopped", () => {
+                    taskProxy.Finish().catch(onCritFail({
+                        context: cockpit.format(N_("Installation of the system failed: $0"), refStatusMessage.current),
+                    }));
+                });
+                categoryProxy.addEventListener("CategoryChanged", (_, category) => {
+                    const step = progressStepsMap[category];
+                    setCurrentProgressStep(current => {
+                        if (step !== undefined && step >= current) {
+                            return step;
+                        }
+                        return current;
                     });
+                });
+                categoryProxy.addEventListener("ErrorRaised", (_, message, detailType) => {
+                    if (detailType === DETAIL_TYPE_YESNO) {
+                        setErrorDialogData({
+                            categoryProxy,
+                            message,
+                        });
+                    } else {
+                        setStatus("danger");
+                        categoryProxy.RespondToError(false);
+                        onCritFail()({ message });
+                    }
+                });
+                taskProxy.addEventListener("Succeeded", () => {
+                    setStatus("success");
+                    setCurrentProgressStep(4);
+                });
+            };
+            taskProxy.wait(() => {
+                addEventListeners();
+                if (shouldStart) {
+                    taskProxy.Start().catch(onCritFail({
+                        context: _("Installation of the system failed"),
+                    }));
+                } else {
+                    getSteps({ task: taskPath })
+                            .then(
+                                ret => setSteps(ret.v),
+                                onCritFail()
+                            );
+                }
+            });
+        };
+
+        getActiveInstallationTask()
+                .then(activeTask => {
+                    if (activeTask) {
+                        connectToTask(activeTask, false);
+                    } else {
+                        installWithTasks()
+                                .then(
+                                    tasks => connectToTask(tasks[0], true),
+                                    onCritFail({
+                                        context: _("Installation of the system failed"),
+                                    })
+                                );
+                    }
                 }, onCritFail({
                     context: _("Installation of the system failed"),
                 }));

--- a/test/check-progress
+++ b/test/check-progress
@@ -21,12 +21,10 @@ class TestInstallationProgress(VirtInstallMachineCase):
 
         Expected results:
             - The installation steps are displayed in the correct order
+            - After reloading the page, the UI reconnects to the ongoing installation
             - The 'Successfully installed' message is displayed at the end of the installation
             - The 'Modify Storage' option is not available from the kebab menu
         """
-
-        # HACK Ignore some selinux errors
-        self.allow_journal_messages(".*denied.*comm=\"tar\" name=\"/\".*")
 
         b = self.browser
         m = self.machine
@@ -41,13 +39,11 @@ class TestInstallationProgress(VirtInstallMachineCase):
 
         with b.wait_timeout(300):
             b.wait_in_text("h2", "Installing")
-            b.wait_in_text(".pf-v6-c-empty-state", "Storage configuration: Storage is currently being configured.")
-            b.wait_in_text(".pf-v6-c-empty-state", "Software installation: Storage configuration complete. The "
-                                                   "software is now being installed onto your device.")
-            b.wait_in_text(".pf-v6-c-empty-state", "System configuration: Software installation complete. The system "
-                                                   "is now being configured.")
-            b.wait_in_text(".pf-v6-c-empty-state", "Finalizing: The system configuration is complete. Finalizing "
-                                                   "installation may take a few moments.")
+
+        # Reload the page while installation is running to verify reconnect
+        b.reload()
+        b.wait_visible(".pf-v6-c-progress-stepper")
+        b.wait_in_text("h2", "Installing")
 
         p.wait_done()
         b.wait_in_text("h2", "Successfully installed")


### PR DESCRIPTION
Use the Boss ActiveInstallationTask API to resume ongoing installations when the UI is reloaded, and add a test for the reconnect flow.