### PR TITLE
Check InstallationFinished before starting new install

### DIFF
--- a/src/apis/boss.js
+++ b/src/apis/boss.js
@@ -65,6 +65,13 @@ export const getActiveInstallationTask = () => {
 };
 
 /**
+ * @returns {Promise<boolean>}  Resolves to true if the installation finished successfully, false otherwise
+ */
+export const getInstallationFinished = () => {
+    return _getProperty(BossClient, OBJECT_PATH, INTERFACE_NAME, "InstallationFinished");
+};
+
+/**
  * @returns {Promise}           Resolves a list of tasks
  */
 export const installWithTasks = () => {

--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -10,7 +10,7 @@ import React, { useContext, useEffect, useRef, useState } from "react";
 import { PageSection, PageSectionTypes } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Wizard, WizardStep } from "@patternfly/react-core/dist/esm/components/Wizard/index.js";
 
-import { getActiveInstallationTask } from "../apis/boss.js";
+import { getActiveInstallationTask, getInstallationFinished } from "../apis/boss.js";
 
 import { PageContext, PayloadContext, StorageContext, SystemTypeContext, UserInterfaceContext } from "../contexts/Common.jsx";
 
@@ -73,6 +73,12 @@ export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFe
                 .then(activeTask => {
                     if (activeTask) {
                         cockpit.location.go([finalStepId]);
+                    } else {
+                        getInstallationFinished().then(finished => {
+                            if (finished) {
+                                cockpit.location.go([finalStepId]);
+                            }
+                        });
                     }
                 });
     }, [finalStepId]);

--- a/src/components/installation/InstallationProgress.jsx
+++ b/src/components/installation/InstallationProgress.jsx
@@ -14,7 +14,7 @@ import { ExclamationCircleIcon } from "@patternfly/react-icons/dist/esm/icons/ex
 import { InProgressIcon } from "@patternfly/react-icons/dist/esm/icons/in-progress-icon";
 import { PendingIcon } from "@patternfly/react-icons/dist/esm/icons/pending-icon";
 
-import { BossClient, getActiveInstallationTask, getSteps, installWithTasks } from "../../apis/boss.js";
+import { BossClient, getActiveInstallationTask, getInstallationFinished, getSteps, installWithTasks } from "../../apis/boss.js";
 
 import { exitGui } from "../../helpers/exit.js";
 
@@ -33,6 +33,7 @@ const N_ = cockpit.noop;
 const SCREEN_ID = "anaconda-screen-progress";
 const DETAIL_TYPE_YESNO = "yesno";
 
+const PROGRESS_STEPS_DONE = 4;
 const progressStepsMap = {
     BOOTLOADER_INSTALLATION: 2,
     ENVIRONMENT_CONFIGURATION: 0,
@@ -109,7 +110,7 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
                 });
                 taskProxy.addEventListener("Succeeded", () => {
                     setStatus("success");
-                    setCurrentProgressStep(4);
+                    setCurrentProgressStep(PROGRESS_STEPS_DONE);
                 });
             };
             taskProxy.wait(() => {
@@ -128,18 +129,30 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
             });
         };
 
+        const startNewInstallation = () => {
+            installWithTasks()
+                    .then(
+                        tasks => connectToTask(tasks[0], true),
+                        onCritFail({
+                            context: _("Installation of the system failed"),
+                        })
+                    );
+        };
+
         getActiveInstallationTask()
                 .then(activeTask => {
                     if (activeTask) {
                         connectToTask(activeTask, false);
                     } else {
-                        installWithTasks()
-                                .then(
-                                    tasks => connectToTask(tasks[0], true),
-                                    onCritFail({
-                                        context: _("Installation of the system failed"),
-                                    })
-                                );
+                        getInstallationFinished().then(finished => {
+                            if (finished) {
+                                setStatus("success");
+                                setCurrentProgressStep(PROGRESS_STEPS_DONE);
+                                setSteps([]);
+                            } else {
+                                startNewInstallation();
+                            }
+                        });
                     }
                 }, onCritFail({
                     context: _("Installation of the system failed"),
@@ -206,11 +219,11 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
               paragraph={
                   <Flex direction={{ default: "column" }}>
                       <Content component="p">
-                          {currentProgressStep < 4
+                          {currentProgressStep < PROGRESS_STEPS_DONE
                               ? progressSteps[currentProgressStep].description
                               : cockpit.format(_("To begin using $0, reboot your system."), osRelease.PRETTY_NAME)}
                       </Content>
-                      {currentProgressStep < 4 && (
+                      {currentProgressStep < PROGRESS_STEPS_DONE && (
                           <>
                               <FlexItem spacer={{ default: "spacerXl" }} />
                               <ProgressStepper isCenterAligned>

--- a/test/check-progress
+++ b/test/check-progress
@@ -47,6 +47,12 @@ class TestInstallationProgress(VirtInstallMachineCase):
 
         p.wait_done()
         b.wait_in_text("h2", "Successfully installed")
+        # Reload after completion: InstallationFinished should prevent a new install attempt.
+        # Short timeout: success screen must appear in seconds, not minutes — a full
+        # re-install would take much longer, proving no new install was triggered.
+        b.reload()
+        with b.wait_timeout(30):
+            b.wait_in_text("h2", "Successfully installed")
         b.wait_in_text(".pf-v6-c-empty-state", f"To begin using {get_pretty_name(m)}, reboot your system")
 
         # Pixel test the complete progress step


### PR DESCRIPTION
When a user refreshes the browser after a successful installation, the WebUI could not distinguish between 'never started' and 'finished successfully' because ActiveInstallationTask is cleared on completion. This caused a new install attempt that immediately failed.

Check the new InstallationFinished D-Bus property (INSTALLER-4824) as a fallback when no active task exists. If the installation already finished, navigate to the success screen instead of starting a new installation.

Assisted-by: Claude Opus 4.6