### PR TITLE
Move cockpit-ws config to anaconda-owned path with conf.d support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,11 @@ install: $(DIST_TEST) po/LINGUAS
 	cp browser-ext $(DESTDIR)/usr/libexec/anaconda
 	cp gnome-control-center-ext $(DESTDIR)/usr/libexec/anaconda
 	cp src/scripts/cockpit-coproc-wrapper.sh $(DESTDIR)/usr/libexec/anaconda/
+	cp src/scripts/anaconda-cockpit-conf-merge $(DESTDIR)/usr/libexec/anaconda/
 	mkdir -p $(DESTDIR)/usr/lib/systemd/system/
 	cp src/systemd/webui-cockpit-ws.service $(DESTDIR)/usr/lib/systemd/system/
+	mkdir -p $(DESTDIR)/etc/anaconda/cockpit/conf.d/
+	cp src/config/cockpit/cockpit.conf $(DESTDIR)/etc/anaconda/cockpit/cockpit.conf
 
 dist: $(TARFILE)
 	@ls -1 $(TARFILE)

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -122,6 +122,52 @@ The default browser for Fedora is `Slitherer <https://gitlab.com/VelocityLimitle
 - `anaconda/data/profile.d/fedora-workstation.conf <https://github.com/rhinstaller/anaconda/blob/main/data/profile.d/fedora-workstation.conf>`_
 - `anaconda/data/profile.d/fedora.conf <https://github.com/rhinstaller/anaconda/blob/main/data/profile.d/fedora.conf>`_
 
+.. _cockpit-web-service-configuration:
+
+Cockpit Web Service Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Installer Web UI runs on Cockpit's web service (``cockpit-ws``). Its configuration lives under an Anaconda-owned path at ``/etc/anaconda/cockpit/`` instead of the default ``/etc/cockpit/`` to prevent installer-specific settings (such as disabled TLS or authentication) from leaking into the installed system.
+
+The base configuration file is ``/etc/anaconda/cockpit/cockpit.conf``. It uses the standard `cockpit.conf(5) <https://cockpit-project.org/guide/latest/cockpit.conf.5.html>`_ INI format.
+
+Default settings:
+
+.. code-block:: ini
+
+   [WebService]
+   AllowUnencrypted = true
+   LoginTo = false
+   AllowMultiHost = false
+
+   [Session]
+   IdleTimeout = 0
+
+conf.d drop-in overrides
+'''''''''''''''''''''''''
+
+To customize the Cockpit web service for specific environments without modifying the base configuration, place ``*.conf`` files in ``/etc/anaconda/cockpit/conf.d/``. Files are applied in lexicographic order, and later files override values from earlier ones and from the base configuration.
+
+Example -- enable TLS for a network-based installation:
+
+.. code-block:: ini
+
+   # /etc/anaconda/cockpit/conf.d/50-tls.conf
+   [WebService]
+   AllowUnencrypted = false
+
+Example -- set a custom login title:
+
+.. code-block:: ini
+
+   # /etc/anaconda/cockpit/conf.d/50-branding.conf
+   [WebService]
+   LoginTitle = My Custom Installer
+
+The merged configuration is written to ``/run/anaconda/cockpit/cockpit.conf`` at service start and is used by ``cockpit-ws`` via the ``XDG_CONFIG_DIRS`` environment variable.
+
+For the full list of available cockpit.conf options, see the `cockpit.conf(5) man page <https://cockpit-project.org/guide/latest/cockpit.conf.5.html>`_.
+
 Future: Add-on Support
 -----------------------
 

--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -77,6 +77,10 @@ exit 0
 %{_datadir}/cockpit/anaconda-webui/po.*.js.gz
 %{_datadir}/cockpit/anaconda-webui/VERSION.txt
 %{_libexecdir}/anaconda/cockpit-coproc-wrapper.sh
+%{_libexecdir}/anaconda/anaconda-cockpit-conf-merge
+%dir /etc/anaconda/cockpit
+%config(noreplace) /etc/anaconda/cockpit/cockpit.conf
+%dir /etc/anaconda/cockpit/conf.d
 %dir %{_datadir}/anaconda/firefox-theme
 %dir %{_datadir}/anaconda/firefox-theme/default
 %dir %{_datadir}/anaconda/firefox-theme/default/chrome

--- a/src/config/cockpit/cockpit.conf
+++ b/src/config/cockpit/cockpit.conf
@@ -1,0 +1,19 @@
+# Copyright (C) 2025 Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Cockpit configuration for the Anaconda Installer.
+# This is the base configuration shipped by anaconda-webui.
+# To override settings, place files in /etc/anaconda/cockpit/conf.d/*.conf
+# (later files override earlier ones in lexicographic order).
+
+[WebService]
+# The installer runs behind a local session, no TLS by default
+AllowUnencrypted = true
+
+# Disable multi-host connections -- installer is single-machine
+LoginTo = false
+AllowMultiHost = false
+
+[Session]
+# No idle timeout during installation
+IdleTimeout = 0

--- a/src/scripts/anaconda-cockpit-conf-merge
+++ b/src/scripts/anaconda-cockpit-conf-merge
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2025 Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Merge anaconda's base cockpit.conf with conf.d drop-in overrides.
+# The merged result is written to a runtime path so that cockpit-ws
+# picks it up via XDG_CONFIG_DIRS.
+
+import configparser
+import glob
+import os
+import sys
+
+CONF_BASE = "/etc/anaconda/cockpit/cockpit.conf"
+CONF_D = "/etc/anaconda/cockpit/conf.d"
+CONF_OUT = "/run/anaconda/cockpit/cockpit.conf"
+
+
+def main():
+    config = configparser.ConfigParser()
+    # Preserve CamelCase keys required by cockpit.conf (e.g. AllowUnencrypted)
+    setattr(config, "optionxform", str)  # noqa: B010
+
+    if not os.path.exists(CONF_BASE):
+        print(f"anaconda-cockpit-conf-merge: base config {CONF_BASE} not found, skipping", file=sys.stderr)
+        return
+
+    config.read(CONF_BASE)
+
+    dropins = sorted(glob.glob(os.path.join(CONF_D, "*.conf")))
+    if dropins:
+        config.read(dropins)
+        names = [os.path.basename(f) for f in dropins]
+        print(f"anaconda-cockpit-conf-merge: applied drop-ins: {', '.join(names)}", file=sys.stderr)
+
+    os.makedirs(os.path.dirname(CONF_OUT), exist_ok=True)
+    with open(CONF_OUT, "w") as f:
+        config.write(f)
+
+    print(f"anaconda-cockpit-conf-merge: wrote merged config to {CONF_OUT}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/cockpit-coproc-wrapper.sh
+++ b/src/scripts/cockpit-coproc-wrapper.sh
@@ -13,4 +13,5 @@ WEBUI_ADDRESS=$1
 coproc BRIDGE { cockpit-bridge; }
 
 # Start cockpit-ws connected to the coproc
-exec /usr/libexec/cockpit-ws -p 80 -a "$WEBUI_ADDRESS" --no-tls --local-session=- <&${BRIDGE[0]} >&${BRIDGE[1]}
+# TLS settings are now in /etc/anaconda/cockpit/cockpit.conf (AllowUnencrypted)
+exec /usr/libexec/cockpit-ws -p 80 -a "$WEBUI_ADDRESS" --local-session=- <&${BRIDGE[0]} >&${BRIDGE[1]}

--- a/src/systemd/webui-cockpit-ws.service
+++ b/src/systemd/webui-cockpit-ws.service
@@ -6,6 +6,8 @@ After=network.target
 Type=simple
 EnvironmentFile=/tmp/webui-cockpit-ws.env
 Environment="COCKPIT_SUPERUSER=pkexec"
+Environment="XDG_CONFIG_DIRS=/run/anaconda"
+ExecStartPre=/usr/libexec/anaconda/anaconda-cockpit-conf-merge
 ExecStart=/usr/libexec/anaconda/cockpit-coproc-wrapper.sh $WEBUI_ADDRESS
 Restart=on-failure
 RestartSec=5s


### PR DESCRIPTION
Keep installer-specific Cockpit settings out of /etc/cockpit so they do not leak into the installed system. Use XDG_CONFIG_DIRS and a runtime merge of /etc/anaconda/cockpit/cockpit.conf with conf.d drop-ins.