### PR TITLE
storage: move storage editor entry point from kebab menu to Installation Method

### DIFF
--- a/src/components/AnacondaHeader.jsx
+++ b/src/components/AnacondaHeader.jsx
@@ -23,7 +23,7 @@ import "./AnacondaHeader.scss";
 const _ = cockpit.gettext;
 const N_ = cockpit.noop;
 
-export const AnacondaHeader = ({ currentStepId, dispatch, onCritFail, reportLinkURL, setShowStorage, showStorage, title }) => {
+export const AnacondaHeader = ({ dispatch, onCritFail, reportLinkURL, setShowStorage, showStorage, title }) => {
     const [beta, setBeta] = useState();
     const network = useContext(NetworkContext);
     const isConnected = network.connected;
@@ -44,7 +44,6 @@ export const AnacondaHeader = ({ currentStepId, dispatch, onCritFail, reportLink
                 </Content>
                 {beta && <Beta />}
                 <HeaderKebab
-                  currentStepId={currentStepId}
                   dispatch={dispatch}
                   isConnected={isConnected}
                   onCritFail={onCritFail}

--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -18,7 +18,7 @@ import { AnacondaPage } from "./AnacondaPage.jsx";
 import { AnacondaWizardFooter } from "./AnacondaWizardFooter.jsx";
 import { getSteps } from "./steps.js";
 
-export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFetching, onCritFail, pauseAtSummary, setCurrentStepId, showStorage }) => {
+export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFetching, onCritFail, pauseAtSummary, setCurrentStepId, setShowStorage, showStorage }) => {
     /**
      * Wizard step page state (reset in `AnacondaWizard` `goToStep` on step change).
      * - **isFormValid** / **setIsFormValid** — Required fields satisfied; reset when the step changes in the wizard.
@@ -43,6 +43,7 @@ export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFe
         dispatch,
         onCritFail,
         pauseAtSummary,
+        setShowStorage,
     };
 
     const pageContextValue = {

--- a/src/components/HeaderKebab.jsx
+++ b/src/components/HeaderKebab.jsx
@@ -21,7 +21,7 @@ import { AppVersionContext, OsReleaseContext, SystemTypeContext } from "../conte
 
 import { UserIssue } from "./Error.jsx";
 import { CockpitNetworkConfiguration } from "./network/CockpitNetworkConfiguration.jsx";
-import { CockpitStorageIntegration, ModifyStorage } from "./storage/cockpit-storage-integration/CockpitStorageIntegration.jsx";
+import { CockpitStorageIntegration } from "./storage/cockpit-storage-integration/CockpitStorageIntegration.jsx";
 
 import "./HeaderKebab.scss";
 
@@ -82,7 +82,7 @@ const AnacondaAboutModal = ({ isModalOpen, setIsAboutModalOpen }) => {
     );
 };
 
-export const HeaderKebab = ({ currentStepId, dispatch, isConnected, onCritFail, reportLinkURL, setShowStorage, showStorage }) => {
+export const HeaderKebab = ({ dispatch, isConnected, onCritFail, reportLinkURL, setShowStorage, showStorage }) => {
     const [isOpen, setIsOpen] = useState(false);
     const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
     const [isReportIssueOpen, setIsReportIssueOpen] = useState(false);
@@ -117,11 +117,6 @@ export const HeaderKebab = ({ currentStepId, dispatch, isConnected, onCritFail, 
             ]
             : []
         ),
-        <ModifyStorage
-          currentStepId={currentStepId}
-          key="modify-storage"
-          setShowStorage={setShowStorage}
-        />,
         <DropdownItem id="about-modal-dropdown-item-about" key="about" onClick={handleAboutModal}>
             {_("About")}
         </DropdownItem>,

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -89,7 +89,6 @@ export const Application = ({ conf, dispatch, isFetching, onCritFail, osRelease,
               isFilled={false}
               stickyOnBreakpoint={{ default: "top" }}>
                 <AnacondaHeader
-                  currentStepId={currentStepId}
                   dispatch={dispatch}
                   title={title}
                   reportLinkURL={reportLinkURL}
@@ -107,6 +106,7 @@ export const Application = ({ conf, dispatch, isFetching, onCritFail, osRelease,
               title={title}
               dispatch={dispatch}
               setCurrentStepId={setCurrentStepId}
+              setShowStorage={setShowStorage}
               showStorage={showStorage}
             />
         </>

--- a/src/components/storage/cockpit-storage-integration/CockpitStorageIntegration.jsx
+++ b/src/components/storage/cockpit-storage-integration/CockpitStorageIntegration.jsx
@@ -4,30 +4,18 @@
  */
 import cockpit from "cockpit";
 
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Banner } from "@patternfly/react-core/dist/esm/components/Banner/index.js";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { Content } from "@patternfly/react-core/dist/esm/components/Content/index.js";
-import { DropdownItem } from "@patternfly/react-core/dist/esm/components/Dropdown/index.js";
 import { Modal, ModalBody, ModalFooter, ModalHeader, ModalVariant } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
 import { PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
-import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip/index.js";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { ArrowLeftIcon } from "@patternfly/react-icons/dist/esm/icons/arrow-left-icon";
 import { ExclamationTriangleIcon } from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
 import { TimesIcon } from "@patternfly/react-icons/dist/esm/icons/times-icon";
 
-import {
-    getDeviceAncestors
-} from "../../../helpers/storage.js";
-
-import { StorageContext, TargetSystemRootContext } from "../../../contexts/Common.jsx";
-
 import { useMaybeBackdrop } from "../../../hooks/CockpitIntegration.jsx";
-import {
-    useMountPointConstraints,
-    useOriginalDevices,
-} from "../../../hooks/Storage.jsx";
 
 import { CheckStorageDialog } from "./CheckStorageDialog.jsx";
 import { ModifyStorageSideBar } from "./CockpitStorageIntegrationSidebar.jsx";
@@ -168,49 +156,4 @@ export const CockpitStorageIntegration = ({
             </Modal>
         </>
     );
-};
-
-export const ModifyStorage = ({ currentStepId, setShowStorage }) => {
-    const targetSystemRoot = useContext(TargetSystemRootContext);
-    const { diskSelection } = useContext(StorageContext);
-    const devices = useOriginalDevices();
-    const availableDevices = [
-        ...diskSelection.selectedDisks,
-        ...diskSelection.selectedDisks.map(disk => getDeviceAncestors(devices, disk)).flat(),
-    ];
-    const mountPointConstraints = useMountPointConstraints();
-    const isEfi = mountPointConstraints?.some(c => c["required-filesystem-type"]?.v === "efi");
-    const cockpitAnaconda = JSON.stringify({
-        available_devices: availableDevices.map(device => devices[device].path.v),
-        efi: isEfi,
-        mount_point_prefix: targetSystemRoot,
-    });
-    // Allow to modify storage only when we are in the scenario selection page
-    const isAriaDisabled = currentStepId !== "anaconda-screen-method";
-    const item = (
-        <DropdownItem
-          id="modify-storage"
-          isAriaDisabled={isAriaDisabled}
-          onClick={() => {
-              window.sessionStorage.setItem("cockpit_anaconda", cockpitAnaconda);
-              setShowStorage(true);
-          }}
-        >
-            {_("Launch storage editor")}
-        </DropdownItem>
-    );
-
-    if (!isAriaDisabled) {
-        return item;
-    } else {
-        return (
-            <Tooltip
-              id="modify-storage-tooltip"
-              content={_("Storage editor is available only in the `Installation method` step.")}>
-                <span>
-                    {item}
-                </span>
-            </Tooltip>
-        );
-    }
 };

--- a/src/components/storage/installation-method/InstallationMethod.jsx
+++ b/src/components/storage/installation-method/InstallationMethod.jsx
@@ -40,6 +40,7 @@ export const InstallationMethod = ({
     isEfi,
     isFirstScreen,
     onCritFail,
+    setShowStorage,
 }) => {
     const { setIsFormValid } = useContext(PageContext) ?? {};
     const [isReclaimSpaceCheckboxChecked, setIsReclaimSpaceCheckboxChecked] = useState();
@@ -77,6 +78,7 @@ export const InstallationMethod = ({
                   idPrefix={idPrefix}
                   isFirstScreen={isFirstScreen}
                   setIsScenarioValid={setIsScenarioValid}
+                  setShowStorage={setShowStorage}
                 />
             </DialogsContext.Provider>
         </Form>

--- a/src/components/storage/installation-method/InstallationScenario.jsx
+++ b/src/components/storage/installation-method/InstallationScenario.jsx
@@ -6,6 +6,7 @@
 import cockpit from "cockpit";
 
 import React, { useContext, useEffect, useMemo } from "react";
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { FormGroup, FormSection } from "@patternfly/react-core/dist/esm/components/Form/index.js";
 import { Radio } from "@patternfly/react-core/dist/esm/components/Radio/index.js";
 import { Title } from "@patternfly/react-core/dist/esm/components/Title/index.js";
@@ -19,6 +20,7 @@ import {
 import { PageContext, StorageContext } from "../../../contexts/Common.jsx";
 
 import {
+    useLaunchStorageEditor,
     useOriginalDevices,
 } from "../../../hooks/Storage.jsx";
 
@@ -111,11 +113,27 @@ const InstallationScenarioSelector = ({
     return scenarioItems;
 };
 
+const ModifyStorageButton = ({ setShowStorage }) => {
+    const launchStorageEditor = useLaunchStorageEditor({ setShowStorage });
+
+    return (
+        <Button
+          id="modify-storage"
+          variant="link"
+          isInline
+          onClick={launchStorageEditor}
+        >
+            {_("If none of the options above apply, use the storage editor to create a custom partitioning before proceeding.")}
+        </Button>
+    );
+};
+
 export const InstallationScenario = ({
     dispatch,
     idPrefix,
     isFirstScreen,
     setIsScenarioValid,
+    setShowStorage,
 }) => {
     const headingLevel = isFirstScreen ? "h3" : "h2";
     const { diskSelection, storageScenarioId } = useContext(StorageContext);
@@ -157,6 +175,7 @@ export const InstallationScenario = ({
                   dispatch={dispatch}
                   idPrefix={idPrefix}
                 />
+                <ModifyStorageButton setShowStorage={setShowStorage} />
             </FormGroup>
         </FormSection>
     );

--- a/src/hooks/Storage.jsx
+++ b/src/hooks/Storage.jsx
@@ -35,7 +35,7 @@ import {
     systemMountPoints,
 } from "../helpers/storage.js";
 
-import { PageContext, StorageContext, StorageDefaultsContext } from "../contexts/Common.jsx";
+import { PageContext, StorageContext, StorageDefaultsContext, TargetSystemRootContext } from "../contexts/Common.jsx";
 
 import { scenarios } from "../components/storage/scenarios/index.js";
 
@@ -312,4 +312,31 @@ export const useOriginalDevices = () => {
     const originalDeviceTree = useOriginalDeviceTree();
 
     return originalDeviceTree ? originalDeviceTree.devices : {};
+};
+
+export const useLaunchStorageEditor = ({ setShowStorage }) => {
+    const targetSystemRoot = useContext(TargetSystemRootContext);
+    const { diskSelection } = useContext(StorageContext);
+    const devices = useOriginalDevices();
+    const mountPointConstraints = useMountPointConstraints();
+
+    const launchStorageEditor = useMemo(() => {
+        const availableDevices = [
+            ...diskSelection.selectedDisks,
+            ...diskSelection.selectedDisks.map(disk => getDeviceAncestors(devices, disk)).flat(),
+        ];
+        const isEfi = mountPointConstraints?.some(c => c["required-filesystem-type"]?.v === "efi");
+        const cockpitAnaconda = JSON.stringify({
+            available_devices: availableDevices.map(device => devices[device]?.path.v).filter(Boolean),
+            efi: isEfi,
+            mount_point_prefix: targetSystemRoot,
+        });
+
+        return () => {
+            window.sessionStorage.setItem("cockpit_anaconda", cockpitAnaconda);
+            setShowStorage(true);
+        };
+    }, [devices, diskSelection.selectedDisks, mountPointConstraints, setShowStorage, targetSystemRoot]);
+
+    return launchStorageEditor;
 };

--- a/test/check-progress
+++ b/test/check-progress
@@ -55,10 +55,6 @@ class TestInstallationProgress(VirtInstallMachineCase):
             "installation-progress-complete",
         )
 
-        # Check that at this stage 'Modify Storage' is not available
-        b.click("#toggle-kebab")
-        b.wait_visible("li.pf-m-aria-disabled #modify-storage")
-
         self.handleReboot()
 
 

--- a/test/helpers/storage.py
+++ b/test/helpers/storage.py
@@ -112,7 +112,6 @@ class StorageDestination():
         self.browser.wait_not_present("#cockpit-storage-integration-check-storage-dialog")
 
     def modify_storage(self):
-        self.browser.click("#toggle-kebab")
         self.browser.click("#modify-storage")
 
     def enter_cockpit_storage(self):


### PR DESCRIPTION
This change makes the storage editor more discoverable, with still being being presented as a last option when installing.

Assisted-by: Opus 4.6
Resolves: INSTALLER-4655

<img width="2286" height="1419" alt="Screenshot From 2026-08-10 10-25-42" src="https://github.com/user-attachments/assets/c3fd05e4-4e39-4aeb-9c11-e3764018e570" />
<img width="2243" height="1379" alt="Screenshot From 2026-08-10 09-46-39" src="https://github.com/user-attachments/assets/91056259-c0b9-457f-bcb9-129297e24a55" />

Also  I liked the `useLaunchStorageEditor` hook from the storage editor discoverability [PR](https://github.com/rhinstaller/anaconda-webui/pull/1398/changes#diff-b909491b2a39630dfb86a53e6f1612889ce9f738ea6eb7f6868a77b27a08cf6c) and reused it here.