### PR TITLE
Dnf install source minimal (HTTP/HTTPS + baseurl, mirrorlist and metalink)

### DIFF
--- a/src/actions/payload-dnf-actions.js
+++ b/src/actions/payload-dnf-actions.js
@@ -4,32 +4,40 @@
  */
 
 import {
+    getDefaultEnvironment,
     getEnvironmentData,
     getEnvironments,
     getGroupData,
     getPackagesKickstarted,
     getPackagesSelection,
+    resolveEnvironment,
+    setPackagesSelection,
 } from "../apis/payload_dnf.js";
 
 export const getPayloadEnvironmentsAction = () => {
     return async (dispatch) => {
         const environmentIds = await getEnvironments();
 
-        // Fetch environment data for each environment to get descriptions
-        const environmentDataPromises = environmentIds.map(async (envId) => {
-            const envData = await getEnvironmentData(envId);
-            return {
-                description: envData.description,
-                id: envId,
-                name: envData.name,
-            };
-        });
+        const environmentResults = await Promise.all(
+            environmentIds.map(async (envId) => {
+                try {
+                    const envData = await getEnvironmentData(envId);
+                    return {
+                        description: envData.description,
+                        id: envId,
+                        name: envData.name,
+                    };
+                } catch {
+                    return null;
+                }
+            })
+        );
 
-        const environments = await Promise.all(environmentDataPromises);
+        const environments = environmentResults.filter(Boolean);
 
         return dispatch({
             payload: { environments },
-            type: "SET_PAYLOAD_ENVIRONMENTS"
+            type: "SET_PAYLOAD_ENVIRONMENTS",
         });
     };
 };
@@ -76,7 +84,53 @@ export const getPayloadGroupsAction = (environment) => {
 
         return dispatch({
             payload: { groups },
-            type: "SET_PAYLOAD_GROUPS"
+            type: "SET_PAYLOAD_GROUPS",
         });
+    };
+};
+
+/**
+ * Reload environments and re-validate the current selection after the source changes.
+ */
+export const refreshPayloadSoftwareSelectionAction = () => {
+    return async (dispatch) => {
+        await dispatch(getPayloadEnvironmentsAction());
+
+        let selection = await getPackagesSelection();
+        let environment = selection?.environment;
+
+        if (environment) {
+            const resolved = await resolveEnvironment(environment);
+            if (!resolved) {
+                environment = await getDefaultEnvironment();
+                if (environment && await resolveEnvironment(environment)) {
+                    await setPackagesSelection({ environment, groups: [] });
+                } else {
+                    await setPackagesSelection({ environment: "", groups: [] });
+                    environment = "";
+                }
+                await dispatch(getPayloadPackagesSelectionAction());
+                selection = await getPackagesSelection();
+                environment = selection?.environment;
+            }
+        }
+
+        if (environment) {
+            try {
+                await dispatch(getPayloadGroupsAction(environment));
+            } catch {
+                dispatch({
+                    payload: { groups: [] },
+                    type: "SET_PAYLOAD_GROUPS",
+                });
+            }
+        } else {
+            dispatch({
+                payload: { groups: [] },
+                type: "SET_PAYLOAD_GROUPS",
+            });
+        }
+
+        await dispatch(getPayloadPackagesSelectionAction());
     };
 };

--- a/src/actions/payload-source-actions.js
+++ b/src/actions/payload-source-actions.js
@@ -57,3 +57,10 @@ export const getPayloadSourceAction = () => {
         });
     };
 };
+
+export const setSourceApplyPendingAction = (pending) => {
+    return {
+        payload: { pending },
+        type: "SET_SOURCE_APPLY_PENDING",
+    };
+};

--- a/src/actions/payload-source-actions.js
+++ b/src/actions/payload-source-actions.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import {
+    getCdromDeviceId,
+    getPayloadSources,
+    getRepoPath,
+    getSourceConfiguration,
+    getSourceType,
+    getUpdatesEnabled,
+} from "../apis/payload_source.js";
+
+export const getPayloadSourceAction = () => {
+    return async (dispatch) => {
+        const sources = await getPayloadSources();
+
+        if (!sources || sources.length === 0) {
+            return dispatch({
+                payload: { configuration: null, deviceId: null, repoPath: null, sourcePath: null, sourceType: null, updatesEnabled: true },
+                type: "SET_PAYLOAD_SOURCE",
+            });
+        }
+
+        const sourcePath = sources[0];
+        const sourceType = await getSourceType(sourcePath);
+
+        const sourceData = {
+            configuration: null,
+            deviceId: null,
+            repoPath: null,
+            sourcePath,
+            sourceType,
+            updatesEnabled: true,
+        };
+
+        if (sourceType === "URL") {
+            sourceData.configuration = await getSourceConfiguration(sourcePath);
+        }
+
+        if (sourceType === "CLOSEST_MIRROR") {
+            sourceData.updatesEnabled = await getUpdatesEnabled(sourcePath);
+        }
+
+        if (sourceType === "CDROM") {
+            sourceData.deviceId = await getCdromDeviceId(sourcePath);
+        }
+
+        if (sourceType === "REPO_PATH") {
+            sourceData.repoPath = await getRepoPath(sourcePath);
+        }
+
+        return dispatch({
+            payload: sourceData,
+            type: "SET_PAYLOAD_SOURCE",
+        });
+    };
+};

--- a/src/actions/payload-source-actions.js
+++ b/src/actions/payload-source-actions.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import {
+    getCdromDeviceId,
+    getPayloadSources,
+    getRepoPath,
+    getSourceConfiguration,
+    getSourceType,
+    getUpdatesEnabled,
+} from "../apis/payload_source.js";
+
+export const getPayloadSourceAction = () => {
+    return async (dispatch) => {
+        const sources = await getPayloadSources();
+
+        if (!sources || sources.length === 0) {
+            return dispatch({
+                payload: { configuration: null, deviceId: null, repoPath: null, sourcePath: null, sourceType: null, updatesEnabled: true },
+                type: "SET_PAYLOAD_SOURCE",
+            });
+        }
+
+        const sourcePath = sources[0];
+        const sourceType = await getSourceType(sourcePath);
+
+        const sourceData = {
+            configuration: null,
+            deviceId: null,
+            repoPath: null,
+            sourcePath,
+            sourceType,
+            updatesEnabled: true,
+        };
+
+        if (sourceType === "URL") {
+            sourceData.configuration = await getSourceConfiguration(sourcePath);
+        }
+
+        if (sourceType === "CLOSEST_MIRROR") {
+            sourceData.updatesEnabled = await getUpdatesEnabled(sourcePath);
+        }
+
+        if (sourceType === "CDROM") {
+            sourceData.deviceId = await getCdromDeviceId(sourcePath);
+        }
+
+        if (sourceType === "REPO_PATH") {
+            sourceData.repoPath = await getRepoPath(sourcePath);
+        }
+
+        return dispatch({
+            payload: sourceData,
+            type: "SET_PAYLOAD_SOURCE",
+        });
+    };
+};

--- a/src/apis/payload_dnf.js
+++ b/src/apis/payload_dnf.js
@@ -84,10 +84,14 @@ export class PayloadDNFClient {
     }
 
     _handleEnvironmentChange (environment) {
-        // Fetch groups when environment changes
         if (environment !== this._lastEnvironment) {
             this._lastEnvironment = environment;
-            this.dispatch(getPayloadGroupsAction(environment));
+            this.dispatch(getPayloadGroupsAction(environment)).catch(() => {
+                this.dispatch({
+                    payload: { groups: [] },
+                    type: "SET_PAYLOAD_GROUPS",
+                });
+            });
         }
     }
 

--- a/src/apis/payload_source.js
+++ b/src/apis/payload_source.js
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import cockpit from "cockpit";
+
+import { _getProperty, objectFromDbus, objectToDbus } from "./helpers.js";
+
+import { PayloadDNFClient } from "./payload_dnf.js";
+import { PayloadsClient } from "./payloads.js";
+
+const PAYLOADS_OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Payloads";
+const PAYLOADS_INTERFACE = "org.fedoraproject.Anaconda.Modules.Payloads";
+const PAYLOAD_INTERFACE = "org.fedoraproject.Anaconda.Modules.Payloads.Payload";
+const SOURCE_BASE_INTERFACE = "org.fedoraproject.Anaconda.Modules.Payloads.Source";
+const SOURCE_REPOSITORY_INTERFACE = "org.fedoraproject.Anaconda.Modules.Payloads.Source.Repository";
+const SOURCE_CLOSEST_MIRROR_INTERFACE = "org.fedoraproject.Anaconda.Modules.Payloads.Source.ClosestMirror";
+const SOURCE_CDROM_INTERFACE = "org.fedoraproject.Anaconda.Modules.Payloads.Source.CDROM";
+const SOURCE_REPO_PATH_INTERFACE = "org.fedoraproject.Anaconda.Modules.Payloads.Source.RepoPath";
+
+const getClient = () => new PayloadsClient().client;
+
+const getPayloadPath = () => PayloadDNFClient.instance.payload;
+
+/**
+ * Create a new source of the given type.
+ * @param {string} sourceType - e.g. "URL"
+ * @returns {Promise<string>} D-Bus object path of the created source
+ */
+export const createSource = async (sourceType) => {
+    return getClient().call(
+        PAYLOADS_OBJECT_PATH, PAYLOADS_INTERFACE, "CreateSource", [sourceType]
+    )
+            .then(res => res[0]);
+};
+
+/**
+ * Get the list of source object paths attached to the current payload.
+ * @returns {Promise<string[]>}
+ */
+export const getPayloadSources = async () => {
+    return _getProperty(
+        PayloadsClient, getPayloadPath(), PAYLOAD_INTERFACE, "Sources"
+    );
+};
+
+/**
+ * Set the sources on the current payload.
+ * @param {string[]} sources - Array of source D-Bus object paths
+ */
+export const setPayloadSources = async (sources) => {
+    return getClient().call(
+        getPayloadPath(), "org.freedesktop.DBus.Properties", "Set",
+        [PAYLOAD_INTERFACE, "Sources", cockpit.variant("ao", sources)]
+    );
+};
+
+/**
+ * Get the Type property from a source object.
+ * @param {string} sourcePath - D-Bus object path
+ * @returns {Promise<string>}
+ */
+export const getSourceType = async (sourcePath) => {
+    return _getProperty(PayloadsClient, sourcePath, SOURCE_BASE_INTERFACE, "Type");
+};
+
+/**
+ * Get the RepoConfigurationData from a URL source.
+ * @param {string} sourcePath - D-Bus object path
+ * @returns {Promise<Object>} Plain JS object
+ */
+export const getSourceConfiguration = async (sourcePath) => {
+    const structure = await _getProperty(
+        PayloadsClient, sourcePath, SOURCE_REPOSITORY_INTERFACE, "Configuration"
+    );
+    return objectFromDbus(structure);
+};
+
+/**
+ * Set the RepoConfigurationData on a URL source.
+ * @param {string} sourcePath - D-Bus object path
+ * @param {Object} config - Plain JS object with url, type, ssl-verification-enabled
+ */
+export const setSourceConfiguration = async (sourcePath, config) => {
+    const structure = objectToDbus(config);
+    return getClient().call(
+        sourcePath, "org.freedesktop.DBus.Properties", "Set",
+        [SOURCE_REPOSITORY_INTERFACE, "Configuration", cockpit.variant("a{sv}", structure)]
+    );
+};
+
+/**
+ * Get UpdatesEnabled from a closest-mirror source.
+ * @param {string} sourcePath
+ * @returns {Promise<boolean>}
+ */
+export const getUpdatesEnabled = async (sourcePath) => {
+    return _getProperty(
+        PayloadsClient, sourcePath, SOURCE_CLOSEST_MIRROR_INTERFACE, "UpdatesEnabled"
+    );
+};
+
+/**
+ * Set UpdatesEnabled on a closest-mirror source.
+ * @param {string} sourcePath
+ * @param {boolean} enabled
+ */
+export const setUpdatesEnabled = async (sourcePath, enabled) => {
+    return getClient().call(
+        sourcePath, "org.freedesktop.DBus.Properties", "Set",
+        [SOURCE_CLOSEST_MIRROR_INTERFACE, "UpdatesEnabled", cockpit.variant("b", enabled)]
+    );
+};
+
+/**
+ * Run a D-Bus task to completion.
+ * @param {Object} params
+ * @param {string} params.task - D-Bus object path of the task
+ * @returns {Promise<void>}
+ */
+export const runPayloadTask = ({ task }) => {
+    return new Promise((resolve, reject) => {
+        let succeededEmitted = false;
+        const taskProxy = getClient().proxy(
+            "org.fedoraproject.Anaconda.Task",
+            task
+        );
+        const addEventListeners = () => {
+            taskProxy.addEventListener("Stopped", () => taskProxy.Finish().catch(reject));
+            taskProxy.addEventListener("Succeeded", () => {
+                if (succeededEmitted) {
+                    return;
+                }
+                succeededEmitted = true;
+                resolve();
+            });
+        };
+        taskProxy.wait(() => {
+            addEventListeners();
+            taskProxy.Start().catch(reject);
+        });
+    });
+};
+
+/**
+ * Tear down the current sources on the payload.
+ * @returns {Promise<void>}
+ */
+export const tearDownSources = async () => {
+    const task = await getClient().call(
+        getPayloadPath(), PAYLOAD_INTERFACE, "TearDownSourcesWithTask", []
+    )
+            .then(res => res[0]);
+    return runPayloadTask({ task });
+};
+
+/**
+ * Set up the sources on the payload.
+ * @returns {Promise<void>}
+ */
+export const setUpSources = async () => {
+    const task = await getClient().call(
+        getPayloadPath(), PAYLOAD_INTERFACE, "SetUpSourcesWithTask", []
+    )
+            .then(res => res[0]);
+    return runPayloadTask({ task });
+};
+
+/**
+ * Get the DeviceID from a CDROM source.
+ * @param {string} sourcePath
+ * @returns {Promise<string>}
+ */
+export const getCdromDeviceId = async (sourcePath) => {
+    return _getProperty(PayloadsClient, sourcePath, SOURCE_CDROM_INTERFACE, "DeviceID");
+};
+
+/**
+ * Get the Path from a REPO_PATH source.
+ * @param {string} sourcePath
+ * @returns {Promise<string>}
+ */
+export const getRepoPath = async (sourcePath) => {
+    return _getProperty(PayloadsClient, sourcePath, SOURCE_REPO_PATH_INTERFACE, "Path");
+};

--- a/src/apis/payload_source.js
+++ b/src/apis/payload_source.js
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import cockpit from "cockpit";
+
+import { _getProperty, objectFromDbus, objectToDbus } from "./helpers.js";
+
+import { PayloadDNFClient } from "./payload_dnf.js";
+import { PayloadsClient } from "./payloads.js";
+
+const PAYLOADS_OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Payloads";
+const PAYLOADS_INTERFACE = "org.fedoraproject.Anaconda.Modules.Payloads";
+const PAYLOAD_INTERFACE = "org.fedoraproject.Anaconda.Modules.Payloads.Payload";
+const SOURCE_BASE_INTERFACE = "org.fedoraproject.Anaconda.Modules.Payloads.Source";
+const SOURCE_REPOSITORY_INTERFACE = "org.fedoraproject.Anaconda.Modules.Payloads.Source.Repository";
+const SOURCE_CLOSEST_MIRROR_INTERFACE = "org.fedoraproject.Anaconda.Modules.Payloads.Source.ClosestMirror";
+const SOURCE_CDROM_INTERFACE = "org.fedoraproject.Anaconda.Modules.Payloads.Source.CDROM";
+const SOURCE_REPO_PATH_INTERFACE = "org.fedoraproject.Anaconda.Modules.Payloads.Source.RepoPath";
+
+const getClient = () => new PayloadsClient().client;
+
+const getPayloadPath = () => PayloadDNFClient.instance.payload;
+
+/**
+ * Create a new source of the given type.
+ * @param {string} sourceType - e.g. "URL"
+ * @returns {Promise<string>} D-Bus object path of the created source
+ */
+export const createSource = async (sourceType) => {
+    return getClient().call(
+        PAYLOADS_OBJECT_PATH, PAYLOADS_INTERFACE, "CreateSource", [sourceType]
+    )
+            .then(res => res[0]);
+};
+
+/**
+ * Get the list of source object paths attached to the current payload.
+ * @returns {Promise<string[]>}
+ */
+export const getPayloadSources = async () => {
+    return _getProperty(
+        PayloadsClient, getPayloadPath(), PAYLOAD_INTERFACE, "Sources"
+    );
+};
+
+/**
+ * Set the sources on the current payload.
+ * @param {string[]} sources - Array of source D-Bus object paths
+ */
+export const setPayloadSources = async (sources) => {
+    return getClient().call(
+        getPayloadPath(), "org.freedesktop.DBus.Properties", "Set",
+        [PAYLOAD_INTERFACE, "Sources", cockpit.variant("ao", sources)]
+    );
+};
+
+/**
+ * Get the Type property from a source object.
+ * @param {string} sourcePath - D-Bus object path
+ * @returns {Promise<string>}
+ */
+export const getSourceType = async (sourcePath) => {
+    return _getProperty(PayloadsClient, sourcePath, SOURCE_BASE_INTERFACE, "Type");
+};
+
+/**
+ * Get the RepoConfigurationData from a URL source.
+ * @param {string} sourcePath - D-Bus object path
+ * @returns {Promise<Object>} Plain JS object
+ */
+export const getSourceConfiguration = async (sourcePath) => {
+    const structure = await _getProperty(
+        PayloadsClient, sourcePath, SOURCE_REPOSITORY_INTERFACE, "Configuration"
+    );
+    return objectFromDbus(structure);
+};
+
+/**
+ * Set the RepoConfigurationData on a URL source.
+ * @param {string} sourcePath - D-Bus object path
+ * @param {Object} config - Plain JS object with url, type, ssl-verification-enabled
+ */
+export const setSourceConfiguration = async (sourcePath, config) => {
+    const structure = objectToDbus(config);
+    return getClient().call(
+        sourcePath, "org.freedesktop.DBus.Properties", "Set",
+        [SOURCE_REPOSITORY_INTERFACE, "Configuration", cockpit.variant("a{sv}", structure)]
+    );
+};
+
+/**
+ * Get UpdatesEnabled from a closest-mirror source.
+ * @param {string} sourcePath
+ * @returns {Promise<boolean>}
+ */
+export const getUpdatesEnabled = async (sourcePath) => {
+    return _getProperty(
+        PayloadsClient, sourcePath, SOURCE_CLOSEST_MIRROR_INTERFACE, "UpdatesEnabled"
+    );
+};
+
+/**
+ * Set UpdatesEnabled on a closest-mirror source.
+ * @param {string} sourcePath
+ * @param {boolean} enabled
+ */
+export const setUpdatesEnabled = async (sourcePath, enabled) => {
+    return getClient().call(
+        sourcePath, "org.freedesktop.DBus.Properties", "Set",
+        [SOURCE_CLOSEST_MIRROR_INTERFACE, "UpdatesEnabled", cockpit.variant("b", enabled)]
+    );
+};
+
+/**
+ * Run a D-Bus task to completion.
+ * @param {Object} params
+ * @param {string} params.task - D-Bus object path of the task
+ * @returns {Promise<void>}
+ */
+export const runPayloadTask = ({ task }) => {
+    return new Promise((resolve, reject) => {
+        let succeededEmitted = false;
+        const taskProxy = getClient().proxy(
+            "org.fedoraproject.Anaconda.Task",
+            task
+        );
+        const addEventListeners = () => {
+            taskProxy.addEventListener("Stopped", () => taskProxy.Finish().catch(reject));
+            taskProxy.addEventListener("Succeeded", () => {
+                if (succeededEmitted) {
+                    return;
+                }
+                succeededEmitted = true;
+                resolve();
+            });
+        };
+        taskProxy.wait(() => {
+            addEventListeners();
+            taskProxy.Start().catch(reject);
+        });
+    });
+};
+
+/**
+ * Tear down the current sources on the payload.
+ * @returns {Promise<void>}
+ */
+export const tearDownSources = async () => {
+    const task = await getClient().call(
+        getPayloadPath(), PAYLOAD_INTERFACE, "TearDownSourcesWithTask", []
+    )
+            .then(res => res[0]);
+    return runPayloadTask({ task });
+};
+
+/**
+ * Set up the sources on the payload.
+ * @returns {Promise<void>}
+ */
+export const setUpSources = async () => {
+    const task = await getClient().call(
+        getPayloadPath(), PAYLOAD_INTERFACE, "SetUpSourcesWithTask", []
+    )
+            .then(res => res[0]);
+    return runPayloadTask({ task });
+};
+
+/**
+ * Get the DeviceID from a CDROM source.
+ * @param {string} sourcePath
+ * @returns {Promise<string>}
+ */
+export const getCdromDeviceId = async (sourcePath) => {
+    return _getProperty(PayloadsClient, sourcePath, SOURCE_CDROM_INTERFACE, "DeviceID");
+};
+
+/**
+ * Get the Path from a REPO_PATH source.
+ * @param {string} sourcePath
+ * @returns {Promise<string>}
+ */
+export const getRepoPath = async (sourcePath) => {
+    return _getProperty(PayloadsClient, sourcePath, SOURCE_REPO_PATH_INTERFACE, "Path");
+};

--- a/src/apis/payloads.js
+++ b/src/apis/payloads.js
@@ -5,6 +5,7 @@
 import cockpit from "cockpit";
 
 import { setPayloadTypeAction } from "../actions/payload.js";
+import { getPayloadSourceAction } from "../actions/payload-source-actions.js";
 
 import { error } from "../helpers/log.js";
 import { _callClient, _getProperty } from "./helpers.js";
@@ -70,6 +71,7 @@ export class PayloadsClient {
         if (payloadType === "DNF") {
             const dnfClient = new PayloadDNFClient(this.client, this.dispatch, payload);
             await dnfClient.init(args);
+            await this.dispatch(getPayloadSourceAction());
         }
     }
 }

--- a/src/apis/payloads.js
+++ b/src/apis/payloads.js
@@ -5,6 +5,7 @@
 import cockpit from "cockpit";
 
 import { setPayloadTypeAction } from "../actions/payload.js";
+import { getPayloadSourceAction } from "../actions/payload-source-actions.js";
 
 import { error } from "../helpers/log.js";
 import { _callClient, _getProperty } from "./helpers.js";
@@ -66,6 +67,7 @@ export class PayloadsClient {
         if (payloadType === "DNF") {
             const dnfClient = new PayloadDNFClient(this.client, this.dispatch, payload);
             await dnfClient.init(args);
+            await this.dispatch(getPayloadSourceAction());
         }
     }
 }

--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -46,6 +46,7 @@ export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFe
     };
 
     const pageContextValue = {
+        dispatch,
         isFormDisabled: isFormDisabled || isFetching,
         isFormValid,
         setIsFormDisabled,

--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -54,6 +54,7 @@ export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFe
     };
 
     const pageContextValue = {
+        dispatch,
         isFormDisabled: isFormDisabled || isFetching,
         isFormValid,
         setIsFormDisabled,

--- a/src/components/AnacondaWizardFooter.jsx
+++ b/src/components/AnacondaWizardFooter.jsx
@@ -20,9 +20,11 @@ const _ = cockpit.gettext;
 export const AnacondaWizardFooter = ({
     extraActions,
     footerHelperText,
+    isLoading,
     nextButtonText,
     nextButtonVariant,
     onNext,
+    spinnerAriaValueText,
 }) => {
     const [quitWaitsConfirmation, setQuitWaitsConfirmation] = useState(false);
     const { activeStep, goToNextStep, goToPrevStep, steps } = useWizardContext();
@@ -67,6 +69,8 @@ export const AnacondaWizardFooter = ({
                               id="installation-next-btn"
                               variant={nextButtonVariant || "primary"}
                               isAriaDisabled={!isFormValid || isFormDisabled}
+                              isLoading={isLoading || null}
+                              spinnerAriaValueText={isLoading ? (spinnerAriaValueText || _("Loading")) : undefined}
                               onClick={onNextButtonClicked}>
                                 {nextButtonText || _("Next")}
                             </Button>

--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -35,6 +35,9 @@ import { DateAndTimeReviewDescription } from "../datetime/index.js";
 import { usePageComplete as useDatetimePageComplete } from "../datetime/usePageComplete.js";
 import { InstallationLanguageReviewDescription } from "../localization/index.js";
 import { usePageComplete as useLocalizationPageComplete } from "../localization/usePageComplete.js";
+import { SourceReviewDescription } from "../source/index.js";
+import { usePageComplete as useSourcePageComplete } from "../source/usePageComplete.js";
+import { SoftwareReviewDescription } from "../software/index.js";
 import { usePageComplete as useSoftwarePageComplete } from "../software/usePageComplete.js";
 import {
     StorageInstallationReviewSummary,
@@ -85,7 +88,10 @@ export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, p
     const localizationComplete = useLocalizationPageComplete({ isHidden: languagePageHidden });
     const datetimePageHidden = hiddenScreens.includes("anaconda-screen-date-time");
     const datetimeComplete = useDatetimePageComplete({ automatedInstall, isHidden: datetimePageHidden });
-    const { environments, selection, type: payloadType } = useContext(PayloadContext) ?? {};
+    const { type: payloadType } = useContext(PayloadContext) ?? {};
+    const sourcePageHidden =
+        payloadType !== "DNF" || hiddenScreens.includes("anaconda-screen-installation-source");
+    const sourceComplete = useSourcePageComplete({ isHidden: sourcePageHidden });
     const softwarePageHidden =
         payloadType !== "DNF" || hiddenScreens.includes("anaconda-screen-software-selection");
     const softwareSelectionComplete = useSoftwarePageComplete({ automatedInstall, isHidden: softwarePageHidden });
@@ -99,6 +105,7 @@ export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, p
     const pages = [
         { complete: localizationComplete, id: "anaconda-screen-language" },
         { complete: datetimeComplete, id: "anaconda-screen-date-time" },
+        { complete: sourceComplete, id: "anaconda-screen-installation-source" },
         { complete: softwareSelectionComplete, id: "anaconda-screen-software-selection" },
         { complete: storageComplete, id: "anaconda-screen-method" },
         { complete: usersComplete, id: "anaconda-screen-accounts" },
@@ -154,17 +161,13 @@ export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, p
 
     const installationScenarioDescription = <StorageScenarioReviewDescription />;
 
-    const softwareDescription = useMemo(() => {
-        if (!softwareSelectionComplete) {
-            return <IncompleteStepIndicator />;
-        }
-        const envId = selection?.environment;
-        if (!envId) {
-            return "";
-        }
-        const env = environments?.find(e => e.id === envId);
-        return env?.name || envId;
-    }, [softwareSelectionComplete, environments, selection?.environment]);
+    const sourceDescription = sourceComplete
+        ? <SourceReviewDescription />
+        : <IncompleteStepIndicator />;
+
+    const softwareDescription = softwareSelectionComplete
+        ? <SoftwareReviewDescription />
+        : <IncompleteStepIndicator />;
 
     const storageDescription = (
         <Flex direction={{ default: "column" }} spaceItems={{ default: "spaceItemsSm" }}>
@@ -240,6 +243,12 @@ export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, p
                                   id={`${SCREEN_ID}-target-system-timezone`}
                                   term={_("Timezone")}
                                   description={timezoneDescription}
+                                />}
+                                {!sourcePageHidden &&
+                                <ReviewDescriptionListItem
+                                  id={`${SCREEN_ID}-target-system-source`}
+                                  term={_("Installation source")}
+                                  description={sourceDescription}
                                 />}
                                 {!softwarePageHidden &&
                                 <ReviewDescriptionListItem

--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -35,6 +35,9 @@ import { DateAndTimeReviewDescription } from "../datetime/index.js";
 import { usePageComplete as useDatetimePageComplete } from "../datetime/usePageComplete.js";
 import { InstallationLanguageReviewDescription } from "../localization/index.js";
 import { usePageComplete as useLocalizationPageComplete } from "../localization/usePageComplete.js";
+import { SourceReviewDescription } from "../source/index.js";
+import { usePageComplete as useSourcePageComplete } from "../source/usePageComplete.js";
+import { SoftwareReviewDescription } from "../software/index.js";
 import { usePageComplete as useSoftwarePageComplete } from "../software/usePageComplete.js";
 import {
     StorageInstallationReviewSummary,
@@ -85,7 +88,10 @@ export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, g
     const localizationComplete = useLocalizationPageComplete({ automatedInstall, isHidden: languagePageHidden });
     const datetimePageHidden = hiddenScreens.includes("anaconda-screen-date-time");
     const datetimeComplete = useDatetimePageComplete({ automatedInstall, isHidden: datetimePageHidden });
-    const { environments, selection, type: payloadType } = useContext(PayloadContext) ?? {};
+    const { type: payloadType } = useContext(PayloadContext) ?? {};
+    const sourcePageHidden =
+        payloadType !== "DNF" || hiddenScreens.includes("anaconda-screen-installation-source");
+    const sourceComplete = useSourcePageComplete({ isHidden: sourcePageHidden });
     const softwarePageHidden =
         payloadType !== "DNF" || hiddenScreens.includes("anaconda-screen-software-selection");
     const softwareSelectionComplete = useSoftwarePageComplete({ automatedInstall, isHidden: softwarePageHidden });
@@ -99,6 +105,7 @@ export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, g
     const pages = [
         { complete: localizationComplete, id: "anaconda-screen-language" },
         { complete: datetimeComplete, id: "anaconda-screen-date-time" },
+        { complete: sourceComplete, id: "anaconda-screen-installation-source" },
         { complete: softwareSelectionComplete, id: "anaconda-screen-software-selection" },
         { complete: storageComplete, id: "anaconda-screen-method" },
         { complete: usersComplete, id: "anaconda-screen-accounts" },
@@ -153,17 +160,13 @@ export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, g
 
     const installationScenarioDescription = <StorageScenarioReviewDescription />;
 
-    const softwareDescription = useMemo(() => {
-        if (!softwareSelectionComplete) {
-            return <IncompleteStepIndicator />;
-        }
-        const envId = selection?.environment;
-        if (!envId) {
-            return "";
-        }
-        const env = environments?.find(e => e.id === envId);
-        return env?.name || envId;
-    }, [softwareSelectionComplete, environments, selection?.environment]);
+    const sourceDescription = sourceComplete
+        ? <SourceReviewDescription />
+        : <IncompleteStepIndicator />;
+
+    const softwareDescription = softwareSelectionComplete
+        ? <SoftwareReviewDescription />
+        : <IncompleteStepIndicator />;
 
     const storageDescription = (
         <Flex direction={{ default: "column" }} spaceItems={{ default: "spaceItemsSm" }}>
@@ -239,6 +242,12 @@ export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, g
                                   id={`${SCREEN_ID}-target-system-timezone`}
                                   term={_("Timezone")}
                                   description={timezoneDescription}
+                                />}
+                                {!sourcePageHidden &&
+                                <ReviewDescriptionListItem
+                                  id={`${SCREEN_ID}-target-system-source`}
+                                  term={_("Installation source")}
+                                  description={sourceDescription}
                                 />}
                                 {!softwarePageHidden &&
                                 <ReviewDescriptionListItem

--- a/src/components/software/SoftwareReviewDescription.jsx
+++ b/src/components/software/SoftwareReviewDescription.jsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+import { useContext, useMemo } from "react";
+
+import { PayloadContext } from "../../contexts/Common.jsx";
+
+/** Review description body for the software selection step (incomplete UI is chosen in ReviewConfiguration). */
+export const SoftwareReviewDescription = () => {
+    const { environments, selection } = useContext(PayloadContext) ?? {};
+
+    return useMemo(() => {
+        const envId = selection?.environment;
+        if (!envId) {
+            return "";
+        }
+        const env = environments?.find(e => e.id === envId);
+        return env?.name || envId;
+    }, [environments, selection?.environment]);
+};

--- a/src/components/software/SoftwareSelection.jsx
+++ b/src/components/software/SoftwareSelection.jsx
@@ -5,14 +5,24 @@
 
 import cockpit from "cockpit";
 
-import React, { useContext, useEffect, useMemo } from "react";
+import React, { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { Alert } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { useWizardFooter } from "@patternfly/react-core/dist/esm/components/Wizard/index.js";
 import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 
-import { getDefaultEnvironment, resolveEnvironment, setPackagesSelection } from "../../apis/payload_dnf.js";
+import {
+    resolveEnvironment,
+    setPackagesSelection,
+} from "../../apis/payload_dnf.js";
+
+import {
+    getPayloadGroupsAction,
+} from "../../actions/payload-dnf-actions.js";
 
 import { PageContext, PayloadContext } from "../../contexts/Common.jsx";
 
+import { AnacondaWizardFooter } from "../AnacondaWizardFooter.jsx";
 import { MenuSearch } from "../common/MenuSearch.jsx";
 
 import "./SoftwareSelection.scss";
@@ -20,19 +30,12 @@ import "./SoftwareSelection.scss";
 const _ = cockpit.gettext;
 const SCREEN_ID = "anaconda-screen-software-selection";
 
-const EnvironmentSelection = () => {
-    const { environments, selection } = useContext(PayloadContext);
-    const environment = selection?.environment;
-
-    useEffect(() => {
-        (async () => {
-            if (!environment) {
-                const defaultEnv = await getDefaultEnvironment();
-                await setPackagesSelection({ environment: defaultEnv, groups: [] });
-            }
-        })();
-    }, [environment]);
-
+const EnvironmentSelection = ({
+    environment,
+    environments,
+    onEnvironmentSelect,
+    selectionError,
+}) => {
     const options = useMemo(() => {
         if (!environments) {
             return [];
@@ -52,19 +55,23 @@ const EnvironmentSelection = () => {
         }));
     }, [environments]);
 
-    const handleOnSelect = (_ev, itemId) => {
-        // Reset groups selection when changing environment
-        setPackagesSelection({ environment: itemId, groups: [] });
-    };
-
     return (
         <FormGroup
           className="anaconda-screen-software-selection-form-group"
           label={_("Base environment")}
         >
+            {selectionError && (
+                <Alert
+                  isInline
+                  title={_("Failed to load the selected environment")}
+                  variant="danger"
+                >
+                    {selectionError}
+                </Alert>
+            )}
             <MenuSearch
               ariaLabelSearch={_("Search for an environment")}
-              handleOnSelect={handleOnSelect}
+              handleOnSelect={(_ev, itemId) => onEnvironmentSelect(itemId)}
               menuType="environment"
               options={options}
               screenId={SCREEN_ID}
@@ -74,10 +81,11 @@ const EnvironmentSelection = () => {
     );
 };
 
-const GroupPackagesSelection = () => {
-    const { groups, selection } = useContext(PayloadContext);
-    const selectedGroups = selection?.groups || [];
-
+const GroupPackagesSelection = ({
+    groups,
+    onGroupSelect,
+    selectedGroups,
+}) => {
     const groupOptions = useMemo(() => {
         if (!groups) {
             return [];
@@ -137,19 +145,6 @@ const GroupPackagesSelection = () => {
         return options;
     }, [groups]);
 
-    const handleGroupSelect = async (_ev, groupId) => {
-        // Toggle selection
-        let newSelectedGroups;
-        if (selectedGroups.includes(groupId)) {
-            newSelectedGroups = selectedGroups.filter(id => id !== groupId);
-        } else {
-            newSelectedGroups = [...selectedGroups, groupId];
-        }
-
-        // Update packages selection
-        await setPackagesSelection({ groups: newSelectedGroups });
-    };
-
     return (
         <FormGroup
           className="anaconda-screen-software-selection-form-group"
@@ -157,7 +152,7 @@ const GroupPackagesSelection = () => {
         >
             <MenuSearch
               ariaLabelSearch={_("Search for additional software")}
-              handleOnSelect={handleGroupSelect}
+              handleOnSelect={(_ev, groupId) => onGroupSelect(groupId)}
               menuType="groups"
               options={groupOptions}
               screenId={SCREEN_ID}
@@ -167,38 +162,138 @@ const GroupPackagesSelection = () => {
     );
 };
 
-export const SoftwareSelection = ({ automatedInstall }) => {
-    const { setIsFormValid } = useContext(PageContext) ?? {};
-    const { packagesKickstarted, selection } = useContext(PayloadContext);
-    const environment = selection?.environment;
+const SoftwareSelectionFooter = ({ applyCurrentSelection }) => {
+    const { setIsFormDisabled } = useContext(PageContext) ?? {};
 
-    /*
-     * Match pyanaconda.ui.lib.software.is_software_selection_complete (and GTK spoke `completed`).
-     * kickstarted=True in Anaconda means flags.automatedInstall and payload PackagesKickstarted.
-     */
+    const onNext = async ({ goToNextStep }) => {
+        setIsFormDisabled?.(true);
+        try {
+            await applyCurrentSelection();
+            goToNextStep();
+        } catch {
+            // Error alert is shown by applyCurrentSelection.
+        } finally {
+            setIsFormDisabled?.(false);
+        }
+    };
+
+    return <AnacondaWizardFooter onNext={onNext} />;
+};
+
+export const SoftwareSelection = ({ automatedInstall, dispatch }) => {
+    const { setIsFormDisabled, setIsFormValid } = useContext(PageContext) ?? {};
+    const { environments, groups, packagesKickstarted, selection } = useContext(PayloadContext);
+
+    const [localSelection, setLocalSelection] = useState({
+        environment: selection?.environment || "",
+        groups: selection?.groups || [],
+        isEnvironmentValid: Boolean(selection?.environment),
+    });
+    const [selectionError, setSelectionError] = useState(null);
+    const [applyError, setApplyError] = useState(null);
+
+    useEffect(() => {
+        setIsFormDisabled?.(false);
+    }, [setIsFormDisabled]);
+
+    const handleEnvironmentSelect = useCallback(async (itemId) => {
+        setSelectionError(null);
+        setApplyError(null);
+
+        try {
+            const resolved = await resolveEnvironment(itemId);
+            if (!resolved) {
+                setSelectionError(_("The selected environment is not available from the current installation source."));
+                setLocalSelection({ environment: "", groups: [], isEnvironmentValid: false });
+                return;
+            }
+
+            setLocalSelection({
+                environment: resolved,
+                groups: [],
+                isEnvironmentValid: true,
+            });
+            await dispatch(getPayloadGroupsAction(resolved));
+        } catch (e) {
+            setSelectionError(e.message || String(e));
+            setLocalSelection(current => ({ ...current, isEnvironmentValid: false }));
+        }
+    }, [dispatch]);
+
+    const handleGroupSelect = useCallback((groupId) => {
+        setLocalSelection((current) => {
+            const selectedGroups = current.groups || [];
+            const nextGroups = selectedGroups.includes(groupId)
+                ? selectedGroups.filter(id => id !== groupId)
+                : [...selectedGroups, groupId];
+            return { ...current, groups: nextGroups };
+        });
+    }, []);
+
+    const applyCurrentSelection = useCallback(async () => {
+        setApplyError(null);
+        try {
+            await setPackagesSelection({
+                environment: localSelection.environment,
+                groups: localSelection.groups || [],
+            });
+        } catch (e) {
+            setApplyError(e.message || String(e));
+            throw e;
+        }
+    }, [localSelection]);
+
+    const footer = useMemo(
+        () => <SoftwareSelectionFooter applyCurrentSelection={applyCurrentSelection} />,
+        [applyCurrentSelection]
+    );
+    useWizardFooter(footer);
+
     useEffect(() => {
         const kickstarted =
             packagesKickstarted === true && automatedInstall === true;
 
-        (async () => {
-            if (kickstarted && !environment) {
-                setIsFormValid(true);
-                return;
-            }
-            if (!environment) {
-                setIsFormValid(false);
-                return;
-            }
-            const resolved = await resolveEnvironment(environment);
-            setIsFormValid(Boolean(resolved));
-        })();
-    }, [environment, packagesKickstarted, automatedInstall, setIsFormValid]);
+        if (kickstarted && !localSelection.environment) {
+            setIsFormValid(true);
+            return;
+        }
+        if (!localSelection.environment) {
+            setIsFormValid(false);
+            return;
+        }
+
+        setIsFormValid(localSelection.isEnvironmentValid);
+    }, [
+        automatedInstall,
+        localSelection.environment,
+        localSelection.isEnvironmentValid,
+        packagesKickstarted,
+        setIsFormValid,
+    ]);
 
     return (
         <Form>
+            {applyError && (
+                <Alert
+                  isInline
+                  title={_("Failed to save software selection")}
+                  variant="danger"
+                >
+                    {applyError}
+                </Alert>
+            )}
             <Flex spaceItems={{ default: "spaceItemsXl" }}>
-                <EnvironmentSelection />
-                <GroupPackagesSelection />
+                <EnvironmentSelection
+                  environment={localSelection.environment}
+                  environments={environments}
+                  onEnvironmentSelect={handleEnvironmentSelect}
+                  selectionError={selectionError}
+                />
+                <GroupPackagesSelection
+                  groups={groups}
+                  onGroupSelect={handleGroupSelect}
+                  selectedGroups={localSelection.groups || []}
+                />
             </Flex>
         </Form>
     );

--- a/src/components/software/index.js
+++ b/src/components/software/index.js
@@ -6,8 +6,11 @@
 import cockpit from "cockpit";
 
 import { SoftwareSelection } from "./SoftwareSelection.jsx";
+import { SoftwareReviewDescription } from "./SoftwareReviewDescription.jsx";
 
 const _ = cockpit.gettext;
+
+export { SoftwareReviewDescription };
 
 export class Page {
     _description = "Select packages to install by choosing a base environment.";

--- a/src/components/source/InstallationSource.jsx
+++ b/src/components/source/InstallationSource.jsx
@@ -21,7 +21,7 @@ import {
 } from "../../apis/payload_source.js";
 
 import { refreshPayloadSoftwareSelectionAction } from "../../actions/payload-dnf-actions.js";
-import { getPayloadSourceAction } from "../../actions/payload-source-actions.js";
+import { getPayloadSourceAction, setSourceApplyPendingAction } from "../../actions/payload-source-actions.js";
 
 import { PageContext, PayloadContext } from "../../contexts/Common.jsx";
 
@@ -125,12 +125,12 @@ const buildDesiredSource = ({ protocol, url, urlType }) => {
     };
 };
 
-const InstallationSourceFooter = ({ applyCurrentSource, isDirty }) => {
+const InstallationSourceFooter = ({ applyCurrentSource, needsApply }) => {
     const { setIsFormDisabled } = useContext(PageContext) ?? {};
     const [isLoading, setIsLoading] = useState(false);
 
     const onNext = async ({ goToNextStep }) => {
-        if (!isDirty) {
+        if (!needsApply) {
             goToNextStep();
             return;
         }
@@ -159,7 +159,7 @@ const InstallationSourceFooter = ({ applyCurrentSource, isDirty }) => {
 
 export const InstallationSource = ({ dispatch }) => {
     const { isFormDisabled, setIsFormValid, setStepNotification } = useContext(PageContext) ?? {};
-    const { source } = useContext(PayloadContext);
+    const { source, sourceApplyPending } = useContext(PayloadContext);
 
     const [protocol, setProtocol] = useState(PROTOCOL_CLOSEST_MIRROR);
     const [url, setUrl] = useState("");
@@ -224,7 +224,9 @@ export const InstallationSource = ({ dispatch }) => {
             await setUpSources();
             await dispatch(getPayloadSourceAction());
             await dispatch(refreshPayloadSoftwareSelectionAction());
+            dispatch(setSourceApplyPendingAction(false));
         } catch (e) {
+            dispatch(setSourceApplyPendingAction(true));
             setStepNotification?.({
                 message: e.message || String(e),
                 step: SCREEN_ID,
@@ -253,24 +255,26 @@ export const InstallationSource = ({ dispatch }) => {
         );
     }, [initialUiState, uiState]);
 
+    const needsApply = isDirty || sourceApplyPending;
+
     const applyCurrentSource = useCallback(async () => {
-        if (!isDirty) {
+        if (!needsApply) {
             return;
         }
 
         const desired = buildDesiredSource(uiState);
         await applySource(desired);
         setInitialUiState(uiState);
-    }, [applySource, isDirty, uiState]);
+    }, [applySource, needsApply, uiState]);
 
     const footer = useMemo(
         () => (
             <InstallationSourceFooter
               applyCurrentSource={applyCurrentSource}
-              isDirty={isDirty}
+              needsApply={needsApply}
             />
         ),
-        [applyCurrentSource, isDirty]
+        [applyCurrentSource, needsApply]
     );
     useWizardFooter(footer);
 

--- a/src/components/source/InstallationSource.jsx
+++ b/src/components/source/InstallationSource.jsx
@@ -1,0 +1,336 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import cockpit from "cockpit";
+
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect/index.js";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
+import { useWizardFooter } from "@patternfly/react-core/dist/esm/components/Wizard/index.js";
+
+import {
+    createSource,
+    setPayloadSources,
+    setSourceConfiguration,
+    setUpSources,
+    setUpdatesEnabled,
+    tearDownSources,
+} from "../../apis/payload_source.js";
+
+import { refreshPayloadSoftwareSelectionAction } from "../../actions/payload-dnf-actions.js";
+import { getPayloadSourceAction, setSourceApplyPendingAction } from "../../actions/payload-source-actions.js";
+
+import { PageContext, PayloadContext } from "../../contexts/Common.jsx";
+
+import { AnacondaWizardFooter } from "../AnacondaWizardFooter.jsx";
+
+import "./InstallationSource.scss";
+
+const _ = cockpit.gettext;
+const SCREEN_ID = "anaconda-screen-installation-source";
+
+const PROTOCOL_HTTP = "http";
+const PROTOCOL_HTTPS = "https";
+const PROTOCOL_CLOSEST_MIRROR = "closest-mirror";
+
+const PROTOCOLS = [
+    { label: _("Closest mirror"), value: PROTOCOL_CLOSEST_MIRROR },
+    { label: "http://", value: PROTOCOL_HTTP },
+    { label: "https://", value: PROTOCOL_HTTPS },
+];
+
+const URL_TYPES = [
+    { label: _("Repository URL"), value: "BASEURL" },
+    { label: _("Mirrorlist"), value: "MIRRORLIST" },
+    { label: _("Metalink"), value: "METALINK" },
+];
+
+const isClosestMirrorProtocol = (protocol) => protocol === PROTOCOL_CLOSEST_MIRROR;
+
+const parseHttpUrl = (fullUrl) => {
+    if (!fullUrl) {
+        return { path: "", protocol: PROTOCOL_HTTPS };
+    }
+    for (const proto of [PROTOCOL_HTTP, PROTOCOL_HTTPS]) {
+        const prefix = proto + "://";
+        if (fullUrl.startsWith(prefix)) {
+            return { path: fullUrl.substring(prefix.length), protocol: proto };
+        }
+    }
+    return { path: fullUrl, protocol: PROTOCOL_HTTPS };
+};
+
+const buildHttpUrl = (protocol, path) => {
+    if (!path) {
+        return "";
+    }
+    let clean = path;
+    for (const proto of [PROTOCOL_HTTP, PROTOCOL_HTTPS]) {
+        const prefix = proto + "://";
+        if (clean.startsWith(prefix)) {
+            clean = clean.substring(prefix.length);
+            break;
+        }
+    }
+    return `${protocol}://${clean}`;
+};
+
+const uiStateFromSource = (source) => {
+    if (source?.sourceType === "CLOSEST_MIRROR") {
+        return {
+            protocol: PROTOCOL_CLOSEST_MIRROR,
+            url: "",
+            urlType: "BASEURL",
+        };
+    }
+
+    if (source?.sourceType === "URL" && source.configuration?.url) {
+        const parsed = parseHttpUrl(source.configuration.url);
+        return {
+            protocol: parsed.protocol,
+            url: parsed.path,
+            urlType: source.configuration.type || "BASEURL",
+        };
+    }
+
+    return {
+        protocol: PROTOCOL_CLOSEST_MIRROR,
+        url: "",
+        urlType: "BASEURL",
+    };
+};
+
+const buildDesiredSource = ({ protocol, url, urlType }) => {
+    if (isClosestMirrorProtocol(protocol)) {
+        return {
+            config: {
+                updatesEnabled: true,
+            },
+            sourceType: "CLOSEST_MIRROR",
+        };
+    }
+
+    return {
+        config: {
+            repoConfig: {
+                "ssl-verification-enabled": true,
+                type: urlType,
+                url: buildHttpUrl(protocol, url.trim()),
+            },
+        },
+        sourceType: "URL",
+    };
+};
+
+const InstallationSourceFooter = ({ applyCurrentSource, needsApply }) => {
+    const { setIsFormDisabled } = useContext(PageContext) ?? {};
+    const [isLoading, setIsLoading] = useState(false);
+
+    const onNext = async ({ goToNextStep }) => {
+        if (!needsApply) {
+            goToNextStep();
+            return;
+        }
+
+        setIsLoading(true);
+        setIsFormDisabled?.(true);
+        try {
+            await applyCurrentSource();
+            goToNextStep();
+        } catch {
+            // Step notification is shown by applyCurrentSource.
+        } finally {
+            setIsLoading(false);
+            setIsFormDisabled?.(false);
+        }
+    };
+
+    return (
+        <AnacondaWizardFooter
+          isLoading={isLoading}
+          onNext={onNext}
+          spinnerAriaValueText={_("Setting up installation source")}
+        />
+    );
+};
+
+export const InstallationSource = ({ dispatch }) => {
+    const { isFormDisabled, setIsFormValid, setStepNotification } = useContext(PageContext) ?? {};
+    const { source, sourceApplyPending } = useContext(PayloadContext);
+
+    const [protocol, setProtocol] = useState(PROTOCOL_CLOSEST_MIRROR);
+    const [url, setUrl] = useState("");
+    const [urlType, setUrlType] = useState("BASEURL");
+    const [initialUiState, setInitialUiState] = useState(null);
+
+    const [initialized, setInitialized] = useState(false);
+    const applyingRef = useRef(false);
+
+    const isClosestMirror = isClosestMirrorProtocol(protocol);
+
+    const handleProtocolChange = useCallback((_ev, val) => {
+        setProtocol(val);
+        if (isClosestMirrorProtocol(val)) {
+            setUrl("");
+            setUrlType("BASEURL");
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!source || initialized) {
+            return;
+        }
+
+        const nextUiState = uiStateFromSource(source);
+        setProtocol(nextUiState.protocol);
+        setUrl(nextUiState.url);
+        setUrlType(nextUiState.urlType);
+        setInitialUiState(nextUiState);
+        setInitialized(true);
+    }, [source, initialized]);
+
+    useEffect(() => {
+        if (!setIsFormValid) {
+            return;
+        }
+        if (!initialized) {
+            setIsFormValid(false);
+            return;
+        }
+        setIsFormValid(isClosestMirror || url.trim().length > 0);
+    }, [initialized, isClosestMirror, setIsFormValid, url]);
+
+    const applySource = useCallback(async (desired) => {
+        if (applyingRef.current) {
+            return;
+        }
+
+        applyingRef.current = true;
+        setStepNotification?.(null);
+        try {
+            await tearDownSources();
+
+            const sourcePath = await createSource(desired.sourceType);
+            if (desired.sourceType === "URL") {
+                await setSourceConfiguration(sourcePath, desired.config.repoConfig);
+            } else {
+                await setUpdatesEnabled(sourcePath, desired.config.updatesEnabled);
+            }
+
+            await setPayloadSources([sourcePath]);
+            await setUpSources();
+            await dispatch(getPayloadSourceAction());
+            await dispatch(refreshPayloadSoftwareSelectionAction());
+            dispatch(setSourceApplyPendingAction(false));
+        } catch (e) {
+            dispatch(setSourceApplyPendingAction(true));
+            setStepNotification?.({
+                message: e.message || String(e),
+                step: SCREEN_ID,
+                title: _("Failed to configure installation source"),
+            });
+            throw e;
+        } finally {
+            applyingRef.current = false;
+        }
+    }, [dispatch, setStepNotification]);
+
+    const uiState = useMemo(() => ({
+        protocol,
+        url,
+        urlType,
+    }), [protocol, url, urlType]);
+
+    const isDirty = useMemo(() => {
+        if (!initialUiState) {
+            return false;
+        }
+        return (
+            uiState.protocol !== initialUiState.protocol ||
+            uiState.url !== initialUiState.url ||
+            uiState.urlType !== initialUiState.urlType
+        );
+    }, [initialUiState, uiState]);
+
+    const needsApply = isDirty || sourceApplyPending;
+
+    const applyCurrentSource = useCallback(async () => {
+        if (!needsApply) {
+            return;
+        }
+
+        const desired = buildDesiredSource(uiState);
+        await applySource(desired);
+        setInitialUiState(uiState);
+    }, [applySource, needsApply, uiState]);
+
+    const footer = useMemo(
+        () => (
+            <InstallationSourceFooter
+              applyCurrentSource={applyCurrentSource}
+              needsApply={needsApply}
+            />
+        ),
+        [applyCurrentSource, needsApply]
+    );
+    useWizardFooter(footer);
+
+    return (
+        <Form id={SCREEN_ID}>
+            <FormGroup
+              fieldId={SCREEN_ID + "-url"}
+              label={_("URL")}
+            >
+                <div className="source-url-row">
+                    <FormSelect
+                      className="source-protocol-select"
+                      id={SCREEN_ID + "-protocol"}
+                      isDisabled={isFormDisabled}
+                      onChange={handleProtocolChange}
+                      value={protocol}
+                    >
+                        {PROTOCOLS.map(p => (
+                            <FormSelectOption
+                              key={p.value}
+                              label={p.label}
+                              value={p.value}
+                            />
+                        ))}
+                    </FormSelect>
+                    <TextInput
+                      className="source-url-input"
+                      id={SCREEN_ID + "-url"}
+                      isDisabled={isFormDisabled || isClosestMirror}
+                      onChange={(_ev, val) => setUrl(val)}
+                      placeholder={isClosestMirror ? _("Closest public mirror") : ""}
+                      value={url}
+                    />
+                </div>
+            </FormGroup>
+            <FormGroup
+              fieldId={SCREEN_ID + "-url-type"}
+              label={_("URL type")}
+            >
+                <div className="source-field-select">
+                    <FormSelect
+                      id={SCREEN_ID + "-url-type"}
+                      isDisabled={isFormDisabled || isClosestMirror}
+                      onChange={(_ev, val) => setUrlType(val)}
+                      value={urlType}
+                    >
+                        {URL_TYPES.map(t => (
+                            <FormSelectOption
+                              key={t.value}
+                              label={t.label}
+                              value={t.value}
+                            />
+                        ))}
+                    </FormSelect>
+                </div>
+            </FormGroup>
+        </Form>
+    );
+};

--- a/src/components/source/InstallationSource.jsx
+++ b/src/components/source/InstallationSource.jsx
@@ -1,0 +1,332 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import cockpit from "cockpit";
+
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect/index.js";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
+import { useWizardFooter } from "@patternfly/react-core/dist/esm/components/Wizard/index.js";
+
+import {
+    createSource,
+    setPayloadSources,
+    setSourceConfiguration,
+    setUpSources,
+    setUpdatesEnabled,
+    tearDownSources,
+} from "../../apis/payload_source.js";
+
+import { refreshPayloadSoftwareSelectionAction } from "../../actions/payload-dnf-actions.js";
+import { getPayloadSourceAction } from "../../actions/payload-source-actions.js";
+
+import { PageContext, PayloadContext } from "../../contexts/Common.jsx";
+
+import { AnacondaWizardFooter } from "../AnacondaWizardFooter.jsx";
+
+import "./InstallationSource.scss";
+
+const _ = cockpit.gettext;
+const SCREEN_ID = "anaconda-screen-installation-source";
+
+const PROTOCOL_HTTP = "http";
+const PROTOCOL_HTTPS = "https";
+const PROTOCOL_CLOSEST_MIRROR = "closest-mirror";
+
+const PROTOCOLS = [
+    { label: _("Closest mirror"), value: PROTOCOL_CLOSEST_MIRROR },
+    { label: "http://", value: PROTOCOL_HTTP },
+    { label: "https://", value: PROTOCOL_HTTPS },
+];
+
+const URL_TYPES = [
+    { label: _("Repository URL"), value: "BASEURL" },
+    { label: _("Mirrorlist"), value: "MIRRORLIST" },
+    { label: _("Metalink"), value: "METALINK" },
+];
+
+const isClosestMirrorProtocol = (protocol) => protocol === PROTOCOL_CLOSEST_MIRROR;
+
+const parseHttpUrl = (fullUrl) => {
+    if (!fullUrl) {
+        return { path: "", protocol: PROTOCOL_HTTPS };
+    }
+    for (const proto of [PROTOCOL_HTTP, PROTOCOL_HTTPS]) {
+        const prefix = proto + "://";
+        if (fullUrl.startsWith(prefix)) {
+            return { path: fullUrl.substring(prefix.length), protocol: proto };
+        }
+    }
+    return { path: fullUrl, protocol: PROTOCOL_HTTPS };
+};
+
+const buildHttpUrl = (protocol, path) => {
+    if (!path) {
+        return "";
+    }
+    let clean = path;
+    for (const proto of [PROTOCOL_HTTP, PROTOCOL_HTTPS]) {
+        const prefix = proto + "://";
+        if (clean.startsWith(prefix)) {
+            clean = clean.substring(prefix.length);
+            break;
+        }
+    }
+    return `${protocol}://${clean}`;
+};
+
+const uiStateFromSource = (source) => {
+    if (source?.sourceType === "CLOSEST_MIRROR") {
+        return {
+            protocol: PROTOCOL_CLOSEST_MIRROR,
+            url: "",
+            urlType: "BASEURL",
+        };
+    }
+
+    if (source?.sourceType === "URL" && source.configuration?.url) {
+        const parsed = parseHttpUrl(source.configuration.url);
+        return {
+            protocol: parsed.protocol,
+            url: parsed.path,
+            urlType: source.configuration.type || "BASEURL",
+        };
+    }
+
+    return {
+        protocol: PROTOCOL_CLOSEST_MIRROR,
+        url: "",
+        urlType: "BASEURL",
+    };
+};
+
+const buildDesiredSource = ({ protocol, url, urlType }) => {
+    if (isClosestMirrorProtocol(protocol)) {
+        return {
+            config: {
+                updatesEnabled: true,
+            },
+            sourceType: "CLOSEST_MIRROR",
+        };
+    }
+
+    return {
+        config: {
+            repoConfig: {
+                "ssl-verification-enabled": true,
+                type: urlType,
+                url: buildHttpUrl(protocol, url.trim()),
+            },
+        },
+        sourceType: "URL",
+    };
+};
+
+const InstallationSourceFooter = ({ applyCurrentSource, isDirty }) => {
+    const { setIsFormDisabled } = useContext(PageContext) ?? {};
+    const [isLoading, setIsLoading] = useState(false);
+
+    const onNext = async ({ goToNextStep }) => {
+        if (!isDirty) {
+            goToNextStep();
+            return;
+        }
+
+        setIsLoading(true);
+        setIsFormDisabled?.(true);
+        try {
+            await applyCurrentSource();
+            goToNextStep();
+        } catch {
+            // Step notification is shown by applyCurrentSource.
+        } finally {
+            setIsLoading(false);
+            setIsFormDisabled?.(false);
+        }
+    };
+
+    return (
+        <AnacondaWizardFooter
+          isLoading={isLoading}
+          onNext={onNext}
+          spinnerAriaValueText={_("Setting up installation source")}
+        />
+    );
+};
+
+export const InstallationSource = ({ dispatch }) => {
+    const { isFormDisabled, setIsFormValid, setStepNotification } = useContext(PageContext) ?? {};
+    const { source } = useContext(PayloadContext);
+
+    const [protocol, setProtocol] = useState(PROTOCOL_CLOSEST_MIRROR);
+    const [url, setUrl] = useState("");
+    const [urlType, setUrlType] = useState("BASEURL");
+    const [initialUiState, setInitialUiState] = useState(null);
+
+    const [initialized, setInitialized] = useState(false);
+    const applyingRef = useRef(false);
+
+    const isClosestMirror = isClosestMirrorProtocol(protocol);
+
+    const handleProtocolChange = useCallback((_ev, val) => {
+        setProtocol(val);
+        if (isClosestMirrorProtocol(val)) {
+            setUrl("");
+            setUrlType("BASEURL");
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!source || initialized) {
+            return;
+        }
+
+        const nextUiState = uiStateFromSource(source);
+        setProtocol(nextUiState.protocol);
+        setUrl(nextUiState.url);
+        setUrlType(nextUiState.urlType);
+        setInitialUiState(nextUiState);
+        setInitialized(true);
+    }, [source, initialized]);
+
+    useEffect(() => {
+        if (!setIsFormValid) {
+            return;
+        }
+        if (!initialized) {
+            setIsFormValid(false);
+            return;
+        }
+        setIsFormValid(isClosestMirror || url.trim().length > 0);
+    }, [initialized, isClosestMirror, setIsFormValid, url]);
+
+    const applySource = useCallback(async (desired) => {
+        if (applyingRef.current) {
+            return;
+        }
+
+        applyingRef.current = true;
+        setStepNotification?.(null);
+        try {
+            await tearDownSources();
+
+            const sourcePath = await createSource(desired.sourceType);
+            if (desired.sourceType === "URL") {
+                await setSourceConfiguration(sourcePath, desired.config.repoConfig);
+            } else {
+                await setUpdatesEnabled(sourcePath, desired.config.updatesEnabled);
+            }
+
+            await setPayloadSources([sourcePath]);
+            await setUpSources();
+            await dispatch(getPayloadSourceAction());
+            await dispatch(refreshPayloadSoftwareSelectionAction());
+        } catch (e) {
+            setStepNotification?.({
+                message: e.message || String(e),
+                step: SCREEN_ID,
+                title: _("Failed to configure installation source"),
+            });
+            throw e;
+        } finally {
+            applyingRef.current = false;
+        }
+    }, [dispatch, setStepNotification]);
+
+    const uiState = useMemo(() => ({
+        protocol,
+        url,
+        urlType,
+    }), [protocol, url, urlType]);
+
+    const isDirty = useMemo(() => {
+        if (!initialUiState) {
+            return false;
+        }
+        return (
+            uiState.protocol !== initialUiState.protocol ||
+            uiState.url !== initialUiState.url ||
+            uiState.urlType !== initialUiState.urlType
+        );
+    }, [initialUiState, uiState]);
+
+    const applyCurrentSource = useCallback(async () => {
+        if (!isDirty) {
+            return;
+        }
+
+        const desired = buildDesiredSource(uiState);
+        await applySource(desired);
+        setInitialUiState(uiState);
+    }, [applySource, isDirty, uiState]);
+
+    const footer = useMemo(
+        () => (
+            <InstallationSourceFooter
+              applyCurrentSource={applyCurrentSource}
+              isDirty={isDirty}
+            />
+        ),
+        [applyCurrentSource, isDirty]
+    );
+    useWizardFooter(footer);
+
+    return (
+        <Form id={SCREEN_ID}>
+            <FormGroup
+              fieldId={SCREEN_ID + "-url"}
+              label={_("URL")}
+            >
+                <div className="source-url-row">
+                    <FormSelect
+                      className="source-protocol-select"
+                      id={SCREEN_ID + "-protocol"}
+                      isDisabled={isFormDisabled}
+                      onChange={handleProtocolChange}
+                      value={protocol}
+                    >
+                        {PROTOCOLS.map(p => (
+                            <FormSelectOption
+                              key={p.value}
+                              label={p.label}
+                              value={p.value}
+                            />
+                        ))}
+                    </FormSelect>
+                    <TextInput
+                      className="source-url-input"
+                      id={SCREEN_ID + "-url"}
+                      isDisabled={isFormDisabled || isClosestMirror}
+                      onChange={(_ev, val) => setUrl(val)}
+                      placeholder={isClosestMirror ? _("Closest public mirror") : ""}
+                      value={url}
+                    />
+                </div>
+            </FormGroup>
+            <FormGroup
+              fieldId={SCREEN_ID + "-url-type"}
+              label={_("URL type")}
+            >
+                <div className="source-field-select">
+                    <FormSelect
+                      id={SCREEN_ID + "-url-type"}
+                      isDisabled={isFormDisabled || isClosestMirror}
+                      onChange={(_ev, val) => setUrlType(val)}
+                      value={urlType}
+                    >
+                        {URL_TYPES.map(t => (
+                            <FormSelectOption
+                              key={t.value}
+                              label={t.label}
+                              value={t.value}
+                            />
+                        ))}
+                    </FormSelect>
+                </div>
+            </FormGroup>
+        </Form>
+    );
+};

--- a/src/components/source/InstallationSource.scss
+++ b/src/components/source/InstallationSource.scss
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#anaconda-screen-installation-source {
+  width: min(90ch, 100%);
+
+  .source-url-row {
+    display: flex;
+    align-items: stretch;
+    gap: var(--pf-t--global--spacer--sm);
+    width: 100%;
+
+    .source-protocol-select {
+      flex: 0 0 auto;
+      width: min(16ch, 40%);
+    }
+
+    .source-url-input {
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+  }
+
+  .source-field-select {
+    width: min(25ch, 100%);
+  }
+}

--- a/src/components/source/InstallationSource.scss
+++ b/src/components/source/InstallationSource.scss
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#anaconda-screen-installation-source {
+  width: min(90ch, 100%);
+
+  .source-url-row {
+    display: flex;
+    align-items: stretch;
+    gap: var(--pf-t--global--spacer--sm);
+    width: 100%;
+
+    .source-protocol-select {
+      flex: 0 0 auto;
+      width: min(16ch, 40%);
+    }
+
+    .source-url-input {
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+  }
+
+  .source-field-select {
+    width: min(25ch, 100%);
+  }
+}

--- a/src/components/source/SourceReviewDescription.jsx
+++ b/src/components/source/SourceReviewDescription.jsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+import cockpit from "cockpit";
+import { useContext } from "react";
+
+import { PayloadContext } from "../../contexts/Common.jsx";
+
+const _ = cockpit.gettext;
+
+/** Review description body for the installation source step (incomplete UI is chosen in ReviewConfiguration). */
+export const SourceReviewDescription = () => {
+    const { source } = useContext(PayloadContext) ?? {};
+
+    switch (source?.sourceType) {
+    case "CLOSEST_MIRROR":
+        return _("Closest mirror");
+    case "URL":
+        return source?.configuration?.url || "";
+    default:
+        return source?.sourceType || "";
+    }
+};

--- a/src/components/source/index.js
+++ b/src/components/source/index.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import cockpit from "cockpit";
+
+import { InstallationSource } from "./InstallationSource.jsx";
+import { SourceReviewDescription } from "./SourceReviewDescription.jsx";
+
+const _ = cockpit.gettext;
+
+export { SourceReviewDescription };
+
+export class Page {
+    _description = "Configure the installation source for package downloads.";
+
+    constructor ({ payloadType }) {
+        this.component = InstallationSource;
+        this.id = "anaconda-screen-installation-source";
+        this.isHidden = payloadType !== "DNF";
+        this.label = _("Installation source");
+        this.title = _("Installation source");
+    }
+}

--- a/src/components/source/index.js
+++ b/src/components/source/index.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import cockpit from "cockpit";
+
+import { InstallationSource } from "./InstallationSource.jsx";
+import { SourceReviewDescription } from "./SourceReviewDescription.jsx";
+import { useSourcePageInit } from "./usePageInit.js";
+
+const _ = cockpit.gettext;
+
+export { SourceReviewDescription };
+
+export class Page {
+    _description = "Configure the installation source for package downloads.";
+
+    constructor ({ payloadType }) {
+        this.component = InstallationSource;
+        this.id = "anaconda-screen-installation-source";
+        this.isHidden = payloadType !== "DNF";
+        this.label = _("Installation source");
+        this.title = _("Installation source");
+        this.usePageInit = useSourcePageInit;
+    }
+}

--- a/src/components/source/index.js
+++ b/src/components/source/index.js
@@ -7,6 +7,7 @@ import cockpit from "cockpit";
 
 import { InstallationSource } from "./InstallationSource.jsx";
 import { SourceReviewDescription } from "./SourceReviewDescription.jsx";
+import { useSourcePageInit } from "./usePageInit.js";
 
 const _ = cockpit.gettext;
 
@@ -21,5 +22,6 @@ export class Page {
         this.isHidden = payloadType !== "DNF";
         this.label = _("Installation source");
         this.title = _("Installation source");
+        this.usePageInit = useSourcePageInit;
     }
 }

--- a/src/components/source/usePageComplete.js
+++ b/src/components/source/usePageComplete.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import { useContext } from "react";
+
+import { PayloadContext } from "../../contexts/Common.jsx";
+
+/**
+ * Installation source completeness for the Review screen.
+ *
+ * The spoke configures URL repositories only; other source types may still be
+ * active from the default backend configuration without visiting the spoke.
+ *
+ * @param {{ isHidden?: boolean }} [opts]
+ * @returns {true | false}
+ */
+export const usePageComplete = ({ isHidden } = {}) => {
+    const { source } = useContext(PayloadContext);
+
+    if (isHidden) {
+        return true;
+    }
+
+    if (!source?.sourceType) {
+        return false;
+    }
+
+    switch (source.sourceType) {
+    case "CLOSEST_MIRROR":
+    case "CDROM":
+    case "REPO_PATH":
+    case "REPO_FILES":
+        return true;
+
+    case "URL":
+        return Boolean(source.configuration?.url);
+
+    default:
+        return true;
+    }
+};

--- a/src/components/source/usePageComplete.js
+++ b/src/components/source/usePageComplete.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import { useContext } from "react";
+
+import { PayloadContext } from "../../contexts/Common.jsx";
+
+/**
+ * Installation source completeness for the Review screen.
+ *
+ * The spoke configures URL repositories only; other source types may still be
+ * active from the default backend configuration without visiting the spoke.
+ *
+ * @param {{ isHidden?: boolean }} [opts]
+ * @returns {true | false}
+ */
+export const usePageComplete = ({ isHidden } = {}) => {
+    const { source } = useContext(PayloadContext);
+
+    if (isHidden) {
+        return true;
+    }
+
+    if (!source?.sourceType) {
+        return false;
+    }
+
+    switch (source.sourceType) {
+    case "CLOSEST_MIRROR":
+    case "CDROM":
+    case "REPO_PATH":
+    case "REPO_FILES":
+        return true;
+
+    case "URL":
+        return Boolean(source.configuration?.url);
+
+    default:
+        return true;
+    }
+};

--- a/src/components/source/usePageInit.js
+++ b/src/components/source/usePageInit.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import { useContext, useEffect } from "react";
+
+import { getPayloadSourceAction } from "../../actions/payload-source-actions.js";
+
+import { PageContext } from "../../contexts/Common.jsx";
+
+export const useSourcePageInit = () => {
+    const { dispatch, setIsFormDisabled } = useContext(PageContext) ?? {};
+
+    useEffect(() => {
+        if (!dispatch) {
+            setIsFormDisabled?.(false);
+            return undefined;
+        }
+
+        dispatch(getPayloadSourceAction())
+            .finally(() => setIsFormDisabled?.(false));
+
+        return undefined;
+    }, [dispatch, setIsFormDisabled]);
+};

--- a/src/components/source/usePageInit.js
+++ b/src/components/source/usePageInit.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import { useContext, useEffect } from "react";
+
+import { getPayloadSourceAction } from "../../actions/payload-source-actions.js";
+
+import { PageContext } from "../../contexts/Common.jsx";
+
+export const useSourcePageInit = () => {
+    const { dispatch, setIsFormDisabled } = useContext(PageContext) ?? {};
+
+    useEffect(() => {
+        if (!dispatch) {
+            setIsFormDisabled?.(false);
+            return undefined;
+        }
+
+        dispatch(getPayloadSourceAction())
+            .finally(() => setIsFormDisabled?.(false));
+
+        return undefined;
+    }, [dispatch, setIsFormDisabled]);
+};

--- a/src/components/steps.js
+++ b/src/components/steps.js
@@ -12,6 +12,7 @@ import { Page as PageInstallationLanguage } from "./localization/index.js";
 import { Page as PageNetworkConfiguration } from "./network/index.js";
 import { Page as PageReviewConfiguration } from "./review/index.js";
 import { Page as PageSoftwareSelection } from "./software/index.js";
+import { Page as PageInstallationSource } from "./source/index.js";
 import { Page as PageInstallationMethod } from "./storage/installation-method/index.js";
 import { Page as PageMountPointMapping } from "./storage/mount-point-mapping/index.js";
 import { Page as PageStorageConfiguration } from "./storage/storage-configuration/index.js";
@@ -26,6 +27,7 @@ export const getSteps = (automatedInstall, userInterfaceConfig, args) => {
         new PageInstallationLanguage(args),
         new PageNetworkConfiguration(args),
         new PageDateAndTime(args),
+        new PageInstallationSource(args),
         new PageSoftwareSelection(args),
         new PageInstallationMethod(args),
         new PageStorageConfiguration(args),

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -86,6 +86,7 @@ export const payloadInitialState = {
         sourceType: null,
         updatesEnabled: true,
     },
+    sourceApplyPending: false,
     type: null,
 };
 
@@ -302,6 +303,8 @@ export const payloadReducer = (state = payloadInitialState, action) => {
                 ...action.payload,
             },
         };
+    } else if (action.type === "SET_SOURCE_APPLY_PENDING") {
+        return { ...state, sourceApplyPending: action.payload.pending };
     } else {
         return state;
     }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -78,6 +78,14 @@ export const payloadInitialState = {
     groups: [],
     packagesKickstarted: false,
     selection: null,
+    source: {
+        configuration: null,
+        deviceId: null,
+        repoPath: null,
+        sourcePath: null,
+        sourceType: null,
+        updatesEnabled: true,
+    },
     type: null,
 };
 
@@ -286,6 +294,14 @@ export const payloadReducer = (state = payloadInitialState, action) => {
         return { ...state, type: action.payload.type };
     } else if (action.type === "SET_PAYLOAD_GROUPS") {
         return { ...state, groups: action.payload.groups };
+    } else if (action.type === "SET_PAYLOAD_SOURCE") {
+        return {
+            ...state,
+            source: {
+                ...state.source,
+                ...action.payload,
+            },
+        };
     } else {
         return state;
     }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -69,6 +69,14 @@ export const payloadInitialState = {
     groups: [],
     packagesKickstarted: false,
     selection: null,
+    source: {
+        configuration: null,
+        deviceId: null,
+        repoPath: null,
+        sourcePath: null,
+        sourceType: null,
+        updatesEnabled: true,
+    },
     type: null,
 };
 
@@ -258,6 +266,14 @@ export const payloadReducer = (state = payloadInitialState, action) => {
         return { ...state, type: action.payload.type };
     } else if (action.type === "SET_PAYLOAD_GROUPS") {
         return { ...state, groups: action.payload.groups };
+    } else if (action.type === "SET_PAYLOAD_SOURCE") {
+        return {
+            ...state,
+            source: {
+                ...state.source,
+                ...action.payload,
+            },
+        };
     } else {
         return state;
     }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -77,6 +77,7 @@ export const payloadInitialState = {
         sourceType: null,
         updatesEnabled: true,
     },
+    sourceApplyPending: false,
     type: null,
 };
 
@@ -274,6 +275,8 @@ export const payloadReducer = (state = payloadInitialState, action) => {
                 ...action.payload,
             },
         };
+    } else if (action.type === "SET_SOURCE_APPLY_PENDING") {
+        return { ...state, sourceApplyPending: action.payload.pending };
     } else {
         return state;
     }

--- a/test/check-review
+++ b/test/check-review
@@ -27,6 +27,7 @@ class TestReview(VirtInstallMachineCase):
             - The review step shows the correct information after setting encryption
             - The hostname is shown for Live ISO
             - The timezone is not shown for Live ISO
+            - The installation source is not shown for Live ISO
             - The UI elements for accessing network configuration are not present
         """
 
@@ -63,6 +64,9 @@ class TestReview(VirtInstallMachineCase):
 
         # check timezone is not visible for Live ISO
         r.check_timezone_not_present()
+
+        # check installation source is not visible for Live ISO
+        r.check_installation_source_not_present()
 
         # Pixel test the review step
         b.assert_pixels(

--- a/test/helpers/review.py
+++ b/test/helpers/review.py
@@ -62,6 +62,10 @@ class Review(NetworkDBus, StorageDBus):
         self.browser.wait_not_present(f"#{self._step}-target-system-timezone")
 
     @log_step()
+    def check_installation_source_not_present(self):
+        self.browser.wait_not_present(f"#{self._step}-target-system-source")
+
+    @log_step()
     def check_storage_config(self, scenario):
         self.browser.wait_in_text(f"#{self._step}-target-system-mode > .pf-v6-c-description-list__text", scenario)
 

--- a/test/helpers/review.py
+++ b/test/helpers/review.py
@@ -42,6 +42,10 @@ class Review(NetworkDBus, StorageDBus):
         self.browser.wait_not_present(f"#{self._step}-target-system-timezone")
 
     @log_step()
+    def check_installation_source_not_present(self):
+        self.browser.wait_not_present(f"#{self._step}-target-system-source")
+
+    @log_step()
     def check_storage_config(self, scenario):
         self.browser.wait_in_text(f"#{self._step}-target-system-mode > .pf-v6-c-description-list__text", scenario)
 

--- a/test/machine_install.py
+++ b/test/machine_install.py
@@ -8,6 +8,7 @@ import shlex
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 from tempfile import TemporaryDirectory
 
@@ -39,6 +40,7 @@ INSTALLER_VM_MEMORY_MB = 4096
 class VirtInstallMachine(VirtMachine):
     http_install_server = None
     http_install_port = None
+    _target_disk = None
 
     def __init__(self, image, **kwargs):
         # From test ``provision`` / ``new_machine``; must not reach Machine.__init__.
@@ -50,6 +52,14 @@ class VirtInstallMachine(VirtMachine):
         # test/run (CI), local test/check-*, and GlobalMachine.reset() which omits memory_mb.
         kwargs["memory_mb"] = max(kwargs.get("memory_mb") or 0, INSTALLER_VM_MEMORY_MB)
         super().__init__(image, **kwargs)
+
+    def _disk_arg(self):
+        if self.payload_type != "dnf":
+            return "none"
+        _, path = tempfile.mkstemp(suffix=".qcow2", prefix=f"disk-{self.label}-")
+        subprocess.check_call(["qemu-img", "create", "-f", "qcow2", path, "15G"])
+        self._target_disk = path
+        return f"{path},format=qcow2"
 
     def _attach_libvirt_domain(self, timeout_sec=120):
         conn = self.virt_connection
@@ -221,7 +231,7 @@ class VirtInstallMachine(VirtMachine):
                 "-device virtio-net-pci,netdev=hostnet0,id=net0,addr=0x16' "
                 f"--extra-args '{extra_args}' "
                 f"{extra_boot_args_option}"
-                f"--disk=none "
+                f"--disk {self._disk_arg()} "
                 f"--location {location} &"
             )
 
@@ -256,6 +266,12 @@ class VirtInstallMachine(VirtMachine):
             f"virsh -q -c qemu:///session undefine --nvram "
             f"--remove-all-storage {self.label} || true"
         )
+        if self._target_disk:
+            try:
+                os.unlink(self._target_disk)
+            except FileNotFoundError:
+                pass
+            self._target_disk = None
         if self.http_install_server:
             self.http_install_server.kill()
             self.http_install_server = None

--- a/test/webui_testvm.py
+++ b/test/webui_testvm.py
@@ -23,13 +23,15 @@ def cmd_cli():
                         action='store_true', dest="pause_at_summary")
     parser.add_argument("--remote-pin", help="PIN for accessing the webui. Blank value defaults to inst.webui.remote.noauth",
                         dest="remote_pin")
+    parser.add_argument("--payload", help="Payload type (liveimg or dnf)", default="liveimg", dest="payload_type")
     args = parser.parse_args()
 
     if args.bios:
         os.environ["TEST_FIRMWARE"] = "bios"
     machine = VirtInstallMachine(image=args.image, memory_mb=INSTALLER_VM_MEMORY_MB,
                                  kickstart_file_name=args.kickstart_file_name,
-                                 pause_at_summary=args.pause_at_summary, remote_pin=args.remote_pin)
+                                 pause_at_summary=args.pause_at_summary, remote_pin=args.remote_pin,
+                                 payload_type=args.payload_type)
     try:
         machine.start()
 


### PR DESCRIPTION
Adds a minimal DNF installation source spoke: closest mirror and http/https repositories (base URL, mirrorlist, and metalink). Values set via kickstart (`url --url`, `--metalink`, `--mirrorlist`) are shown pre-filled in the spoke and can still be changed.

Commits:
- Add dnf payload to test/webui_testvm.py
- Add payload source Redux state and D-Bus API
- Add installation source spoke for DNF payloads
- Refresh software selection after installation source changes
- test: check installation source is not shown on Live ISO review step

If you enter an invalid URL, the UI waits on backend setup with no way to cancel — a cancel button might be worth adding later.

Resolves: INSTALLER-3621
Assisted-by: Composer 2.5

<img width="1736" height="1081" alt="Screenshot From 2026-07-24 11-27-05" src="https://github.com/user-attachments/assets/8e2acda7-eef2-4223-948c-3e1bb2b67618" />
<img width="1736" height="1081" alt="Screenshot From 2026-07-24 11-27-17" src="https://github.com/user-attachments/assets/02b3d311-4e08-465f-92ae-df0b8ff34522" />