### PR TITLE
Do not reset kickstart boot drive in applyStorage

### DIFF
--- a/src/apis/storage_bootloader.js
+++ b/src/apis/storage_bootloader.js
@@ -4,15 +4,23 @@
  */
 import cockpit from "cockpit";
 
-import { _setProperty } from "./helpers.js";
+import { _getProperty, _setProperty } from "./helpers.js";
 
 import { StorageClient } from "./storage.js";
 
 const INTERFACE_NAME = "org.fedoraproject.Anaconda.Modules.Storage.Bootloader";
 const OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Storage/Bootloader";
 
+const getProperty = (...args) => {
+    return _getProperty(StorageClient, OBJECT_PATH, INTERFACE_NAME, ...args);
+};
+
 const setProperty = (...args) => {
     return _setProperty(StorageClient, OBJECT_PATH, INTERFACE_NAME, ...args);
+};
+
+export const getBootloaderDrive = () => {
+    return getProperty("Drive");
 };
 
 /**

--- a/src/apis/storage_partitioning.js
+++ b/src/apis/storage_partitioning.js
@@ -15,8 +15,12 @@ import {
     StorageClient,
 } from "./storage.js";
 import {
+    getBootloaderDrive,
     setBootloaderDrive,
 } from "./storage_bootloader.js";
+import {
+    getSelectedDisks,
+} from "./storage_disks_selection.js";
 
 const INTERFACE_NAME_STORAGE = "org.fedoraproject.Anaconda.Modules.Storage";
 const INTERFACE_NAME_PARTITIONING = "org.fedoraproject.Anaconda.Modules.Storage.Partitioning";
@@ -282,6 +286,12 @@ export const applyStorage = async ({ devices, luks, partitioning }) => {
         await partitioningSetPassphrase({ partitioning, passphrase: luks.passphrase });
     }
 
+    const [currentBootDrive, selectedDisks] = await Promise.all([
+        getBootloaderDrive(),
+        getSelectedDisks(),
+    ]);
+    const shouldResetBootDrive = currentBootDrive && !selectedDisks?.includes(currentBootDrive);
+
     const method = await getPartitioningMethod({ partitioning });
     if (method === "MANUAL") {
         const requests = await gatherRequests({ partitioning });
@@ -292,10 +302,10 @@ export const applyStorage = async ({ devices, luks, partitioning }) => {
 
         if (bootloaderDisk !== rootDisk && !!bootloaderDisk) {
             await setBootloaderDrive({ drive: bootloaderDisk });
-        } else {
+        } else if (shouldResetBootDrive || !currentBootDrive) {
             await setBootloaderDrive({ drive: "" });
         }
-    } else {
+    } else if (shouldResetBootDrive) {
         await setBootloaderDrive({ drive: "" });
     }
 


### PR DESCRIPTION
Match the GTK UI behavior: only reset the bootloader drive if it was set to a disk that is no longer in the selected disks. Previously the WebUI unconditionally cleared the Drive property for non-MANUAL partitioning, which overwrote kickstart --boot-drive settings.

Note: This makes the bootloader-4 kickstart test succeed.