### PR TITLE
storage: Skip partitioning reset for kickstart scenarios

### DIFF
--- a/src/hooks/Storage.jsx
+++ b/src/hooks/Storage.jsx
@@ -224,8 +224,9 @@ export const usePartitioningReset = () => {
     const pageHasMounted = useRef(false);
     // Always reset the partitioning when entering the installation destination page
     // If the last partitioning applied was from the cockpit storage integration
-    // we should not reset it, as this option does apply the partitioning onNext
+    // or from a kickstart we should not reset it
     const needsReset = partitioning.storageScenarioId !== "use-configured-storage" &&
+        partitioning.storageScenarioId !== "use-configured-storage-kickstart" &&
         appliedPartitioning &&
         pageHasMounted.current !== true;
 


### PR DESCRIPTION
The usePartitioningReset hook was resetting the partitioning when entering the Installation Method page for the kickstart scenario. The condition excluded "use-configured-storage" (cockpit storage) but not "use-configured-storage-kickstart", causing an unnecessary reset/re-apply cycle.

The pixel test changes are desired - there was some race before causing the swap to dissapear. Now it's there as the test specifies; https://github.com/rhinstaller/anaconda-webui/blob/main/test/kickstarts/TestKickstartAutomated-testBasic.ks#L6 