### PR TITLE
storage: Compare raw required space against filesystem free space

### DIFF
--- a/src/components/storage/StorageReview.jsx
+++ b/src/components/storage/StorageReview.jsx
@@ -30,7 +30,7 @@ import {
     usePlannedActions,
     usePlannedDevices,
     usePlannedMountPoints,
-    useRequiredSize,
+    useRequiredSpace,
 } from "../../hooks/Storage.jsx";
 
 import { ListingTable } from "cockpit-components-table.jsx";
@@ -65,7 +65,7 @@ const DeviceRow = ({ disk, isReviewScreen }) => {
     const actions = usePlannedActions();
     const mountPoints = usePlannedMountPoints();
     const devices = usePlannedDevices();
-    const requiredSize = useRequiredSize();
+    const requiredSpace = useRequiredSpace();
     const freeSpace = useFreeSpaceForSystem();
 
     const requests = partitioning.requests;
@@ -79,9 +79,9 @@ const DeviceRow = ({ disk, isReviewScreen }) => {
     }
 
     let insufficientSizeMessage = "";
-    if (requiredSize > freeSpace) {
+    if (requiredSpace > freeSpace) {
         if (Object.keys(plannedSystemMountPoints).length === 1) {
-            insufficientSizeMessage = cockpit.format(_("Needs at least $0"), cockpit.format_bytes(requiredSize));
+            insufficientSizeMessage = cockpit.format(_("Needs at least $0"), cockpit.format_bytes(requiredSpace));
         } else if (Object.keys(plannedSystemMountPoints).length > 1) {
             insufficientSizeMessage = _("May need more free space");
         }

--- a/src/components/storage/installation-method/usePageComplete.jsx
+++ b/src/components/storage/installation-method/usePageComplete.jsx
@@ -16,7 +16,7 @@ import { PageContext, StorageContext } from "../../../contexts/Common.jsx";
 import {
     useFreeSpaceForSystem,
     useOriginalDevices,
-    useRequiredSize,
+    useRequiredSpace,
 } from "../../../hooks/Storage.jsx";
 
 import { createStorageValidationNotification } from "../Common.jsx";
@@ -41,24 +41,24 @@ const StorageCompleteStatus = Object.freeze({
 export const useStorageComplete = () => {
     const { appliedPartitioning, storageScenarioId } = useContext(StorageContext);
     const freeSpace = useFreeSpaceForSystem();
-    const requiredSize = useRequiredSize();
+    const requiredSpace = useRequiredSpace();
 
     const hasInsufficientSpace =
-        requiredSize != null && freeSpace != null && requiredSize > freeSpace;
+        requiredSpace != null && freeSpace != null && requiredSpace > freeSpace;
 
     const pending =
         !appliedPartitioning ||
         !storageScenarioId ||
-        !requiredSize ||
+        !requiredSpace ||
         !freeSpace;
 
     if (pending) {
-        return { freeSpace, requiredSize, status: StorageCompleteStatus.PENDING };
+        return { freeSpace, requiredSpace, status: StorageCompleteStatus.PENDING };
     }
 
     return {
         freeSpace,
-        requiredSize,
+        requiredSpace,
         status: hasInsufficientSpace
             ? StorageCompleteStatus.INSUFFICIENT
             : StorageCompleteStatus.OK,
@@ -97,7 +97,7 @@ const useApplyStorageOnReview = () => {
     return { validationPending, validationReport };
 };
 
-const useStorageSpaceNotification = (status, freeSpace, requiredSize) => {
+const useStorageSpaceNotification = (status, freeSpace, requiredSpace) => {
     const { appliedPartitioning, storageScenarioId } = useContext(StorageContext);
     const { setStepNotification } = useContext(PageContext) ?? {};
     const { goToStepById } = useWizardContext();
@@ -113,7 +113,7 @@ const useStorageSpaceNotification = (status, freeSpace, requiredSize) => {
             const title = _("Not enough available free space");
             const message = cockpit.format(
                 _("$0 is required, but only $1 is available."),
-                cockpit.format_bytes(requiredSize),
+                cockpit.format_bytes(requiredSpace),
                 cockpit.format_bytes(freeSpace)
             );
             const actionLinks = (
@@ -141,7 +141,7 @@ const useStorageSpaceNotification = (status, freeSpace, requiredSize) => {
         fixupStepId,
         freeSpace,
         goToStepById,
-        requiredSize,
+        requiredSpace,
         setStepNotification,
         status,
     ]);
@@ -156,7 +156,7 @@ export const usePageComplete = () => {
     const spaceState = useStorageComplete();
 
     const { validationPending } = useApplyStorageOnReview();
-    useStorageSpaceNotification(spaceState.status, spaceState.freeSpace, spaceState.requiredSize);
+    useStorageSpaceNotification(spaceState.status, spaceState.freeSpace, spaceState.requiredSpace);
 
     let complete;
     if (spaceState.status === StorageCompleteStatus.PENDING) {

--- a/src/hooks/Storage.jsx
+++ b/src/hooks/Storage.jsx
@@ -125,6 +125,21 @@ export const useUsablePartitions = () => {
     return usablePartitions;
 };
 
+export const useRequiredSpace = () => {
+    const [requiredSpace, setRequiredSpace] = useState();
+
+    useEffect(() => {
+        const update = async () => {
+            const requiredSpace = await getRequiredSpace();
+
+            setRequiredSpace(requiredSpace);
+        };
+        update();
+    }, []);
+
+    return requiredSpace;
+};
+
 export const useRequiredSize = () => {
     const [requiredSize, setRequiredSize] = useState();
 


### PR DESCRIPTION
GetFreeSpaceForSystem returns free space on formatted filesystems (accounting for FS metadata via blivet's free_space_estimate). Comparing it against GetRequiredDeviceSize double-counts metadata overhead, causing false "insufficient space" on tight layouts like the default-fstype kickstart test (rhinstaller/kickstart-tests#1716).

Use raw CalculateRequiredSpace (payload size) for filesystem-level comparisons in usePageComplete and StorageReview. Keep the inflated GetRequiredDeviceSize for raw-disk comparisons and display.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>

Fixes: https://github.com/rhinstaller/kickstart-tests/issues/1716

----
  CalculateRequiredSpace = raw payload size (e.g. 3.0 GiB). This is how much data needs to be written.

  GetRequiredDeviceSize = payload inflated by worst-case FS metadata overhead (blivet's biggest_overhead_FS, which is btrfs at 20%). So 3.0 GiB becomes ~3.75 GiB. This answers: "how big must
  a raw device be so that after formatting, there's enough room for the payload?"

  GetFreeSpaceForSystem = device size minus FS metadata estimate. For a 4000 MiB ext4 partition with blivet's 15% overhead factor: ~3.4 GiB. This already accounts for metadata — it's the
  usable space on the formatted filesystem.

  The bug was comparing GetRequiredDeviceSize against GetFreeSpaceForSystem:

  3.75 GiB (payload + metadata)  >  3.4 GiB (device - metadata)  →  "insufficient space"

  Metadata is subtracted on the right side AND added on the left side. Both values already account for FS overhead, so comparing them double-counts it.

  The correct comparison (what GTK does):

  3.0 GiB (raw payload)  >  3.4 GiB (device - metadata)  →  OK, it fits