### PR TITLE
test: enforce minimum installer VM memory for local and CI runs

### DIFF
--- a/test/anacondalib.py
+++ b/test/anacondalib.py
@@ -17,7 +17,7 @@ sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
 
 from installer import Installer
 from language import Language
-from machine_install import VirtInstallMachine
+from machine_install import INSTALLER_VM_MEMORY_MB, VirtInstallMachine  # noqa: F401  (INSTALLER_VM_MEMORY_MB re-exported)
 from payload_dnf import PayloadDNFDBus
 from progress import Progress
 from storage import Storage
@@ -27,9 +27,6 @@ from users import Users
 from utils import add_public_key
 
 pixel_tests_ignore = ["#anaconda-screen-review-target-system-timezone"]
-
-
-INSTALLER_VM_MEMORY_MB = 4096
 
 
 class VirtInstallMachineCase(MachineCase):

--- a/test/machine_install.py
+++ b/test/machine_install.py
@@ -31,6 +31,10 @@ from machine.testvm import (
 # suite expects it to not exist
 os.environ["TEST_ALLOW_NOLOGIN"] = "true"
 
+# Single source of truth for installer VM RAM (CI scheduler, provision, local runs).
+# Cockpit's run-tests defaults nondestructive machines to ~1 GB; Anaconda needs more.
+INSTALLER_VM_MEMORY_MB = 4096
+
 
 class VirtInstallMachine(VirtMachine):
     http_install_server = None
@@ -41,6 +45,9 @@ class VirtInstallMachine(VirtMachine):
         self.kickstart_file_name = kwargs.pop("kickstart_file_name", None)
         self.pause_at_summary = kwargs.pop("pause_at_summary", False)
         self.payload_type = kwargs.pop("payload_type", "liveimg".lower())
+        # Always enforce the minimum RAM the installer requires. Covers every entry point the same way:
+        # test/run (CI), local test/check-*, and GlobalMachine.reset() which omits memory_mb.
+        kwargs["memory_mb"] = max(kwargs.get("memory_mb") or 0, INSTALLER_VM_MEMORY_MB)
         super().__init__(image, **kwargs)
 
     def _attach_libvirt_domain(self, timeout_sec=120):

--- a/test/run
+++ b/test/run
@@ -113,8 +113,10 @@ echo "<pool type='dir'>
 virsh pool-define --file /tmp/storage-pool.xml
 
 export TEST_OS
-# Installer VMs need more RAM than typical Cockpit test guests
-RUN_TESTS_COMMON_OPTS="--nondestructive-memory-mb 4096"
+# Keep the scheduler's RAM budget in sync with VirtInstallMachine (capacity planning).
+# Actual VM memory is also enforced in VirtInstallMachine.__init__.
+INSTALLER_VM_MEMORY_MB=$(python3 -c "import sys; sys.path.insert(0, 'test'); from machine_install import INSTALLER_VM_MEMORY_MB; print(INSTALLER_VM_MEMORY_MB)")
+RUN_TESTS_COMMON_OPTS="--nondestructive-memory-mb ${INSTALLER_VM_MEMORY_MB}"
 TEST_AUDIT_NO_SELINUX=1 test/common/run-tests $RUN_TESTS_COMMON_OPTS --test-dir test/ $RUN_OPTS
 exit_code=$?
 


### PR DESCRIPTION
run-tests defaults nondestructive machines to ~1 GB, which is too little for Anaconda. Enforce INSTALLER_VM_MEMORY_MB in VirtInstallMachine so local test runs work without --nondestructive-memory-mb.