### PR TITLE
Sync destination modal selection with backend disk changes

### DIFF
--- a/src/components/storage/installation-method/InstallationDestination.jsx
+++ b/src/components/storage/installation-method/InstallationDestination.jsx
@@ -328,6 +328,10 @@ const ChangeDestination = ({ dispatch, idPrefix, onCritFail }) => {
     const { diskSelection } = useContext(StorageContext);
     const [unappliedSelection, setUnappliedSelection] = useState(diskSelection.selectedDisks);
 
+    useEffect(() => {
+        setUnappliedSelection(diskSelection.selectedDisks);
+    }, [diskSelection.selectedDisks]);
+
     const onSave = () => {
         setSelectedDisks({ drives: unappliedSelection });
         setIsModalOpen(false);


### PR DESCRIPTION
The unappliedSelection state may be initialized before selectedDisks are properly fetched from the backend, resulting in a desync. Add a useEffect to keep unappliedSelection in sync with the backend state.

Resolves: rhbz#2459685