### PR TITLE
storage: Add support for home reuse partitioning with Stratis

### DIFF
--- a/src/apis/storage_partitioning.js
+++ b/src/apis/storage_partitioning.js
@@ -104,6 +104,7 @@ export const getAutopartReuseDBusRequest = ({ reuseEFIPart, scheme }) => {
         LVM: cockpit.variant("i", 2),
         LVM_THINP: cockpit.variant("i", 3),
         PLAIN: cockpit.variant("i", 0),
+        STRATIS: cockpit.variant("i", 4),
     };
     const request = {
         "partitioning-scheme": configurationSchemeToDBus?.[scheme],
@@ -116,8 +117,8 @@ export const getAutopartReuseDBusRequest = ({ reuseEFIPart, scheme }) => {
         const removed = reuseEFIPart ? ["/", "/boot"] : ["/", "/boot", "bootloader"];
         request["removed-mount-points"] = cockpit.variant("as", removed);
     } else {
-        // "LVM", "BTRFS", "LVM_THINP"
-        // "/" can't be reallocated by autopartitioing as it is sharing container device with /home
+        // "LVM", "BTRFS", "LVM_THINP", "STRATIS"
+        // "/" can't be reallocated by autopartitioning as it is sharing container device with /home
         const removed = reuseEFIPart ? ["/boot"] : ["/boot", "bootloader"];
         request["removed-mount-points"] = cockpit.variant("as", removed);
         request["reformatted-mount-points"] = cockpit.variant("as", ["/"]);

--- a/src/components/storage/scenarios/reinstall-fedora/ReinstallFedora.jsx
+++ b/src/components/storage/scenarios/reinstall-fedora/ReinstallFedora.jsx
@@ -104,6 +104,7 @@ export const useAvailabilityHomeReuse = () => {
                 LVM: "lvmlv",
                 LVM_THINP: "lvmthinlv",
                 PLAIN: "partition",
+                STRATIS: "stratis filesystem",
             };
             if (homeDeviceType !== requiredSchemeTypes[autopartScheme]) {
                 availability.available = false;


### PR DESCRIPTION
Unfortunately home reuse currently works only with default partitioning so to make it work with stratis, it needs to be changed in the config.