### PR TITLE
Fix Unknown device traceback

### DIFF
--- a/src/actions/storage-actions.js
+++ b/src/actions/storage-actions.js
@@ -42,12 +42,16 @@ export const getDevicesAction = () => {
             try {
                 const devData = await getDeviceData({ disk: device });
 
-                const free = await getDiskFreeSpace({ diskNames: [device] });
-                // extend it with variants to keep the format consistent
-                devData.free = cockpit.variant(String, free);
+                if (devData["is-disk"].v) {
+                    const free = await getDiskFreeSpace({ diskNames: [device] });
+                    devData.free = cockpit.variant(String, free);
 
-                const total = await getDiskTotalSpace({ diskNames: [device] });
-                devData.total = cockpit.variant(String, total);
+                    const total = await getDiskTotalSpace({ diskNames: [device] });
+                    devData.total = cockpit.variant(String, total);
+                } else {
+                    devData.free = cockpit.variant(String, 0);
+                    devData.total = cockpit.variant(String, devData.size.v);
+                }
 
                 const formatData = await getFormatData({ diskName: device });
                 devData.formatData = formatData;

--- a/src/actions/storage-actions.js
+++ b/src/actions/storage-actions.js
@@ -33,20 +33,23 @@ export const getDevicesAction = () => {
             type: "SET_IS_FETCHING",
         });
 
-        const actions = await getActions();
-        const devices = await getDevices();
-        const deviceData = {};
-        const mountPoints = await getMountPoints();
-        const existingSystems = await getExistingSystems();
-        for (const device of devices) {
+        const [actions, devices, mountPoints, existingSystems] = await Promise.all([
+            getActions(),
+            getDevices(),
+            getMountPoints(),
+            getExistingSystems(),
+        ]);
+
+        const results = await Promise.all(devices.map(async device => {
             try {
                 const devData = await getDeviceData({ disk: device });
 
                 if (devData["is-disk"].v) {
-                    const free = await getDiskFreeSpace({ diskNames: [device] });
+                    const [free, total] = await Promise.all([
+                        getDiskFreeSpace({ diskNames: [device] }),
+                        getDiskTotalSpace({ diskNames: [device] }),
+                    ]);
                     devData.free = cockpit.variant(String, free);
-
-                    const total = await getDiskTotalSpace({ diskNames: [device] });
                     devData.total = cockpit.variant(String, total);
                 } else {
                     devData.free = cockpit.variant(String, 0);
@@ -56,15 +59,16 @@ export const getDevicesAction = () => {
                 const formatData = await getFormatData({ diskName: device });
                 devData.formatData = formatData;
 
-                deviceData[device] = devData;
+                return [device, devData];
             } catch (error) {
                 if (error.name === "org.fedoraproject.Anaconda.Modules.Storage.UnknownDeviceError") {
-                    continue;
-                } else {
-                    throw error;
+                    return null;
                 }
+                throw error;
             }
-        }
+        }));
+
+        const deviceData = Object.fromEntries(results.filter(Boolean));
 
         dispatch({
             payload: {


### PR DESCRIPTION
Many kickstart tests are failing like this:
```
WARNING:dasbus.server.handler:The call org.fedoraproject.Anaconda.Modules.Storage.DeviceTree.Viewer.GetDiskFreeSpace has      failed with an exception:
Traceback (most recent call last): 
  File "/usr/lib/python3.15/site-packages/dasbus/server/handler.py", line 455, in _method_callback
    result = self._handle_call(    
        interface_name,            
    ...<2 lines>...                
        **additional_args          
    )                              
  File "/usr/lib/python3.15/site-packages/dasbus/server/handler.py", line 265, in _handle_call
    return handler(*parameters, **additional_args)
  File "/usr/lib64/python3.15/site-packages/pyanaconda/modules/storage/devicetree/viewer_interface.py", line 183, in GetD     iskFreeSpace
    return self.implementation.get_disk_free_space(disk_ids)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/usr/lib64/python3.15/site-packages/pyanaconda/modules/storage/devicetree/viewer.py", line 486, in get_disk_free_     space
    disks = self._get_devices(disk_ids)
  File "/usr/lib64/python3.15/site-packages/pyanaconda/modules/storage/devicetree/viewer.py", line 296, in _get_devices
    return list(map(self._get_device, device_ids))
  File "/usr/lib64/python3.15/site-packages/pyanaconda/modules/storage/devicetree/viewer.py", line 286, in _get_device
    raise UnknownDeviceError(device_id)
pyanaconda.modules.common.errors.storage.UnknownDeviceError: LUKS-luks-vda3

```