### PR TITLE
Use backend CheckAdminUserExists for accounts page completeness

### DIFF
--- a/src/actions/users-actions.js
+++ b/src/actions/users-actions.js
@@ -5,6 +5,7 @@
 
 import {
     getCanChangeRootPassword,
+    getCheckAdminUserExists,
     getIsRootAccountLocked,
     getIsRootPasswordSet,
     getUsers,
@@ -62,6 +63,11 @@ export const getUserConfigurationPolicyAction = (args = {}) => async (dispatch) 
             usersSpecifiedByKickstart,
         }),
     }));
+};
+
+export const getAdminUserExistsAction = () => async (dispatch) => {
+    const adminUserExists = await getCheckAdminUserExists();
+    dispatch(setUsersAction({ adminUserExists: !!adminUserExists }));
 };
 
 export const getUsersAction = () => async (dispatch) => {

--- a/src/apis/users.js
+++ b/src/apis/users.js
@@ -4,7 +4,7 @@
  */
 import cockpit from "cockpit";
 
-import { getUserConfigurationPolicyAction, getUsersAction } from "../actions/users-actions.js";
+import { getAdminUserExistsAction, getUserConfigurationPolicyAction, getUsersAction } from "../actions/users-actions.js";
 
 import { debug, error } from "../helpers/log.js";
 import { _callClient, _getProperty, _setProperty, objectFromDbus } from "./helpers.js";
@@ -52,6 +52,7 @@ export class UsersClient {
         this.startEventMonitor(args);
         return Promise.all([
             this.dispatch(getUsersAction()),
+            this.dispatch(getAdminUserExistsAction()),
             this.dispatch(getUserConfigurationPolicyAction(args)),
         ]);
     }
@@ -119,4 +120,8 @@ export const getIsRootPasswordSet = () => {
 
 export const getCanChangeRootPassword = () => {
     return getProperty("CanChangeRootPassword");
+};
+
+export const getCheckAdminUserExists = () => {
+    return callClient("CheckAdminUserExists", []);
 };

--- a/src/components/users/Accounts.jsx
+++ b/src/components/users/Accounts.jsx
@@ -88,6 +88,12 @@ export const AccountsReviewDescription = () => {
             </Flex>
         );
     }
+    // The root was specified as locked via kickstart
+    // and no user account was created
+    if (accounts.adminUserExists && !hasUsers) {
+        return _("Root account has been configured");
+    }
+
     return null;
 };
 
@@ -461,9 +467,10 @@ export const Accounts = ({
         setIsFormValid(
             (skipAccountCreation || isUserValid || kickstartUsersReadOnly) &&
             (skipRootCreation || isRootValid) &&
-            !(skipRootCreation && skipAccountCreation && !kickstartUsersReadOnly)
+            !(skipRootCreation && skipAccountCreation && !kickstartUsersReadOnly && !accounts.adminUserExists)
         );
     }, [
+        accounts.adminUserExists,
         accounts.isRootEnabled,
         accounts.canModifyUserConfiguration,
         isRootValid,
@@ -517,7 +524,7 @@ const CustomFooter = () => {
 
     return (
         <AnacondaWizardFooter
-          footerHelperText={(!accounts.isRootEnabled && noUserAccount) ? _("You have to enable the root account or create a local user account to proceed.") : null}
+          footerHelperText={(!accounts.isRootEnabled && noUserAccount && !accounts.adminUserExists) ? _("You have to enable the root account or create a local user account to proceed.") : null}
           onNext={onNext}
         />
     );

--- a/src/components/users/usePageComplete.jsx
+++ b/src/components/users/usePageComplete.jsx
@@ -18,11 +18,14 @@ export const usePageComplete = ({ isHidden } = {}) => {
     if (isHidden) {
         return true;
     }
+
     const hasUser = (accounts?.users?.length ?? 0) > 0;
 
     const rootDefined =
         accounts?.isRootEnabled === true &&
         accounts?.isRootPasswordSet === true;
 
-    return hasUser || rootDefined;
+    const adminUserExists = accounts?.adminUserExists === true;
+
+    return hasUser || rootDefined || adminUserExists;
 };

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -77,6 +77,7 @@ export const payloadInitialState = {
 /* FIXME: This is not storing information from the anaconda backend, but also non-submitted user input */
 /* The Store is meant to store information from the backend only */
 export const usersInitialState = {
+    adminUserExists: false,
     canModifyRootConfiguration: true,
     canModifyUserConfiguration: true,
     confirmPassword: "",

--- a/test/kickstarts/TestKickstartAutomated-testBasic.ks
+++ b/test/kickstarts/TestKickstartAutomated-testBasic.ks
@@ -7,10 +7,7 @@ part swap --size=1024
 part / --fstype=xfs --grow
 part /home --fstype=xfs --size=2048
 
-rootpw testcase
-user --name=alice --gecos="Alice Admin" --groups=wheel
-user --name=bob --gecos="Bob User"
-user --name=carol --gecos="Carol Dev" --groups=wheel,adm
+rootpw --lock
 
 timezone --utc Europe/Prague
 timesource --ntp-server ntp.cesnet.cz


### PR DESCRIPTION
The GTK and TUI allow installations to complete if 'any root account' is configured via kickstart, even locked one.
CheckAdminUserExists handles this logic, so let's also consume it to match the GTK behavior.

Fixes: https://github.com/rhinstaller/kickstart-tests/issues/1727