### PR TITLE
Add Bugzilla duplicate detection to the error reporting flow

### DIFF
--- a/src/components/Error.jsx
+++ b/src/components/Error.jsx
@@ -41,6 +41,7 @@ import { debug, error } from "../helpers/log.js";
 import { AppVersionContext, NetworkContext, OsReleaseContext, SystemTypeContext } from "../contexts/Common.jsx";
 
 import createBugzillaBug from "../scripts/create-bugzilla-bug.py";
+import searchBugzillaBugs from "../scripts/search-bugzilla-bugs.py";
 import validateBugzillaApiKeyScript from "../scripts/validate-bugzilla-api-key.py";
 import { ExternalLink } from "./common/ExternalLink.jsx";
 
@@ -292,7 +293,53 @@ const BZReportTabs = ({
 };
 
 /**
- * Component for bug report details form (step 2)
+ * Component for displaying potential duplicate bugs found in Bugzilla
+ */
+const BZDuplicatesList = ({ duplicateBugs, idPrefix, isBootIso }) => {
+    return (
+        <>
+            <Alert
+              id={idPrefix + "-duplicates-alert"}
+              title={_("Potential duplicate bugs found")}
+              variant="info"
+              isInline
+            >
+                <Content>
+                    {_("The following open bugs may be related to your issue. Please review them before creating a new report.")}
+                </Content>
+            </Alert>
+            <div
+              id={idPrefix + "-duplicates-list"}
+              className="bug-report-duplicates-list"
+            >
+                {duplicateBugs.map(bug => {
+                    const bugUrl = convertToExtlinkIfNeeded(bug.url, !isBootIso);
+                    return (
+                        <div
+                          key={bug.id}
+                          id={idPrefix + "-duplicate-" + bug.id}
+                          className="bug-report-duplicate-item"
+                        >
+                            <Content component={ContentVariants.p}>
+                                <ExternalLink href={bugUrl}>
+                                    <strong>#{bug.id}</strong>
+                                </ExternalLink>
+                                {" "}<span className="bug-report-duplicate-status">[{bug.status}]</span>{" "}
+                                {bug.summary}
+                            </Content>
+                        </div>
+                    );
+                })}
+            </div>
+            <Content>
+                {_("If your issue matches one of the bugs above, you can open it and add your information there instead of creating a duplicate report.")}
+            </Content>
+        </>
+    );
+};
+
+/**
+ * Component for bug report details form (step 3)
  */
 const BZReportDetailsForm = ({
     bugCreationError,
@@ -399,7 +446,8 @@ const componentFromException = (exception) => {
 };
 
 /**
- * Exception report flow component - handles the 2-step for exception reporting
+ * Exception report flow component - handles the 3-step flow for exception reporting
+ * Step 1: API key entry, Step 2: Duplicate check (skipped if none found), Step 3: Bug details + submit
  */
 const BZExceptionReportFlow = ({
     buttons,
@@ -418,8 +466,9 @@ const BZExceptionReportFlow = ({
     const [isCreatingBug, setIsCreatingBug] = useState(false);
     const [bugCreationError, setBugCreationError] = useState(null);
     const [bugzillaApiKey, setBugzillaApiKey] = useState("");
-    const [reportStep, setReportStep] = useState(1); // 1 = API key entry, 2 = bug report details
+    const [reportStep, setReportStep] = useState(1); // 1 = API key entry, 2 = duplicate check, 3 = bug report details
     const [isValidatingApiKey, setIsValidatingApiKey] = useState(false);
+    const [duplicateBugs, setDuplicateBugs] = useState([]);
 
     // Note: Summary and description are editable by the user, which is why they're stored in state.
     // The stacktrace and environmentInfo are auto-added to the bug report and are not editable.
@@ -451,6 +500,29 @@ const BZExceptionReportFlow = ({
         }
     }, [exception]);
 
+    const searchDuplicates = async () => {
+        try {
+            const searchData = JSON.stringify({
+                api_key: bugzillaApiKey,
+                component,
+                limit: 5,
+                product,
+                summary: bugSummary,
+            });
+            const searchProcess = python.spawn(searchBugzillaBugs, [], {
+                environ: ["LC_ALL=C.UTF-8"],
+                err: "message"
+            });
+            searchProcess.input(searchData);
+            const searchResult = await searchProcess;
+            const searchResponse = JSON.parse(searchResult);
+            return searchResponse.bugs || [];
+        } catch (e) {
+            debug("Duplicate search failed, continuing without results:", e.message);
+            return [];
+        }
+    };
+
     const handleNext = async () => {
         setBugCreationError(null);
         setIsValidatingApiKey(true);
@@ -463,7 +535,15 @@ const BZExceptionReportFlow = ({
             });
             process.input(inputData);
             await process;
-            setReportStep(2);
+
+            const bugs = await searchDuplicates();
+            setDuplicateBugs(bugs);
+
+            if (bugs.length > 0) {
+                setReportStep(2);
+            } else {
+                setReportStep(3);
+            }
         } catch (e) {
             setBugCreationError(e.message);
         } finally {
@@ -555,6 +635,13 @@ const BZExceptionReportFlow = ({
                         </>
                     )}
                     {reportStep === 2 && (
+                        <BZDuplicatesList
+                          duplicateBugs={duplicateBugs}
+                          idPrefix={idPrefix}
+                          isBootIso={isBootIso}
+                        />
+                    )}
+                    {reportStep === 3 && (
                         <BZReportDetailsForm
                           bugCreationError={bugCreationError}
                           bugDescription={bugDescription}
@@ -587,6 +674,31 @@ const BZExceptionReportFlow = ({
                           key="back"
                           variant="secondary"
                           onClick={() => setReportStep(1)}
+                        >
+                            {_("Back")}
+                        </Button>
+                        <Button
+                          id={idPrefix + "-continue-new-btn"}
+                          key="continue-new"
+                          variant="primary"
+                          onClick={() => setReportStep(3)}
+                        >
+                            {_("My issue is different, continue")}
+                        </Button>
+                    </>
+                )}
+                {reportStep === 3 && (
+                    <>
+                        <Button
+                          key="back"
+                          variant="secondary"
+                          onClick={() => {
+                              if (duplicateBugs.length > 0) {
+                                  setReportStep(2);
+                              } else {
+                                  setReportStep(1);
+                              }
+                          }}
                         >
                             {_("Back")}
                         </Button>

--- a/src/components/Error.scss
+++ b/src/components/Error.scss
@@ -26,3 +26,19 @@ h4.critical-error-bz-report-modal-intructions-header.pf-v6-c-content--h4 {
   max-height: 400px;
   overflow: auto;
 }
+
+.bug-report-duplicates-list {
+  .bug-report-duplicate-item {
+    padding-block: var(--pf-t--global--spacer--xs);
+    border-block-end: 1px solid var(--pf-t--global--border--color--default);
+
+    &:last-child {
+      border-block-end: none;
+    }
+  }
+
+  .bug-report-duplicate-status {
+    font-size: var(--pf-t--global--font--size--body--sm);
+    color: var(--pf-t--global--text--color--subtle);
+  }
+}

--- a/src/scripts/search-bugzilla-bugs.py
+++ b/src/scripts/search-bugzilla-bugs.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2025 Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# Search Bugzilla for open bugs similar to a given summary.
+#
+# This script accepts JSON input via stdin with the following structure:
+# {
+#     "api_key": "your-api-key-here",
+#     "product": "Fedora",
+#     "summary": "error message text",
+#     "component": "anaconda-webui",   (optional)
+#     "limit": 5                       (optional, default 5)
+# }
+#
+# Outputs JSON to stdout:
+# {
+#     "bugs": [
+#         {"id": 123456, "summary": "...", "status": "NEW", "url": "https://..."}
+#     ]
+# }
+
+import json
+import sys
+from typing import Any
+
+import bugzilla  # type: ignore[import-not-found]
+
+BUGZILLA_BASE_URL = "https://bugzilla.redhat.com"
+
+OPEN_STATUSES = ["NEW", "ASSIGNED", "ON_DEV", "MODIFIED", "POST"]
+
+input_data = json.load(sys.stdin)
+
+api_key = input_data.get("api_key")
+product = input_data.get("product")
+summary = input_data.get("summary", "")
+component = input_data.get("component")
+limit = input_data.get("limit", 5)
+
+bz = bugzilla.Bugzilla(BUGZILLA_BASE_URL, api_key=api_key)
+
+query_kwargs = {
+    "product": product,
+    "status": OPEN_STATUSES,
+    # python-bugzilla maps short_desc to Bugzilla's summary search field
+    "short_desc": summary,
+    "limit": limit,
+    "include_fields": ["id", "summary", "status"],
+}
+if component:
+    query_kwargs["component"] = component
+
+try:
+    bugs = bz.query(bz.build_query(**query_kwargs))
+except Exception as e:
+    print(json.dumps({"bugs": [], "error": str(e)}))
+    sys.exit(0)
+
+result: dict[str, Any] = {
+    "bugs": [
+        {
+            "id": bug.id,
+            "summary": bug.summary,
+            "status": bug.status,
+            "url": f"{BUGZILLA_BASE_URL}/show_bug.cgi?id={bug.id}",
+        }
+        for bug in bugs
+    ]
+}
+print(json.dumps(result))

--- a/test/check-basic
+++ b/test/check-basic
@@ -4,6 +4,11 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 from anacondalib import VirtInstallMachineCase
+from bugzilla_mock import (
+    install_mock_bugzilla,
+    set_mock_bugzilla_bugs,
+    uninstall_mock_bugzilla,
+)
 from installer import Installer
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 from utils import get_pretty_name
@@ -201,6 +206,109 @@ class TestBasic(VirtInstallMachineCase):
             "myNonExistingFunction is not defined",
             m.execute("journalctl -b -t anaconda-webui")
         )
+
+    def _open_critical_error_report_step1(self):
+        b = self.browser
+        i = Installer(b, self.machine)
+
+        i.open()
+        b.wait_not_present("#critical-error-bz-report-modal")
+        b.eval_js("window.setTimeout(function() { myNonExistingFunction()}, 0);")
+        b.wait_in_text("#critical-error-bz-report-modal-details", "myNonExistingFunction is not defined")
+        b.wait_visible("#critical-error-bugzilla-apikey")
+
+    def testBugzillaDuplicateDetection(self):
+        """
+        Description:
+            Test duplicate detection in the Bugzilla reporting flow
+
+        Setup:
+            - Install a mock python-bugzilla package that returns canned open bugs
+            - Trigger a JS error to open the critical-error report modal
+
+        Expected results:
+            - After API key validation, potential duplicates are shown
+            - Users can continue to create a new report
+            - Back navigation returns to the duplicate list when matches exist
+            - When no duplicates are found, the duplicates step is skipped
+        """
+        b = self.browser
+        m = self.machine
+        dialog = "#critical-error-bz-report-modal"
+        mock_bugs = [
+            {
+                "id": 2428210,
+                "summary": "WebUI: org.fedoraproject.Anaconda.BootloaderInstallationError: boot loader install failed",
+                "status": "NEW",
+            },
+            {
+                "id": 2491005,
+                "summary": (
+                    "Installation of the system failed: Installing boot loader"
+                    " org.fedoraproject.Anaconda.BootloaderInstallationError:"
+                    " boot loader install failed"
+                ),
+                "status": "NEW",
+            },
+            {
+                "id": 2485664,
+                "summary": (
+                    "Installation of the system failed: Installing boot loader"
+                    " org.fedoraproject.Anaconda.BootloaderInstallationError:"
+                    " boot loader install failed"
+                ),
+                "status": "NEW",
+            },
+        ]
+
+        install_mock_bugzilla(m, mock_bugs)
+        self.addCleanup(uninstall_mock_bugzilla, m)
+
+        self._open_critical_error_report_step1()
+
+        # Step 1: enter API key and continue
+        b.set_input_text("#critical-error-bugzilla-apikey", "fake-valid-api-key")
+        b.wait_visible(f"{dialog} button:contains('Next'):not([disabled])")
+        b.click(f"{dialog} button:contains('Next')")
+
+        # Step 2: duplicates list
+        b.wait_visible("#critical-error-duplicates-alert")
+        b.wait_in_text("#critical-error-duplicates-alert", "Potential duplicate bugs found")
+        b.wait_visible("#critical-error-duplicates-list")
+        b.wait_in_text("#critical-error-duplicate-2428210", "#2428210")
+        b.wait_in_text("#critical-error-duplicate-2428210", "[NEW]")
+        b.wait_in_text("#critical-error-duplicate-2491005", "#2491005")
+        b.wait_in_text("#critical-error-duplicate-2485664", "#2485664")
+        b.wait_visible("#critical-error-continue-new-btn")
+
+        # Continue to create a new report (step 3)
+        b.click("#critical-error-continue-new-btn")
+        b.wait_visible("#critical-error-bug-summary")
+        b.wait_not_present("#critical-error-duplicates-list")
+        b.wait_visible(f"{dialog} button:contains('Report issue')")
+
+        # Back returns to the duplicates step when matches exist
+        b.click(f"{dialog} button:contains('Back')")
+        b.wait_visible("#critical-error-duplicates-list")
+        b.wait_not_present("#critical-error-bug-summary")
+
+        # Back from duplicates returns to API key entry
+        b.click(f"{dialog} button:contains('Back')")
+        b.wait_visible("#critical-error-bugzilla-apikey")
+        b.wait_not_present("#critical-error-duplicates-list")
+
+        # No duplicates: skip straight to bug details
+        set_mock_bugzilla_bugs(m, [])
+        b.set_input_text("#critical-error-bugzilla-apikey", "fake-valid-api-key")
+        b.click(f"{dialog} button:contains('Next')")
+        b.wait_visible("#critical-error-bug-summary")
+        b.wait_not_present("#critical-error-duplicates-list")
+        b.wait_visible(f"{dialog} button:contains('Report issue')")
+
+        # Back skips the empty duplicates step and returns to API key entry
+        b.click(f"{dialog} button:contains('Back')")
+        b.wait_visible("#critical-error-bugzilla-apikey")
+        b.wait_not_present("#critical-error-bug-summary")
 
 
 if __name__ == '__main__':

--- a/test/helpers/bugzilla_mock.py
+++ b/test/helpers/bugzilla_mock.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2025 Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Helpers for mocking the python-bugzilla package in integration tests."""
+
+import json
+from pathlib import Path
+
+MOCK_BUGS_PATH = "/tmp/anaconda-bugzilla-mock-bugs.json"
+
+MOCK_SCRIPTS_DIR = Path(__file__).parent.parent / "mock_bugzilla_scripts"
+
+
+def _python_cmd(machine):
+    return machine.execute(
+        "command -v /usr/libexec/platform-python || command -v python3"
+    ).strip()
+
+
+def _site_packages(machine):
+    py = _python_cmd(machine)
+    return machine.execute(
+        f"{py} -c 'import sysconfig; print(sysconfig.get_paths()[\"purelib\"])'"
+    ).strip()
+
+
+def install_mock_bugzilla(machine, bugs=None):
+    """Install a mock bugzilla package and optional canned search results.
+
+    :param machine: test machine
+    :param bugs: list of dicts with id/summary/status, or empty list for no matches
+    """
+    if bugs is None:
+        bugs = []
+
+    machine.write(MOCK_BUGS_PATH, json.dumps(bugs))
+
+    site = _site_packages(machine)
+    machine.execute(f"""
+set -eu
+SITE="{site}"
+if [ -e "$SITE/bugzilla" ] && [ ! -e "$SITE/bugzilla.anaconda-test-bak" ]; then
+    mv "$SITE/bugzilla" "$SITE/bugzilla.anaconda-test-bak"
+fi
+if [ -e "$SITE/bugzilla.py" ] && [ ! -e "$SITE/bugzilla.py.anaconda-test-bak" ]; then
+    mv "$SITE/bugzilla.py" "$SITE/bugzilla.py.anaconda-test-bak"
+fi
+mkdir -p "$SITE/bugzilla"
+""")
+    mock_bugzilla_init = (MOCK_SCRIPTS_DIR / "bugzilla_init.py").read_text()
+    machine.write(f"{site}/bugzilla/__init__.py", mock_bugzilla_init)
+
+
+def set_mock_bugzilla_bugs(machine, bugs):
+    """Update canned search results for an already installed mock."""
+    machine.write(MOCK_BUGS_PATH, json.dumps(bugs))
+
+
+def uninstall_mock_bugzilla(machine):
+    """Restore the original bugzilla package if it was backed up."""
+    site = _site_packages(machine)
+    machine.execute(f"""
+set -eu
+SITE="{site}"
+rm -rf "$SITE/bugzilla"
+if [ -e "$SITE/bugzilla.anaconda-test-bak" ]; then
+    mv "$SITE/bugzilla.anaconda-test-bak" "$SITE/bugzilla"
+fi
+if [ -e "$SITE/bugzilla.py.anaconda-test-bak" ]; then
+    mv "$SITE/bugzilla.py.anaconda-test-bak" "$SITE/bugzilla.py"
+fi
+rm -f "{MOCK_BUGS_PATH}"
+""")

--- a/test/mock_bugzilla_scripts/bugzilla_init.py
+++ b/test/mock_bugzilla_scripts/bugzilla_init.py
@@ -1,0 +1,42 @@
+import json
+import os
+from xmlrpc.client import Fault
+
+MOCK_BUGS_PATH = "/tmp/anaconda-bugzilla-mock-bugs.json"
+
+
+class Bug:
+    def __init__(self, bug_id, summary, status):
+        self.id = bug_id
+        self.summary = summary
+        self.status = status
+
+
+class Bugzilla:
+    def __init__(self, url, api_key=None):
+        self.url = url
+        self.api_key = api_key
+
+    @property
+    def logged_in(self):
+        if not self.api_key or self.api_key == "invalid-api-key":
+            raise Fault(300, "The API key you specified is invalid")
+        return True
+
+    def build_query(self, **kwargs):
+        return kwargs
+
+    def query(self, query):
+        if not os.path.exists(MOCK_BUGS_PATH):
+            return []
+        with open(MOCK_BUGS_PATH, encoding="utf-8") as handle:
+            data = json.load(handle)
+        return [Bug(item["id"], item["summary"], item["status"]) for item in data]
+
+    def createbug(self, **kwargs):
+        class NewBug:
+            id = 999999
+        return NewBug()
+
+    def attachfile(self, *args, **kwargs):
+        return 1

--- a/test/unit/test_search_bugzilla_bugs.py
+++ b/test/unit/test_search_bugzilla_bugs.py
@@ -1,0 +1,130 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2025 Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Unit tests for src/scripts/search-bugzilla-bugs.py"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from textwrap import dedent
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT_DIR / "src" / "scripts" / "search-bugzilla-bugs.py"
+
+
+class TestSearchBugzillaBugs(unittest.TestCase):
+    def _run_script(self, payload, mock_module_dir):
+        env = os.environ.copy()
+        env["PYTHONPATH"] = mock_module_dir + os.pathsep + env.get("PYTHONPATH", "")
+        return subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=False,
+            env=env,
+        )
+
+    def _write_mock_bugzilla(self, directory, bugs=None, raise_on_query=False):
+        bugs = bugs or []
+        bug_literals = ", ".join(
+            f"MockBug({bug['id']!r}, {bug['summary']!r}, {bug['status']!r})"
+            for bug in bugs
+        )
+        query_body = (
+            "raise RuntimeError('query failed')"
+            if raise_on_query
+            else f"return [{bug_literals}]"
+        )
+        (Path(directory) / "bugzilla.py").write_text(
+            dedent(
+                f"""
+                class MockBug:
+                    def __init__(self, id, summary, status):
+                        self.id = id
+                        self.summary = summary
+                        self.status = status
+
+                class Bugzilla:
+                    def __init__(self, url, api_key=None):
+                        self.url = url
+                        self.api_key = api_key
+
+                    def build_query(self, **kwargs):
+                        return kwargs
+
+                    def query(self, query):
+                        {query_body}
+                """
+            ),
+            encoding="utf-8",
+        )
+
+    def test_returns_matching_bugs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bugs = [
+                {"id": 111, "summary": "Storage failed", "status": "NEW"},
+                {"id": 222, "summary": "Network failed", "status": "ASSIGNED"},
+            ]
+            self._write_mock_bugzilla(tmp, bugs)
+            result = self._run_script(
+                {
+                    "api_key": "key",
+                    "product": "Fedora",
+                    "summary": "Storage failed",
+                    "component": "anaconda-webui",
+                    "limit": 5,
+                },
+                tmp,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            data = json.loads(result.stdout)
+            self.assertEqual(len(data["bugs"]), 2)
+            self.assertEqual(data["bugs"][0]["id"], 111)
+            self.assertEqual(data["bugs"][0]["status"], "NEW")
+            self.assertEqual(
+                data["bugs"][0]["url"],
+                "https://bugzilla.redhat.com/show_bug.cgi?id=111",
+            )
+            self.assertEqual(data["bugs"][1]["id"], 222)
+
+    def test_returns_empty_list_when_no_matches(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_mock_bugzilla(tmp, [])
+            result = self._run_script(
+                {
+                    "api_key": "key",
+                    "product": "Fedora",
+                    "summary": "no matches",
+                },
+                tmp,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            data = json.loads(result.stdout)
+            self.assertEqual(data["bugs"], [])
+
+    def test_returns_empty_list_on_query_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_mock_bugzilla(tmp, raise_on_query=True)
+            result = self._run_script(
+                {
+                    "api_key": "key",
+                    "product": "Fedora",
+                    "summary": "anything",
+                },
+                tmp,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            data = json.loads(result.stdout)
+            self.assertEqual(data["bugs"], [])
+            self.assertIn("error", data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Search for similar open bugs before submitting a new report so users can attach information to an existing issue instead of creating duplicates.
<img width="855" height="498" alt="image" src="https://github.com/user-attachments/assets/d26bcdef-7f06-4f37-a96b-cedc8f14009b" />
