### PR TITLE
Add Restart button to post-installation screen for live media

### DIFF
--- a/src/apis/runtime.js
+++ b/src/apis/runtime.js
@@ -8,7 +8,7 @@ import cockpit from "cockpit";
 import { getPasswordPoliciesAction } from "../actions/runtime-actions.js";
 
 import { debug, error } from "../helpers/log.js";
-import { _getProperty } from "./helpers.js";
+import { _getProperty, _setProperty } from "./helpers.js";
 
 const OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Runtime/UserInterface";
 const INTERFACE_NAME = "org.fedoraproject.Anaconda.Modules.Runtime.UserInterface";
@@ -108,4 +108,12 @@ export const getPasswordPolicies = () => {
  */
 export const getRebootData = () => {
     return _getProperty(RuntimeClient, RUNTIME_OBJECT_PATH, RUNTIME_INTERFACE_NAME, "Reboot");
+};
+
+/**
+ * @param {Object} rebootData    The RebootData structure (action, eject, kexec)
+ */
+export const setRebootData = (rebootData) => {
+    return _setProperty(RuntimeClient, RUNTIME_OBJECT_PATH, RUNTIME_INTERFACE_NAME,
+                        "Reboot", cockpit.variant("a{sv}", rebootData));
 };

--- a/src/components/installation/InstallationProgress.jsx
+++ b/src/components/installation/InstallationProgress.jsx
@@ -16,7 +16,7 @@ import { PendingIcon } from "@patternfly/react-icons/dist/esm/icons/pending-icon
 
 import { BossClient, getSteps, installWithTasks } from "../../apis/boss.js";
 
-import { exitGui } from "../../helpers/exit.js";
+import { exitGui, rebootSystem } from "../../helpers/exit.js";
 
 import { OsReleaseContext, SystemTypeContext } from "../../contexts/Common.jsx";
 
@@ -174,6 +174,11 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
         },
     ];
 
+    const successActions = [
+        <Button key="reboot" onClick={isBootIso ? exitGui : rebootSystem}>{_("Reboot to installed system")}</Button>,
+        ...(!isBootIso ? [<Button key="exit" variant="link" onClick={exitGui}>{_("Exit to live desktop")}</Button>] : []),
+    ];
+
     return (
         <Flex direction={{ default: "column" }} className={SCREEN_ID + "-status " + SCREEN_ID + "-status-" + status}>
             <EmptyStatePanel
@@ -242,10 +247,7 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
                           </>)}
                   </Flex>
               }
-              secondary={
-                  status === "success" &&
-                  <Button onClick={exitGui}>{isBootIso ? _("Reboot to installed system") : _("Exit to live desktop")}</Button>
-              }
+              secondary={status === "success" && successActions}
               title={title}
               headingLevel="h2"
             />

--- a/src/helpers/exit.js
+++ b/src/helpers/exit.js
@@ -4,11 +4,21 @@
  */
 import cockpit from "cockpit";
 
+import { setRebootData } from "../apis/runtime.js";
+
 import { debug, error } from "./log.js";
+
+const KS_REBOOT = 1;
 
 let _isExiting = false;
 
 export const isExiting = () => _isExiting;
+
+export const rebootSystem = () => {
+    setRebootData({
+        action: cockpit.variant("i", KS_REBOOT),
+    }).then(exitGui);
+};
 
 export const exitGui = () => {
     _isExiting = true;


### PR DESCRIPTION
On live media, users only saw "Exit to live desktop" after installation, but were told to reboot. Show also a "Reboot to installed system" button that sets the Reboot D-Bus property on the Runtime module and exits through anaconda's normal exit path, ensuring proper cleanup.

Resolves: rhbz#2326672

<img width="1146" height="716" alt="Screenshot 2026-07-13 at 17-41-41 Virtual machines - kkoukiou@fedora" src="https://github.com/user-attachments/assets/ec5b677e-0f9d-450e-b0fd-05ad85aa8c14" />

Needs: https://github.com/rhinstaller/anaconda/pull/7176