### PR TITLE
Add quick-updates.img target for faster dev cycles

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -33,7 +33,7 @@ To prepare Anaconda Web UI sources, you need to run this command::
     make dist
 
 The easiest way to test changes you make is to set up a test VM.
-You can find intructions for preparing a test VM at ``test/README.rst``.
+You can find instructions for preparing a test VM at ``test/README.rst``.
 
 Running eslint
 --------------

--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,10 @@ create-updates.img: bots
 	-rm *updates.img
 	make $(UPDATES_IMG)
 
+# Download dependency RPMs (cockpit, anaconda-core, udisks) via container.
+fetch-rpms:
+	test/fetch-rpms
+
 test/reference: test/common
 	test/common/pixel-tests pull
 

--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,26 @@ create-updates.img: bots
 fetch-rpms:
 	test/fetch-rpms
 
+tmp/rpms:
+	$(MAKE) fetch-rpms
+
+# Fast updates.img for dev: builds JS + installs files directly, no RPM/VM.
+# Set ANACONDA_DIR=~/src/anaconda to also include backend changes.
+# Fetches dependency RPMs on first run, then reuses them.
+quick-updates.img: $(DIST_TEST) tmp/rpms
+	rm -rf updates updates.img
+	$(MAKE) install DESTDIR=$$(pwd)/updates
+	cd updates && for rpm in ../tmp/rpms/*.rpm; do rpm2cpio "$$rpm" | cpio -idmu 2>/dev/null; done
+	if [ -n "$${ANACONDA_DIR}" ]; then \
+		tag=$$(cd "$${ANACONDA_DIR}" && git describe --tags --abbrev=0 2>/dev/null) && \
+		(cd "$${ANACONDA_DIR}" && ./scripts/makeupdates -t "$$tag") && \
+		(cd updates && gzip -dc "$${ANACONDA_DIR}/updates.img" | cpio -idmu 2>/dev/null); \
+	fi
+	cd updates && find . | cpio -c -o 2>/dev/null | gzip -9 > ../updates.img
+	rm -rf updates
+	cp updates.img updates-$$(echo $(TEST_OS) | sed 's/-boot//').img
+	@ls -lh updates.img updates-$$(echo $(TEST_OS) | sed 's/-boot//').img
+
 test/reference: test/common
 	test/common/pixel-tests pull
 

--- a/test/README.rst
+++ b/test/README.rst
@@ -82,6 +82,28 @@ The most robust way of doing this is::
 
     make create-updates.img
 
+For faster development cycles, use ``quick-updates.img`` to build an updates.img
+directly from sources without RPM packaging or a build VM::
+
+    make quick-updates.img
+
+To also include anaconda backend changes::
+
+    ANACONDA_DIR=~/src/anaconda make quick-updates.img
+
+This is significantly faster than ``make create-updates.img`` (~5s vs ~60s) as
+it skips the RPM build. It requires ``make fetch-rpms`` or ``make create-updates.img``
+to have run once to download the dependency RPMs.
+
+Note: this only includes source files (JS, Python, shell scripts, systemd units).
+It does not pull in RPM dependencies — use ``make create-updates.img`` if you need
+those. The resulting updates.img is larger than the RPM-only version, so test VMs
+may need more memory to unpack the initramfs (4 GB is recommended).
+
+For pure frontend development, ``make rsync`` is still the fastest option — it
+watches for source changes and syncs them to a running VM instantly, without
+rebuilding the updates.img or restarting the VM.
+
 Interactive browser
 -------------------
 

--- a/test/fetch-rpms
+++ b/test/fetch-rpms
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Download dependency RPMs (cockpit, anaconda-core, udisks, etc.) via container.
+# Usage: test/fetch-rpms
+set -eu
+
+DESTDIR="$(pwd)/tmp/rpms"
+rm -rf "$DESTDIR"
+mkdir -p "$DESTDIR"
+
+SCENARIO="${TEST_SCENARIO:-}"
+
+# Cockpit packages
+if [[ "$SCENARIO" == *cockpit-pr-* ]]; then
+    COCKPIT_PR="${SCENARIO##*-}"
+    COCKPIT_COPR="packit/cockpit-project-cockpit-${COCKPIT_PR}"
+else
+    COCKPIT_COPR="@cockpit/main-builds"
+fi
+COCKPIT_REPO="copr:copr.fedorainfracloud.org:${COCKPIT_COPR//\//:}"
+COCKPIT_REPO="${COCKPIT_REPO//@/group_}"
+
+# Anaconda packages
+if [[ "$SCENARIO" == *anaconda-pr* ]]; then
+    ANACONDA_PR="${SCENARIO##*-}"
+    ANACONDA_COPR="packit/rhinstaller-anaconda-${ANACONDA_PR}"
+else
+    ANACONDA_COPR="@rhinstaller/Anaconda"
+fi
+ANACONDA_REPO="copr:copr.fedorainfracloud.org:${ANACONDA_COPR//\//:}"
+ANACONDA_REPO="${ANACONDA_REPO//@/group_}"
+
+MISSING_PACKAGES="fedora-logos udisks2 libudisks2 udisks2-lvm2 udisks2-btrfs udisks2-iscsi python3-bugzilla"
+
+podman run --rm -v "$DESTDIR:/output:z" registry.fedoraproject.org/fedora:rawhide bash -c "
+set -e
+dnf -y copr enable $COCKPIT_COPR
+dnf download --destdir /output --repo $COCKPIT_REPO --releasever rawhide \
+    cockpit-bridge cockpit-ws cockpit-storaged cockpit-networkmanager
+
+dnf -y copr enable $ANACONDA_COPR
+dnf download --destdir /output --repo $ANACONDA_REPO --releasever rawhide \
+    anaconda-core anaconda-tui
+
+dnf download --destdir /output --releasever rawhide $MISSING_PACKAGES
+"
+
+echo "RPMs downloaded to $DESTDIR"
+ls "$DESTDIR"

--- a/test/machine_install.py
+++ b/test/machine_install.py
@@ -223,12 +223,12 @@ class VirtInstallMachine(VirtMachine):
             if not self.is_live():
                 Machine.wait_boot(self, timeout_sec=300)
 
-                for _ in range(30):
+                for _ in range(150):
                     try:
                         Machine.execute(self, "journalctl -t anaconda | grep 'anaconda: ui.webui: cockpit web view has been started'")
                         break
                     except subprocess.CalledProcessError:
-                        time.sleep(10)
+                        time.sleep(2)
                 else:
                     raise AssertionError("Webui initialization did not finish")
 


### PR DESCRIPTION
Build updates.img directly from sources, bypassing RPM packaging and the build VM. Reduces build time from ~60s to ~3s*. Optionally merges anaconda backend changes via ANACONDA_DIR - which also saves time given building the backend RPM is also a time consuming process.

Also reduce webui_testvm.py readiness polling interval from 10s to 2s, reducing VM startup time from ~60s to ~45s*.

* Measured on the author's machine.

Assisted-by: Claude Opus 4.6