### PR TITLE
 feat: track installation status and pending errors on reconnection 

### DIFF
--- a/src/actions/boss-actions.js
+++ b/src/actions/boss-actions.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+import { getInstallationStatus, getPendingErrorMessage, getPendingErrorType } from "../apis/boss.js";
+
+export const getInstallationStatusAction = () => {
+    return async (dispatch) => {
+        const status = await getInstallationStatus();
+        return dispatch({
+            payload: { status },
+            type: "GET_INSTALLATION_STATUS",
+        });
+    };
+};
+export const getPendingErrorAction = () => {
+    return async (dispatch) => {
+        const [message, type] = await Promise.all([getPendingErrorMessage(), getPendingErrorType()]);
+        return dispatch({
+            payload: { message, type },
+            type: "GET_PENDING_ERROR",
+        });
+    };
+};

--- a/src/apis/boss.js
+++ b/src/apis/boss.js
@@ -5,6 +5,8 @@
 
 import cockpit from "cockpit";
 
+import { getInstallationStatusAction, getPendingErrorAction } from "../actions/boss-actions.js";
+
 import { error } from "../helpers/log.js";
 import { _callClient, _getProperty } from "./helpers.js";
 
@@ -12,6 +14,7 @@ import { moduleClients } from "./index.js";
 
 const OBJECT_PATH = "/org/fedoraproject/Anaconda/Boss";
 const INTERFACE_NAME = "org.fedoraproject.Anaconda.Boss";
+export const INSTALLATION_STATUS = { FAILED: "failed", NOT_STARTED: "not_started", RUNNING: "running", SUCCEEDED: "succeeded" };
 
 const callClient = (...args) => {
     return _callClient(BossClient, OBJECT_PATH, INTERFACE_NAME, ...args);
@@ -44,9 +47,11 @@ export class BossClient {
     init (args = {}) {
         this.client.addEventListener("close", () => error("Boss client closed"));
 
-        return Promise.all(
-            moduleClients.map(Client => new Client(this.address, this.dispatch).init(args))
-        ).then(() => {
+        return Promise.all([
+            this.dispatch(getInstallationStatusAction()),
+            this.dispatch(getPendingErrorAction()),
+            ...moduleClients.map(Client => new Client(this.address, this.dispatch).init(args))
+        ]).then(() => {
             this.startEventMonitor();
         });
     }
@@ -107,4 +112,25 @@ export const installWithTasks = () => {
  */
 export const setLocale = ({ locale }) => {
     return callClient("SetLocale", [locale]);
+};
+
+/**
+ * @returns {Promise}           Resolves the installation status enum value
+ */
+export const getInstallationStatus = () => {
+    return _getProperty(BossClient, OBJECT_PATH, INTERFACE_NAME, "InstallationStatus");
+};
+
+/**
+ * @returns {Promise}           Resolves the pending error message, or ""
+ */
+export const getPendingErrorMessage = () => {
+    return _getProperty(BossClient, OBJECT_PATH, INTERFACE_NAME, "PendingErrorMessage");
+};
+
+/**
+ * @returns {Promise}           Resolves the pending error type
+ */
+export const getPendingErrorType = () => {
+    return _getProperty(BossClient, OBJECT_PATH, INTERFACE_NAME, "PendingErrorType");
 };

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -34,7 +34,7 @@ export const ApplicationLoading = () => (
     </PageSection>
 );
 
-export const Application = ({ conf, dispatch, isFetching, onCritFail, osRelease, reportLinkURL, setShowStorage, showStorage }) => {
+export const Application = ({ conf, dispatch, installationStatus, isFetching, onCritFail, osRelease, reportLinkURL, setShowStorage, showStorage }) => {
     const [storeInitialized, setStoreInitialized] = useState(false);
     const [currentStepId, setCurrentStepId] = useState();
     const address = useAddress(onCritFail);
@@ -75,7 +75,7 @@ export const Application = ({ conf, dispatch, isFetching, onCritFail, osRelease,
     }, [address, automatedInstall, conf, dispatch, onCritFail]);
 
     // Postpone rendering anything until we read the dbus address and the default configuration
-    if (!address || !storeInitialized) {
+    if (!address || !storeInitialized || !installationStatus) {
         debug("Loading initial data...");
         return <ApplicationLoading />;
     }
@@ -210,6 +210,7 @@ export const ApplicationWithErrorBoundary = () => {
                     <Application
                       conf={conf}
                       dispatch={dispatch}
+                      installationStatus={state.boss.installationStatus}
                       isFetching={state.misc.isFetching}
                       onCritFail={onCritFail}
                       osRelease={osRelease}

--- a/src/components/installation/InstallationProgress.jsx
+++ b/src/components/installation/InstallationProgress.jsx
@@ -55,6 +55,8 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
     useAutoReboot(status, automatedInstall);
 
     useEffect(() => {
+        const failureCtx = { context: _("Installation of the system failed") };
+
         const connectToTask = (taskPath, shouldStart) => {
             const taskProxy = new BossClient().client.proxy(
                 "org.fedoraproject.Anaconda.Task",
@@ -116,9 +118,7 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
             taskProxy.wait(() => {
                 addEventListeners();
                 if (shouldStart) {
-                    taskProxy.Start().catch(onCritFail({
-                        context: _("Installation of the system failed"),
-                    }));
+                    taskProxy.Start().catch(onCritFail(failureCtx));
                 } else {
                     getSteps({ task: taskPath })
                             .then(
@@ -137,14 +137,10 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
                         installWithTasks()
                                 .then(
                                     tasks => connectToTask(tasks[0], true),
-                                    onCritFail({
-                                        context: _("Installation of the system failed"),
-                                    })
+                                    onCritFail(failureCtx)
                                 );
                     }
-                }, onCritFail({
-                    context: _("Installation of the system failed"),
-                }));
+                }, onCritFail(failureCtx));
     }, [onCritFail]);
 
     const submitErrorDecision = (shouldContinue) => {

--- a/src/components/installation/InstallationProgress.jsx
+++ b/src/components/installation/InstallationProgress.jsx
@@ -32,6 +32,7 @@ const _ = cockpit.gettext;
 const N_ = cockpit.noop;
 const SCREEN_ID = "anaconda-screen-progress";
 const DETAIL_TYPE_YESNO = "yesno";
+const PROGRESS_STEPS_DONE = 4;
 
 const progressStepsMap = {
     BOOTLOADER_INSTALLATION: 2,
@@ -109,7 +110,7 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
                 });
                 taskProxy.addEventListener("Succeeded", () => {
                     setStatus("success");
-                    setCurrentProgressStep(4);
+                    setCurrentProgressStep(PROGRESS_STEPS_DONE);
                 });
             };
             taskProxy.wait(() => {
@@ -211,11 +212,11 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
               paragraph={
                   <Flex direction={{ default: "column" }}>
                       <Content component="p">
-                          {currentProgressStep < 4
+                          {currentProgressStep < PROGRESS_STEPS_DONE
                               ? progressSteps[currentProgressStep].description
                               : cockpit.format(_("To begin using $0, reboot your system."), osRelease.PRETTY_NAME)}
                       </Content>
-                      {currentProgressStep < 4 && (
+                      {currentProgressStep < PROGRESS_STEPS_DONE && (
                           <>
                               <FlexItem spacer={{ default: "spacerXl" }} />
                               <ProgressStepper isCenterAligned>

--- a/src/components/installation/InstallationProgress.jsx
+++ b/src/components/installation/InstallationProgress.jsx
@@ -101,16 +101,7 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
                     });
                 });
                 categoryProxy.addEventListener("ErrorRaised", (_, message, detailType) => {
-                    if (detailType === DETAIL_TYPE_YESNO) {
-                        setErrorDialogData({
-                            categoryProxy,
-                            message,
-                        });
-                    } else {
-                        setStatus("danger");
-                        categoryProxy.RespondToError(false);
-                        onCritFail()({ message });
-                    }
+                    handleError(message, detailType, categoryProxy);
                 });
                 taskProxy.addEventListener("Succeeded", () => {
                     setStatus("success");
@@ -127,30 +118,43 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
                                 ret => setSteps(ret.v),
                                 onCritFail()
                             );
-                    if (pendingError.message) {
-                        if (pendingError.type === DETAIL_TYPE_YESNO) {
-                            setErrorDialogData({
-                                categoryProxy,
-                                message: pendingError.message,
-                            });
-                        } else {
-                            setStatus("danger");
-                            onCritFail()({ message: pendingError.message });
-                        }
-                    }
+                    handleError(pendingError.message, pendingError.type, categoryProxy);
                 }
             });
         };
 
+        const startNewInstallation = () =>
+            installWithTasks().then(
+                tasks => connectToTask(tasks[0], true),
+                onCritFail(failureCtx)
+            );
+
+        const handleError = (message, detailType, categoryProxy) => {
+            if (!message) return;
+
+            if (detailType === DETAIL_TYPE_YESNO && categoryProxy) {
+                setErrorDialogData({ categoryProxy, message });
+            } else {
+                setStatus("danger");
+                categoryProxy?.RespondToError(false);
+                onCritFail()({ message });
+            }
+        };
+
         /** Sync UI with the backend installation status: finalize if done, reconnect if running, or start a new installation. */
         const syncInstallState = async () => {
-            if (installationStatus === INSTALLATION_STATUS.SUCCEEDED) {
+            switch (installationStatus) {
+            case INSTALLATION_STATUS.SUCCEEDED:
                 setStatus("success");
                 setCurrentProgressStep(PROGRESS_STEPS_DONE);
                 setSteps([]);
-            } else if (installationStatus === INSTALLATION_STATUS.FAILED) {
-                onCritFail()({ message: pendingError.message });
-            } else if (installationStatus === INSTALLATION_STATUS.RUNNING) {
+                break;
+
+            case INSTALLATION_STATUS.FAILED:
+                handleError(pendingError.message, pendingError.type, null);
+                break;
+
+            case INSTALLATION_STATUS.RUNNING:
                 try {
                     const activeTask = await getActiveInstallationTask();
                     if (activeTask) {
@@ -164,11 +168,10 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
                 } catch (error) {
                     onCritFail(failureCtx)(error);
                 }
-            } else {
-                installWithTasks().then(
-                    tasks => connectToTask(tasks[0], true),
-                    onCritFail(failureCtx)
-                );
+                break;
+
+            default:
+                startNewInstallation();
             }
         };
         syncInstallState();

--- a/src/components/installation/InstallationProgress.jsx
+++ b/src/components/installation/InstallationProgress.jsx
@@ -14,11 +14,12 @@ import { ExclamationCircleIcon } from "@patternfly/react-icons/dist/esm/icons/ex
 import { InProgressIcon } from "@patternfly/react-icons/dist/esm/icons/in-progress-icon";
 import { PendingIcon } from "@patternfly/react-icons/dist/esm/icons/pending-icon";
 
-import { BossClient, getActiveInstallationTask, getSteps, installWithTasks } from "../../apis/boss.js";
+import { BossClient, getActiveInstallationTask, getSteps, INSTALLATION_STATUS, installWithTasks } from "../../apis/boss.js";
 
 import { exitGui, rebootSystem } from "../../helpers/exit.js";
+import { debug } from "../../helpers/log.js";
 
-import { OsReleaseContext, SystemTypeContext } from "../../contexts/Common.jsx";
+import { BossContext, OsReleaseContext, SystemTypeContext } from "../../contexts/Common.jsx";
 
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
@@ -51,6 +52,7 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
     const refStatusMessage = useRef("");
     const isBootIso = useContext(SystemTypeContext).systemType === "BOOT_ISO";
     const osRelease = useContext(OsReleaseContext);
+    const { installationStatus, pendingError } = useContext(BossContext);
 
     useAutoReboot(status, automatedInstall);
 
@@ -125,23 +127,53 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
                                 ret => setSteps(ret.v),
                                 onCritFail()
                             );
+                    if (pendingError.message) {
+                        if (pendingError.type === DETAIL_TYPE_YESNO) {
+                            setErrorDialogData({
+                                categoryProxy,
+                                message: pendingError.message,
+                            });
+                        } else {
+                            setStatus("danger");
+                            onCritFail()({ message: pendingError.message });
+                        }
+                    }
                 }
             });
         };
 
-        getActiveInstallationTask()
-                .then(activeTask => {
+        /** Sync UI with the backend installation status: finalize if done, reconnect if running, or start a new installation. */
+        const syncInstallState = async () => {
+            if (installationStatus === INSTALLATION_STATUS.SUCCEEDED) {
+                setStatus("success");
+                setCurrentProgressStep(PROGRESS_STEPS_DONE);
+                setSteps([]);
+            } else if (installationStatus === INSTALLATION_STATUS.FAILED) {
+                onCritFail()({ message: pendingError.message });
+            } else if (installationStatus === INSTALLATION_STATUS.RUNNING) {
+                try {
+                    const activeTask = await getActiveInstallationTask();
                     if (activeTask) {
                         connectToTask(activeTask, false);
                     } else {
-                        installWithTasks()
-                                .then(
-                                    tasks => connectToTask(tasks[0], true),
-                                    onCritFail(failureCtx)
-                                );
+                        // this should be impossible. How is the status = RUNNING and no task is active?
+                        const errMsg = "Installation status is RUNNING but no active installation task was found";
+                        debug(errMsg);
+                        throw new Error(errMsg);
                     }
-                }, onCritFail(failureCtx));
-    }, [onCritFail]);
+                } catch (error) {
+                    onCritFail(failureCtx)(error);
+                }
+            } else {
+                installWithTasks().then(
+                    tasks => connectToTask(tasks[0], true),
+                    onCritFail(failureCtx)
+                );
+            }
+        };
+        syncInstallState();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pendingError is read on reconnection only, not reactively
+    }, [installationStatus, onCritFail]);
 
     const submitErrorDecision = (shouldContinue) => {
         if (!errorDialogData) {

--- a/src/contexts/Common.jsx
+++ b/src/contexts/Common.jsx
@@ -10,6 +10,7 @@ import { HelpIcon } from "@patternfly/react-icons/dist/esm/icons/help-icon";
 
 import { WithDialogs } from "dialogs.jsx";
 
+export const BossContext = createContext(null);
 export const PageContext = createContext(null);
 export const LanguageContext = createContext(null);
 export const OsReleaseContext = createContext(null);
@@ -45,21 +46,23 @@ export const FormGroupHelpPopover = ({ helpContent }) => {
 
 const ModuleContextWrapper = ({ children, state }) => {
     return (
-        <LanguageContext.Provider value={state.localization}>
-            <RuntimeContext.Provider value={state.runtime}>
-                <StorageContext.Provider value={{ ...state.storage, isFetching: state.misc.isFetching }}>
-                    <UsersContext.Provider value={state.users}>
-                        <NetworkContext.Provider value={state.network}>
-                            <PayloadContext.Provider value={state.payload}>
-                                <TimezoneContext.Provider value={state.timezone}>
-                                    {children}
-                                </TimezoneContext.Provider>
-                            </PayloadContext.Provider>
-                        </NetworkContext.Provider>
-                    </UsersContext.Provider>
-                </StorageContext.Provider>
-            </RuntimeContext.Provider>
-        </LanguageContext.Provider>
+        <BossContext.Provider value={state.boss}>
+            <LanguageContext.Provider value={state.localization}>
+                <RuntimeContext.Provider value={state.runtime}>
+                    <StorageContext.Provider value={{ ...state.storage, isFetching: state.misc.isFetching }}>
+                        <UsersContext.Provider value={state.users}>
+                            <NetworkContext.Provider value={state.network}>
+                                <PayloadContext.Provider value={state.payload}>
+                                    <TimezoneContext.Provider value={state.timezone}>
+                                        {children}
+                                    </TimezoneContext.Provider>
+                                </PayloadContext.Provider>
+                            </NetworkContext.Provider>
+                        </UsersContext.Provider>
+                    </StorageContext.Provider>
+                </RuntimeContext.Provider>
+            </LanguageContext.Provider>
+        </BossContext.Provider>
     );
 };
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -43,6 +43,12 @@ export const localizationInitialState = {
     xlayouts: undefined,
 };
 
+/* Initial state for the boss store substate */
+export const bossInitialState = {
+    installationStatus: null,
+    pendingError: { message: "", type: "" },
+};
+
 /* Intial state for the network store substate */
 export const networkInitialState = {
     connected: null
@@ -92,6 +98,7 @@ export const usersInitialState = {
 
 /* Initial state for the global store */
 export const initialState = {
+    boss: bossInitialState,
     localization: localizationInitialState,
     misc: miscInitialState,
     network: networkInitialState,
@@ -123,6 +130,7 @@ export const useReducerWithThunk = (reducer, initialState) => {
 
 export const reducer = (state, action) => {
     return ({
+        boss: bossReducer(state.boss, action),
         localization: localizationReducer(state.localization, action),
         misc: miscReducer(state.misc, action),
         network: networkReducer(state.network, action),
@@ -202,6 +210,16 @@ export const localizationReducer = (state = localizationInitialState, action) =>
         };
     } else if (action.type === "SET_LANGUAGE_KICKSTARTED") {
         return { ...state, languageKickstarted: action.payload.languageKickstarted };
+    } else {
+        return state;
+    }
+};
+
+export const bossReducer = (state = bossInitialState, action) => {
+    if (action.type === "GET_INSTALLATION_STATUS") {
+        return { ...state, installationStatus: action.payload.status };
+    } else if (action.type === "GET_PENDING_ERROR") {
+        return { ...state, pendingError: { message: action.payload.message, type: action.payload.type } };
     } else {
         return state;
     }

--- a/test/check-kickstart-automated
+++ b/test/check-kickstart-automated
@@ -206,6 +206,11 @@ class TestKickstartAutomatedNonCriticalError(VirtInstallMachineCase):
         b.open("/cockpit/@localhost/anaconda-webui/index.html")
         p.wait_installation_error_dialog("domain-client-nonexisting")
         b.wait_visible("#anaconda-screen-progress-installation-error-continue-btn")
+        # Simulate remote reconnection
+        b.reload()
+        b.wait_visible(".pf-v6-c-page")
+        p.wait_installation_error_dialog("domain-client-nonexisting")
+        b.wait_visible("#anaconda-screen-progress-installation-error-continue-btn")
         p.respond_installation_error_abort()
         p.wait_installation_failed()
 
@@ -263,6 +268,11 @@ class TestKickstartAutomatedFatalError(VirtInstallMachineCase):
         b.open("/cockpit/@localhost/anaconda-webui/index.html")
         p.wait_installation_failed("This is a fatal error", timeout=1200)
         b.wait_not_present("#anaconda-screen-progress-installation-error-continue-btn")
+
+        # Simulate remote reconnection — error should persist
+        b.reload()
+        b.wait_visible(".pf-v6-c-page")
+        p.wait_installation_failed("This is a fatal error", timeout=10)
 
 
 class TestKickstartAutomatedIncomplete(VirtInstallMachineCase):


### PR DESCRIPTION
Add Boss context to track installation status and pending errors, allowing the progress screen to recover state when a remote user reconnects. Rework InstallationProgress to branch on backend status instead of always starting a new installation.

Add reconnection tests for non-critical and fatal error cases.

Resolves: INSTALLER-4815
Related: INSTALLER-4824
Assisted-by: Claude Opus 4.6