### PR TITLE
Allow automated installations to proceed despite storage warnings

### DIFF
--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -91,7 +91,6 @@ export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, p
     const softwareSelectionComplete = useSoftwarePageComplete({ automatedInstall, isHidden: softwarePageHidden });
     const {
         complete: storageComplete,
-        hasWarnings: hasStorageWarnings,
         validationPending: storageValidationPending,
     } = useStorageInstallationPageComplete();
     const accountsPageHidden = hiddenScreens.includes("anaconda-screen-accounts");
@@ -120,8 +119,9 @@ export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, p
 
     // Auto-proceed to installation when kickstart is used without inst.pauseatsummary.
     // This is a one-shot check: once validations complete and any issue is found
-    // (incomplete pages, storage warnings), auto-proceed is permanently disabled
-    // so the user must manually click "Begin installation" after fixing the issue.
+    // (incomplete pages), auto-proceed is permanently disabled so the user must
+    // manually click "Begin installation" after fixing the issue.
+    // Storage warnings do NOT block auto-proceed, matching GTK/TUI behavior.
     useEffect(() => {
         if (!automatedInstall || pauseAtSummary || autoProceedBlockedRef.current) {
             return;
@@ -130,13 +130,13 @@ export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, p
         if (reviewValidationPending || storageValidationPending) {
             return;
         }
-        if (allValidatedReviewPagesComplete && !hasStorageWarnings) {
+        if (allValidatedReviewPagesComplete) {
             cockpit.location.go(["anaconda-screen-progress"]);
         } else {
             autoProceedBlockedRef.current = true;
         }
     }, [automatedInstall, pauseAtSummary, allValidatedReviewPagesComplete, storageValidationPending,
-        hasStorageWarnings, autoProceedBlockedRef, reviewValidationPending]);
+        autoProceedBlockedRef, reviewValidationPending]);
 
     // Display custom footer
     const getFooter = useMemo(() => (

--- a/src/components/storage/installation-method/usePageComplete.jsx
+++ b/src/components/storage/installation-method/usePageComplete.jsx
@@ -153,11 +153,8 @@ const useStorageSpaceNotification = (status, freeSpace, requiredSize) => {
 export const usePageComplete = () => {
     const spaceState = useStorageComplete();
 
-    const { validationPending, validationReport } = useApplyStorageOnReview();
+    const { validationPending } = useApplyStorageOnReview();
     useStorageSpaceNotification(spaceState.status, spaceState.freeSpace, spaceState.requiredSize);
-
-    const warningMessages = validationReport?.["warning-messages"]?.v || [];
-    const hasWarnings = !validationPending && warningMessages.length > 0;
 
     let complete;
     if (spaceState.status === StorageCompleteStatus.PENDING) {
@@ -168,5 +165,5 @@ export const usePageComplete = () => {
         complete = true;
     }
 
-    return { complete, hasWarnings, validationPending };
+    return { complete, validationPending };
 };

--- a/test/check-kickstart-automated
+++ b/test/check-kickstart-automated
@@ -140,22 +140,13 @@ class TestKickstartAutomatedWarning(VirtInstallMachineCase):
             Boot with ``inst.ks=TestKickstartAutomatedWarning-testBasic.ks``
 
         Expected results:
-            - Automated install stops on the review step with the install action enabled.
-            - Storage validation warnings are shown on the review page.
+            - Automated installation starts despite storage warnings.
+            - Storage warnings do not block auto-proceed (matching GTK/TUI behavior).
         """
         b = self.browser
-        m = self.machine
-        i = Installer(b, m, scenario="use-configured-storage-kickstart")
 
         b.open("/cockpit/@localhost/anaconda-webui/index.html")
-        b.wait_visible("#installation-next-btn:not([aria-disabled=true])")
-
-        # Wait for warning notification about /boot partition size
-        b.wait_in_text(f"#{i.steps.REVIEW}-step-notification",
-                       "Your /boot partition is less than 1024 MiB which is lower than recommended for a normal Fedora install.")
-
-        i.check_next_disabled(disabled=False)
-        b.assert_pixels(".anaconda-wizard-step-anaconda-screen-review", "review-kickstarted", ignore=pixel_tests_ignore)
+        b.wait_in_text("h2", "Installing")
 
 
 class TestKickstartAutomated(VirtInstallMachineCase):


### PR DESCRIPTION
Storage warnings (like boot partition smaller than recommended) should not block automated installations from auto-proceeding through the review screen. This matches GTK/TUI behavior where only incomplete pages block auto-proceed.