### PR TITLE
Stop all D-Bus event monitors when installation starts

### DIFF
--- a/src/apis/boss.js
+++ b/src/apis/boss.js
@@ -8,6 +8,8 @@ import cockpit from "cockpit";
 import { error } from "../helpers/log.js";
 import { _callClient, _getProperty } from "./helpers.js";
 
+import { moduleClients } from "./index.js";
+
 const OBJECT_PATH = "/org/fedoraproject/Anaconda/Boss";
 const INTERFACE_NAME = "org.fedoraproject.Anaconda.Boss";
 
@@ -17,11 +19,12 @@ const callClient = (...args) => {
 
 /**
  * @param {string} address      Anaconda bus address
+ * @param {Function} dispatch   Redux dispatch function
  *
  * @returns {Object}            A DBus client for the Boss bus
  */
 export class BossClient {
-    constructor (address) {
+    constructor (address, dispatch) {
         if (BossClient.instance && (!address || BossClient.instance.address === address)) {
             return BossClient.instance;
         }
@@ -35,10 +38,38 @@ export class BossClient {
             { address, bus: "none", superuser: "try" }
         );
         this.address = address;
+        this.dispatch = dispatch;
     }
 
-    init (args = {}) { // eslint-disable-line no-unused-vars -- optional bootstrap args from Application
+    init (args = {}) {
         this.client.addEventListener("close", () => error("Boss client closed"));
+
+        return Promise.all(
+            moduleClients.map(Client => new Client(this.address, this.dispatch).init(args))
+        ).then(() => {
+            this.startEventMonitor();
+        });
+    }
+
+    startEventMonitor () {
+        this._subscription = this.client.subscribe(
+            { },
+            (path, iface, signal, args) => {
+                if (signal === "PropertiesChanged" &&
+                    args[0] === INTERFACE_NAME &&
+                    Object.hasOwn(args[1], "ActiveInstallationTask") &&
+                    args[1].ActiveInstallationTask.v) {
+                    for (const Client of moduleClients) {
+                        Client.instance?.stopEventMonitor();
+                    }
+                    this.stopEventMonitor();
+                }
+            }
+        );
+    }
+
+    stopEventMonitor () {
+        this._subscription?.remove();
     }
 }
 

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -2,7 +2,6 @@
  * Copyright (C) 2023 Red Hat, Inc.
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
-import { BossClient } from "./boss.js";
 import { LocalizationClient } from "./localization.js";
 import { NetworkClient } from "./network.js";
 import { PayloadsClient } from "./payloads.js";
@@ -11,8 +10,7 @@ import { StorageClient } from "./storage.js";
 import { TimezoneClient } from "./timezone.js";
 import { UsersClient } from "./users.js";
 
-export const clients = [
-    BossClient,
+export const moduleClients = [
     LocalizationClient,
     NetworkClient,
     PayloadsClient,

--- a/src/apis/localization.js
+++ b/src/apis/localization.js
@@ -56,8 +56,12 @@ export class LocalizationClient {
         await this.dispatch(getKeyboardConfigurationAction());
     }
 
+    stopEventMonitor () {
+        this._subscription?.remove();
+    }
+
     startEventMonitor () {
-        this.client.subscribe(
+        this._subscription = this.client.subscribe(
             { },
             async (path, iface, signal, args) => {
                 switch (signal) {

--- a/src/apis/network.js
+++ b/src/apis/network.js
@@ -52,8 +52,12 @@ export class NetworkClient {
         await this.dispatch(getHostnameAction());
     }
 
+    stopEventMonitor () {
+        this._subscription?.remove();
+    }
+
     startEventMonitor () {
-        this.client.subscribe(
+        this._subscription = this.client.subscribe(
             { },
             (path, iface, signal, args) => {
                 switch (signal) {

--- a/src/apis/payload_dnf.js
+++ b/src/apis/payload_dnf.js
@@ -91,8 +91,12 @@ export class PayloadDNFClient {
         }
     }
 
+    stopEventMonitor () {
+        this._subscription?.remove();
+    }
+
     startEventMonitor () {
-        this.client.subscribe(
+        this._subscription = this.client.subscribe(
             { },
             (path, iface, signal, args) => {
                 switch (signal) {

--- a/src/apis/payloads.js
+++ b/src/apis/payloads.js
@@ -50,6 +50,10 @@ export class PayloadsClient {
         this.initData(args);
     }
 
+    stopEventMonitor () {
+        PayloadDNFClient.instance?.stopEventMonitor();
+    }
+
     async initData (args = {}) {
         const activePayload = await getActivePayload();
 

--- a/src/apis/runtime.js
+++ b/src/apis/runtime.js
@@ -48,8 +48,12 @@ export class RuntimeClient {
         await this.initData();
     }
 
+    stopEventMonitor () {
+        this._subscription?.remove();
+    }
+
     startEventMonitor () {
-        this.client.subscribe(
+        this._subscription = this.client.subscribe(
             { },
             (path, iface, signal, args) => {
                 switch (signal) {

--- a/src/apis/storage.js
+++ b/src/apis/storage.js
@@ -51,8 +51,12 @@ export class StorageClient {
         await this.initData();
     }
 
+    stopEventMonitor () {
+        this._subscription?.remove();
+    }
+
     startEventMonitor () {
-        this.client.subscribe(
+        this._subscription = this.client.subscribe(
             { },
             (path, iface, signal, args) => {
                 switch (signal) {

--- a/src/apis/timezone.js
+++ b/src/apis/timezone.js
@@ -62,8 +62,12 @@ export class TimezoneClient {
         this.dispatch(setAllValidTimezonesAction({ allValidTimezones }));
     }
 
+    stopEventMonitor () {
+        this._subscription?.remove();
+    }
+
     startEventMonitor () {
-        this.client.subscribe(
+        this._subscription = this.client.subscribe(
             { },
             async (path, iface, signal, args) => {
                 switch (signal) {

--- a/src/apis/users.js
+++ b/src/apis/users.js
@@ -56,8 +56,12 @@ export class UsersClient {
         ]);
     }
 
+    stopEventMonitor () {
+        this._subscription?.remove();
+    }
+
     startEventMonitor () {
-        this.client.subscribe(
+        this._subscription = this.client.subscribe(
             { },
             async (path, iface, signal, args) => {
                 switch (signal) {

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -7,7 +7,7 @@ import cockpit from "cockpit";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Page, PageGroup, PageSection, PageSectionTypes } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 
-import { clients } from "../apis/index.js";
+import { BossClient } from "../apis/boss.js";
 
 import { initialState, reducer, useReducerWithThunk } from "../reducer.js";
 
@@ -68,7 +68,7 @@ export const Application = ({ conf, dispatch, isFetching, onCritFail, osRelease,
         // Attach a click event listener to detect external link clicks
         document.addEventListener("click", allowExternalNavigation);
 
-        Promise.all(clients.map(Client => new Client(address, dispatch).init({ automatedInstall, conf })))
+        new BossClient(address, dispatch).init({ automatedInstall, conf })
                 .then(() => {
                     setStoreInitialized(true);
                 }, onCritFail({ context: N_("Reading information about the computer failed.") }));


### PR DESCRIPTION
Once installation begins the UI only needs to display progress, there is no need to keep reacting to module property changes. This also prevents UnknownDeviceError tracebacks (which are ignored by WebUI) caused by querying devices while blivet is restructuring the device tree during installation.

Asssisted-By: Claude Opus 4.6 <noreply@anthropic.com>

Note: I think this will fix some failing tests from [webUI KS runs](https://github.com/rhinstaller/kickstart-tests/actions/runs/29460339497/job/87502307568) which were failing because there where 'UnknownDeviceErrors' in the journal which were caused by WebUI API calls after the installation had started.