### PR TITLE
Require authentication for remote installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,11 +128,17 @@ install: $(DIST_TEST) po/LINGUAS
 	cp browser-ext $(DESTDIR)/usr/libexec/anaconda
 	cp gnome-control-center-ext $(DESTDIR)/usr/libexec/anaconda
 	cp src/scripts/cockpit-coproc-wrapper.sh $(DESTDIR)/usr/libexec/anaconda/
+	cp src/scripts/cockpit-pin-auth $(DESTDIR)/usr/libexec/anaconda/
 	cp src/scripts/anaconda-cockpit-conf-merge $(DESTDIR)/usr/libexec/anaconda/
 	mkdir -p $(DESTDIR)/usr/lib/systemd/system/
 	cp src/systemd/webui-cockpit-ws.service $(DESTDIR)/usr/lib/systemd/system/
+	cp src/systemd/cockpit-pin-auth@.service $(DESTDIR)/usr/lib/systemd/system/
+	cp src/systemd/cockpit-pin-auth.socket $(DESTDIR)/usr/lib/systemd/system/
 	mkdir -p $(DESTDIR)/etc/anaconda/cockpit/conf.d/
 	cp src/config/cockpit/cockpit.conf $(DESTDIR)/etc/anaconda/cockpit/cockpit.conf
+	# Staged config, not active by default — webui-desktop copies it to conf.d/ at runtime
+	mkdir -p $(DESTDIR)/usr/share/anaconda/cockpit/conf.d/
+	cp src/config/cockpit/conf.d/50-remote-auth.conf $(DESTDIR)/usr/share/anaconda/cockpit/conf.d/
 
 dist: $(TARFILE)
 	@ls -1 $(TARFILE)

--- a/build.js
+++ b/build.js
@@ -49,7 +49,7 @@ function watchDirs (dir, onChange) {
 
 const context = await esbuild.context({
     bundle: true,
-    entryPoints: ["./src/index.js"],
+    entryPoints: ["./src/index.js", "./src/anacondaLogin.js"],
     external: ["*.woff", "*.woff2", "*.jpg", "*.svg", "../../assets*"],
     legalComments: "external", // Move all legal comments to a .LEGAL.txt file
     loader: {
@@ -69,6 +69,7 @@ const context = await esbuild.context({
                 { from: ["./images/qr-code-feedback.svg"], to: ["./qr-code-feedback.svg"] },
                 { from: ["./src/manifest.json"], to: ["./manifest.json"] },
                 { from: ["./src/index.html"], to: ["./index.html"] },
+                { from: ["./src/login.html"], to: ["./login.html"] },
                 { from: ["./VERSION.txt"], to: ["./VERSION.txt"] },
             ]
         }),
@@ -77,7 +78,9 @@ const context = await esbuild.context({
             quietDeps: true,
         }),
         cockpitPoEsbuildPlugin(),
-        cockpitCompressPlugin(),
+        // Login assets are served via /cockpit/static/ which does not
+        // support .gz transparent serving, causing MIME type mismatch.
+        cockpitCompressPlugin({ exclude: /anacondaLogin\.(js|css)$/ }),
         cockpitRsyncEsbuildPlugin({ dest: packageJson.name }),
 
         {

--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -65,7 +65,13 @@ exit 0
 %files
 %dir %{_datadir}/cockpit/anaconda-webui
 %doc README.rst
-%license LICENSE dist/index.js.LEGAL.txt
+%license LICENSE dist/index.js.LEGAL.txt dist/anacondaLogin.js.LEGAL.txt
+%{_datadir}/cockpit/anaconda-webui/login.html
+%{_datadir}/cockpit/anaconda-webui/anacondaLogin.js
+%{_datadir}/cockpit/anaconda-webui/anacondaLogin.js.map
+%{_datadir}/cockpit/anaconda-webui/anacondaLogin.js.LEGAL.txt
+%{_datadir}/cockpit/anaconda-webui/anacondaLogin.css
+%{_datadir}/cockpit/anaconda-webui/anacondaLogin.css.map
 %{_datadir}/cockpit/anaconda-webui/qr-code-feedback.svg
 %{_datadir}/cockpit/anaconda-webui/index.js.LEGAL.txt
 %{_datadir}/cockpit/anaconda-webui/index.html
@@ -81,6 +87,10 @@ exit 0
 %dir /etc/anaconda/cockpit
 %config(noreplace) /etc/anaconda/cockpit/cockpit.conf
 %dir /etc/anaconda/cockpit/conf.d
+%dir %{_datadir}/anaconda/cockpit
+%dir %{_datadir}/anaconda/cockpit/conf.d
+%{_datadir}/anaconda/cockpit/conf.d/50-remote-auth.conf
+%{_libexecdir}/anaconda/cockpit-pin-auth
 %dir %{_datadir}/anaconda/firefox-theme
 %dir %{_datadir}/anaconda/firefox-theme/default
 %dir %{_datadir}/anaconda/firefox-theme/default/chrome
@@ -98,6 +108,8 @@ exit 0
 %{_datadir}/applications/extlinks.desktop
 %{_datadir}/applications/anaconda-gnome-control-center.desktop
 %{_unitdir}/webui-cockpit-ws.service
+%{_unitdir}/cockpit-pin-auth.socket
+%{_unitdir}/cockpit-pin-auth@.service
 
 
 # The changelog is automatically generated and merged

--- a/src/anacondaLogin.js
+++ b/src/anacondaLogin.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+import cockpit from "cockpit";
+
+import "cockpit-dark-theme";
+
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+import { convertToCockpitLang } from "./helpers/language.js";
+
+import { LoginPage } from "./components/login/LoginPage.jsx";
+
+import "./components/app.scss";
+import "../pkg/lib/patternfly/patternfly-6-cockpit.scss";
+import "../pkg/lib/patternfly/patternfly-6-overrides.scss";
+
+document.addEventListener("DOMContentLoaded", () => {
+    const root = createRoot(document.getElementById("app"));
+    root.render(<LoginPage />);
+    document.documentElement.setAttribute("dir", cockpit.language_direction);
+    document.documentElement.setAttribute("lang", convertToCockpitLang({ lang: cockpit.language }));
+});

--- a/src/components/login/LoginPage.jsx
+++ b/src/components/login/LoginPage.jsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+import cockpit from "cockpit";
+
+import React, { useState } from "react";
+import {
+    ActionGroup,
+    Button,
+    Form,
+    FormGroup,
+    FormHelperText,
+} from "@patternfly/react-core/dist/esm/components";
+import {
+    Card,
+    CardBody,
+    CardTitle
+} from "@patternfly/react-core/dist/esm/components/Card";
+import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText";
+import {
+    TextInputGroup,
+    TextInputGroupMain,
+    TextInputGroupUtilities
+} from "@patternfly/react-core/dist/esm/components/TextInputGroup";
+import { Bullseye } from "@patternfly/react-core/dist/esm/layouts/Bullseye";
+import { ExclamationCircleIcon } from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
+import { EyeIcon } from "@patternfly/react-icons/dist/esm/icons/eye-icon";
+import { EyeSlashIcon } from "@patternfly/react-icons/dist/esm/icons/eye-slash-icon";
+
+const _ = cockpit.gettext;
+
+export const LoginPage = () => {
+    const [pin, setPin] = useState("");
+    const [error, setError] = useState("");
+    const [isLoading, setIsLoading] = useState(false);
+    const [pinHidden, setPinHidden] = useState(true);
+
+    const handleSubmit = async (event) => {
+        event.preventDefault();
+        setError("");
+
+        if (!pin) {
+            setError(_("Please enter a PIN"));
+            return;
+        }
+
+        setIsLoading(true);
+
+        const headers = {
+            // Cockpit Basic auth format: user:password\0known_hosts
+            // https://github.com/cockpit-project/cockpit/blob/25dd89e3d168861cd19acd50237f9c8884341cc5/pkg/static/login.js#L666
+            Authorization: `Basic ${window.btoa(unescape(encodeURIComponent(`:${pin}`)))}`,
+        };
+
+        try {
+            const response = await fetch("/cockpit/login", {
+                headers,
+                method: "GET",
+            });
+
+            if (!response.ok) {
+                throw new Error("Authentication failed");
+            }
+
+            window.location = "/cockpit/@localhost/anaconda-webui/index.html";
+        } catch (err) {
+            setError(_("Invalid PIN. Please try again."));
+            setIsLoading(false);
+        }
+    };
+
+    return (
+
+        <Bullseye>
+            <Card>
+                <CardTitle>{_("Enter PIN to access the installer")}</CardTitle>
+                <CardBody>
+                    <Form onSubmit={handleSubmit}>
+                        <FormGroup isRequired fieldId="pin-input">
+                            <TextInputGroup>
+                                <TextInputGroupMain
+                                  type={pinHidden ? "password" : "text"}
+                                  inputId="pin-input"
+                                  name="pin"
+                                  value={pin}
+                                  onChange={(_event, value) => setPin(value)}
+                                  placeholder={_("Enter PIN")}
+                                />
+                                <TextInputGroupUtilities>
+                                    <Button
+                                      variant="plain"
+                                      onClick={() => setPinHidden(!pinHidden)}
+                                      aria-label={pinHidden ? _("Show PIN") : _("Hide PIN")}
+                                    >
+                                        {pinHidden ? <EyeIcon /> : <EyeSlashIcon />}
+                                    </Button>
+                                </TextInputGroupUtilities>
+                            </TextInputGroup>
+                            {error && (
+                                <FormHelperText>
+                                    <HelperText>
+                                        <HelperTextItem variant="error" icon={<ExclamationCircleIcon />}>
+                                            {error}
+                                        </HelperTextItem>
+                                    </HelperText>
+                                </FormHelperText>
+                            )}
+                        </FormGroup>
+                        <ActionGroup>
+                            <Button
+                              variant="primary"
+                              type="submit"
+                              isBlock
+                              isLoading={isLoading}
+                              isDisabled={isLoading}
+                            >
+                                {_("Log in")}
+                            </Button>
+                        </ActionGroup>
+                    </Form>
+                </CardBody>
+            </Card>
+        </Bullseye>
+
+    );
+};

--- a/src/config/cockpit/conf.d/50-remote-auth.conf
+++ b/src/config/cockpit/conf.d/50-remote-auth.conf
@@ -1,0 +1,15 @@
+# Copyright (C) 2026 Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Cockpit PIN authentication for remote WebUI access.
+# This file is NOT active by default. It is shipped to
+# /usr/share/anaconda/cockpit/conf.d/ and only copied into the
+# active /etc/anaconda/cockpit/conf.d/ at runtime by webui-desktop
+# when inst.webui.remote is set with a password and
+# inst.webui.remote.noauth is not set.
+
+[WebService]
+CustomLoginPage = /usr/share/cockpit/anaconda-webui/
+
+[Basic]
+Command = /usr/libexec/anaconda/cockpit-pin-auth

--- a/src/login.html
+++ b/src/login.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!--
+Copyright (C) 2026 Red Hat, Inc.
+SPDX-License-Identifier: LGPL-2.1-or-later
+-->
+<html lang="en">
+<head>
+    <title translate>Anaconda Web UI</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta insert="dynamic_content_here" />
+
+    <link rel="stylesheet" href="cockpit/static/anacondaLogin.css">
+    <link rel="stylesheet" href="cockpit/static/branding.css">
+    <script type="text/javascript" src="cockpit/static/anacondaLogin.js"></script>
+</head>
+
+<body class="pf-m-redhat-font anaconda">
+    <div class="ct-page-fill" id="app"></div>
+</body>
+</html>

--- a/src/scripts/cockpit-coproc-wrapper.sh
+++ b/src/scripts/cockpit-coproc-wrapper.sh
@@ -12,6 +12,11 @@ WEBUI_ADDRESS=$1
 # Start cockpit-bridge in unconfined context via su using coproc
 coproc BRIDGE { cockpit-bridge; }
 
-# Start cockpit-ws connected to the coproc
-# TLS settings are now in /etc/anaconda/cockpit/cockpit.conf (AllowUnencrypted)
-exec /usr/libexec/cockpit-ws -p 80 -a "$WEBUI_ADDRESS" --local-session=- <&${BRIDGE[0]} >&${BRIDGE[1]}
+# When auth is not enabled, use --local-session=- to connect
+# directly to the bridge (skips cockpit authentication).
+WS_EXTRA_ARGS=()
+if [[ "${WEBUI_AUTH:-0}" != "1" ]]; then
+    WS_EXTRA_ARGS+=(--local-session=-)
+fi
+
+exec /usr/libexec/cockpit-ws "${WS_EXTRA_ARGS[@]}" -p 80 -a "$WEBUI_ADDRESS" <&${BRIDGE[0]} >&${BRIDGE[1]}

--- a/src/scripts/cockpit-pin-auth
+++ b/src/scripts/cockpit-pin-auth
@@ -3,8 +3,68 @@
 # Copyright (C) 2026 Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Cockpit authentication handler that validates Basic credentials
-# against the PIN stored in /run/anaconda/remote-pin.
+# Cockpit authentication helper for Anaconda remote installation.
+#
+# This script implements the Cockpit authentication helper protocol to gate
+# remote WebUI access behind a PIN. It validates HTTP Basic credentials
+# (RFC 7617) against a one-time PIN stored in /run/anaconda/remote-pin.
+#
+# == End-to-end flow ==
+#
+# 1. The user boots the installer with `inst.webui.remote.pin=<PIN>`. Anaconda
+#    backend writes the PIN to /run/anaconda/remote-pin and webui-desktop
+#    copies 50-remote-auth.conf into Cockpit's active config directory,
+#    which sets:
+#      [Basic]
+#      Command = /usr/libexec/anaconda/cockpit-pin-auth
+#
+# 2. A remote browser connects to the installed system IP. Cockpit's custom
+#    login page (the Anaconda WebUI login component) collects the PIN from
+#    the user and sends it as an HTTP Basic auth header (user:password).
+#
+# 3. cockpit-ws spawns THIS script as a child process and communicates
+#    with it over stdin/stdout using Cockpit's length-prefixed JSON framing
+#    protocol (documented below). The systemd socket-activated service
+#    cockpit-pin-auth@.service handles the process lifecycle.
+#
+# 4. This script:
+#    a. Sends a challenge request ("*") to cockpit-ws, asking for credentials.
+#    b. Receives the Basic auth response from cockpit-ws.
+#    c. Decodes the base64 payload and extracts the PIN (password portion).
+#    d. Compares it against the expected PIN from /run/anaconda/remote-pin.
+#    e. On FAILURE: sends an "init" frame with a problem code back to
+#       cockpit-ws, which relays the error to the browser. Process exits.
+#    f. On SUCCESS: exec()s into cockpit-bridge, replacing this process.
+#       The bridge then sends the successful "init" message and handles the
+#       Cockpit session. This is how the protocol works - the auth helper
+#       *becomes* the bridge process via exec(), which replaces the current
+#       process image entirely. Each authenticated session gets its own
+#       bridge; there is no pre-existing bridge waiting for this session.
+#       This is the same pattern used by all upstream Cockpit auth helpers
+#       (cockpit-session, cockpit-auth-ssh-key, etc.).
+#
+# == Wire protocol ==
+#
+# Messages are length-prefixed JSON frames over stdio:
+#   <decimal-length>\n\n<json-payload>
+#
+# The length counts the JSON bytes plus the channel separator (one newline
+# for control-channel messages). Auth helpers use only the control channel.
+#
+# == References ==
+#
+# - Cockpit auth helper protocol:
+#   https://github.com/cockpit-project/cockpit/blob/b1433d5e8cd9786f1f357a9969a24d9634433850/doc/authentication.md
+# - Cockpit wire protocol (framing):
+#   https://github.com/cockpit-project/cockpit/blob/c1676a0d7c1ad664490ed5000b81077d295babdf/doc/protocol.md
+# - HTTP Basic authentication: RFC 7617
+#   https://datatracker.ietf.org/doc/html/rfc7617
+# - Upstream auth helper example (cockpit-auth-ssh-key):
+#   https://github.com/cockpit-project/cockpit/blob/a7ae147258a8102069cb7caa94fce1332ea49af1/containers/ws/cockpit-auth-ssh-key
+#
+# Note: Cockpit does not provide a reusable Python library for the auth
+# helper framing protocol. The read_size/read_frame/send_frame functions
+# below follow the same inline pattern used by upstream auth helpers.
 
 import base64
 import json
@@ -98,21 +158,32 @@ def read_auth_reply():
 
 
 def decode_basic_header(response):
+    """Decode an HTTP Basic auth header (RFC 7617) and return the password.
+
+    Input format: "Basic <base64(user:password)>"
+    The username is discarded - only the PIN (password) matters for our auth.
+    Split on ":" with maxsplit=1 to handle passwords containing colons.
+    Null bytes (\x00) are stripped as a defense against null-byte injection.
+    """
     b64_encoded_header = re.match(r"^Basic\s+(.+)\s*$", response)
     if not b64_encoded_header:
         raise ValueError(f"Invalid Basic auth header: {response}")
 
     decoded = base64.b64decode(b64_encoded_header.group(1)).decode()
-    # Standard Basic auth format is user:password — extract password after the colon
+    # Standard Basic auth format is user:password - extract password after the colon
     _, pin = decoded.split(":", 1)
     return pin.replace("\x00", "")
 
 
 def main():
+    """Authenticate a remote user via PIN and hand off to cockpit-bridge."""
     logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
+    # Step 1: Ask cockpit-ws for the user's credentials.
+    # Challenge "*" means "send me whatever credentials you have".
     send_auth_command("*", None)
 
+    # Step 2: Receive and decode the Basic auth response.
     password = ""
     try:
         response = read_auth_reply()
@@ -121,6 +192,7 @@ def main():
         send_problem_init("internal-error", str(e), {})
         raise
 
+    # Step 3: Load the expected PIN from the file written by webui-desktop.
     try:
         with open(PIN_FILE) as f:
             expected = f.read().strip()
@@ -128,10 +200,18 @@ def main():
         send_problem_init("internal-error", f"PIN file {PIN_FILE} not found", {})
         return
 
+    # Step 4: Compare. On mismatch, report failure and exit.
     if password != expected:
         send_problem_init("authentication-failed", "PIN did not match", {"password": "denied"})
         return
 
+    # Step 5: Replace this process with cockpit-bridge.
+    # The bridge sends the successful "init" message to cockpit-ws and
+    # takes over the Cockpit session. This is the standard auth helper
+    # exit path - the helper does not stay running alongside the bridge.
+    # Note: this code path only runs for remote (authenticated) access.
+    # For local/noauth installs, cockpit-ws is started with --local-session
+    # which spawns the bridge directly, bypassing auth helpers entirely.
     os.execlpe("python3", "python3", "-m", "cockpit.bridge", os.environ)
 
 

--- a/src/scripts/cockpit-pin-auth
+++ b/src/scripts/cockpit-pin-auth
@@ -1,0 +1,139 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2026 Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Cockpit authentication handler that validates Basic credentials
+# against the PIN stored in /run/anaconda/remote-pin.
+
+import base64
+import json
+import logging
+import os
+import re
+import sys
+import time
+
+logger = logging.getLogger(__name__)
+PIN_FILE = "/run/anaconda/remote-pin"
+
+
+def send_frame(content: "dict[str, str]"):
+    data = json.dumps(content).encode()
+    os.write(1, str(len(data) + 1).encode())
+    os.write(1, b"\n\n")
+    os.write(1, data)
+
+
+def send_auth_command(challenge: "str | None", response: "str | None"):
+    cmd = {
+        "command": "authorize",
+    }
+
+    if challenge is not None:
+        cmd["cookie"] = f"session{os.getpid()}{time.time()}"
+        cmd["challenge"] = challenge
+    if response is not None:
+        cmd["response"] = response
+
+    send_frame(cmd)
+
+
+def send_problem_init(problem, message, auth_methods):
+    cmd = {"command": "init", "problem": problem}
+
+    if message:
+        cmd["message"] = message
+
+    if auth_methods:
+        cmd["auth-method-results"] = auth_methods
+
+    send_frame(cmd)
+
+
+def read_size(fd):
+    sep = b"\n"
+    size = 0
+    seen = 0
+
+    while True:
+        t = os.read(fd, 1)
+
+        if not t:
+            return 0
+
+        if t == sep:
+            break
+
+        size = (size * 10) + int(t)
+        seen = seen + 1
+
+        if seen > 7:
+            raise ValueError("Invalid frame: size too long")
+
+    return size
+
+
+def read_frame(fd):
+    size = read_size(fd)
+
+    data = b""
+    while size > 0:
+        d = os.read(fd, size)
+        size = size - len(d)
+        data += d
+
+    return data.decode()
+
+
+def read_auth_reply():
+    data = read_frame(1)
+    cmd = json.loads(data)
+    logger.debug("cmd %s", cmd)
+    response = cmd.get("response")
+    if cmd.get("command") != "authorize" or not cmd.get("cookie") or not response:
+        raise ValueError("Did not receive a valid authorize command")
+
+    return response
+
+
+def decode_basic_header(response):
+    b64_encoded_header = re.match(r"^Basic\s+(.+)\s*$", response)
+    if not b64_encoded_header:
+        raise ValueError(f"Invalid Basic auth header: {response}")
+
+    decoded = base64.b64decode(b64_encoded_header.group(1)).decode()
+    # Standard Basic auth format is user:password — extract password after the colon
+    _, pin = decoded.split(":", 1)
+    return pin.replace("\x00", "")
+
+
+def main():
+    logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+    send_auth_command("*", None)
+
+    password = ""
+    try:
+        response = read_auth_reply()
+        password = decode_basic_header(response)
+    except (ValueError, TypeError, AssertionError) as e:
+        send_problem_init("internal-error", str(e), {})
+        raise
+
+    try:
+        with open(PIN_FILE) as f:
+            expected = f.read().strip()
+    except FileNotFoundError:
+        send_problem_init("internal-error", f"PIN file {PIN_FILE} not found", {})
+        return
+
+    if password != expected:
+        send_problem_init("authentication-failed", "PIN did not match", {"password": "denied"})
+        return
+
+    os.execlpe("python3", "python3", "-m", "cockpit.bridge", os.environ)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/systemd/cockpit-pin-auth.socket
+++ b/src/systemd/cockpit-pin-auth.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=Socket for cockpit pin auth service activation
+PartOf=cockpit-pin-auth.service
+
+[Socket]
+ListenStream=/run/cockpit/wsinstance/cockpit-pin-auth.sock
+SocketUser=root
+SocketMode=0666
+RemoveOnStop=yes
+Accept=yes

--- a/src/systemd/cockpit-pin-auth@.service
+++ b/src/systemd/cockpit-pin-auth@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Cockpit pin auth
+Requires=cockpit-pin-auth.socket
+
+[Service]
+ExecStart=/usr/libexec/anaconda/cockpit-pin-auth
+StandardInput=socket
+StandardOutput=inherit
+StandardError=journal
+Type=simple
+# bridge error, authentication failure, or timeout, that's not a problem with the unit
+SuccessExitStatus=1 5 127

--- a/test/check-remote-auth
+++ b/test/check-remote-auth
@@ -1,0 +1,53 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2026 Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase
+from installer import Installer
+from testlib import test_main  # pylint: disable=import-error
+
+
+class TestRemoteAuth(VirtInstallMachineCase):
+    provision = {
+        "machine1": {
+            "remote_pin": "test1234",
+            "memory_mb": INSTALLER_VM_MEMORY_MB,
+        },
+    }
+
+    def testBasic(self):
+        """
+        Description:
+            Boot with ``inst.webui.remote inst.webui.remote.password=test1234``
+            and verify that PIN authentication is required.
+
+        Expected results:
+            - The login page is shown
+            - Wrong PIN is rejected with an error
+            - Correct PIN grants access to the installer
+        """
+        b = self.browser
+        m = self.machine
+        _i = Installer(b, m)
+
+        b.open("/cockpit/@localhost/anaconda-webui/index.html")
+
+        # Login page should be visible
+        b.wait_visible("#pin-input")
+
+        # Wrong password should be rejected
+        b.set_input_text("#pin-input", "wrongpin")
+        b.click("button[type=submit]")
+        b.wait_in_text(".pf-v6-c-alert", "Invalid PIN")
+
+        # Correct password should grant access
+        b.set_input_text("#pin-input", "test1234")
+        b.click("button[type=submit]")
+
+        # After login redirect, the installer loads at the root path
+        b.wait_js_cond('window.location.pathname === "/cockpit/@localhost/anaconda-webui/index.html"')
+
+
+if __name__ == "__main__":
+    test_main()

--- a/test/machine_install.py
+++ b/test/machine_install.py
@@ -45,6 +45,7 @@ class VirtInstallMachine(VirtMachine):
         self.kickstart_file_name = kwargs.pop("kickstart_file_name", None)
         self.pause_at_summary = kwargs.pop("pause_at_summary", False)
         self.payload_type = kwargs.pop("payload_type", "liveimg".lower())
+        self.remote_pin = kwargs.pop("remote_pin", "")
         # Always enforce the minimum RAM the installer requires. Covers every entry point the same way:
         # test/run (CI), local test/check-*, and GlobalMachine.reset() which omits memory_mb.
         kwargs["memory_mb"] = max(kwargs.get("memory_mb") or 0, INSTALLER_VM_MEMORY_MB)
@@ -194,6 +195,7 @@ class VirtInstallMachine(VirtMachine):
             if self.console_file
             else ""
         )
+        auth_method = f"inst.webui.remote.pin={self.remote_pin}" if self.remote_pin else "inst.webui.remote.noauth"
         try:
             self._execute(
                 "virt-install "
@@ -208,7 +210,7 @@ class VirtInstallMachine(VirtMachine):
                 f"{serial_opt}"
                 f"--graphics vnc,listen={self.ssh_address} "
                 "--extra-args "
-                f"'{virt_kargs}{inst_graphical}inst.sshd inst.webui inst.webui.remote {selinux}{inst_ks_arg} "
+                f"'{virt_kargs}{inst_graphical}inst.sshd inst.webui inst.webui.remote {auth_method} {selinux}{inst_ks_arg} "
                 f"inst.updates=http://10.0.2.2:{self.http_install_port}/"
                 f"{self.label}-updates.img' "
                 "--network none "

--- a/test/webui_testvm.py
+++ b/test/webui_testvm.py
@@ -21,13 +21,15 @@ def cmd_cli():
     parser.add_argument("--kickstart", help="Kickstart file name from test/kickstarts/", dest="kickstart_file_name")
     parser.add_argument("--pause-at-summary", help="Pause automated kickstart install at the review screen",
                         action='store_true', dest="pause_at_summary")
+    parser.add_argument("--remote-pin", help="PIN for accessing the webui. Blank value defaults to inst.webui.remote.noauth",
+                        dest="remote_pin")
     args = parser.parse_args()
 
     if args.bios:
         os.environ["TEST_FIRMWARE"] = "bios"
     machine = VirtInstallMachine(image=args.image, memory_mb=INSTALLER_VM_MEMORY_MB,
                                  kickstart_file_name=args.kickstart_file_name,
-                                 pause_at_summary=args.pause_at_summary)
+                                 pause_at_summary=args.pause_at_summary, remote_pin=args.remote_pin)
     try:
         machine.start()
 

--- a/webui-desktop
+++ b/webui-desktop
@@ -34,13 +34,15 @@ BROWSER_HOME=""
 
 THEME_ID="default"
 WEBUI_REMOTE=0
-while getopts t:r: option
+WEBUI_NOAUTH=0
+while getopts t:r:n: option
 do
     case "${option}"
         in
         t)THEME_ID=${OPTARG};;
         r)WEBUI_REMOTE=${OPTARG};;
-        *) echo "Usage: $0 [-t THEME_ID] [-r WEBUI_REMOTE]" >&2
+        n)WEBUI_NOAUTH=${OPTARG};;
+        *) echo "Usage: $0 [-t THEME_ID] [-r WEBUI_REMOTE] [-n WEBUI_NOAUTH]" >&2
        exit 1 ;;
     esac
 done
@@ -53,7 +55,21 @@ then
     WEBUI_ADDRESS="0.0.0.0"
 fi
 
+REMOTE_AUTH_DROPIN="/etc/anaconda/cockpit/conf.d/50-remote-auth.conf"
+REMOTE_AUTH_SOURCE="/usr/share/anaconda/cockpit/conf.d/50-remote-auth.conf"
+PIN_FILE="/run/anaconda/remote-pin"
+WEBUI_AUTH=0
+
+if [[ -f "$PIN_FILE" ]]; then
+    cp "$REMOTE_AUTH_SOURCE" "$REMOTE_AUTH_DROPIN"
+    WEBUI_AUTH=1
+else
+    rm -f "$REMOTE_AUTH_DROPIN"
+fi
+
 echo "WEBUI_ADDRESS=$WEBUI_ADDRESS" > /tmp/webui-cockpit-ws.env
+echo "WEBUI_AUTH=$WEBUI_AUTH" >> /tmp/webui-cockpit-ws.env
+
 systemctl start webui-cockpit-ws
 
 # Function to setup user-related environment


### PR DESCRIPTION
This work was built on top of the proof of concept #1274 and rhinstaller/anaconda#7228.

Now `inst.webui.remote` requires one additional argument: either `inst.webui.remote.pin=<somevalue>`, which is the intended/recommended way for end users to use it, or `inst.webui.remote.noauth`, which mimicks current behavior. This last option was added as convenience to not disrupt tests.

## How to test

The new test requires the backend to work, so for now it can only be tested with something like
```
TEST_SCENARIO=anaconda-pr-7228 make create-updates.img
toolbox run -c anaconda-webui bash -c 'TEST_OS=fedora-rawhide-boot TEST_AUDIT_NO_SELINUX=1 test/check-remote-auth'
```
Then you can run the vm with webui_testvm CLI
```
toolbox run -c anaconda-webui python test/webui_testvm.py fedora-rawhide-boot --remote-pin=<SOMEPIN>
```

## Screenshots

When logging in you should see this
<img width="816" height="630" alt="image" src="https://github.com/user-attachments/assets/cf67f3dc-7a5f-4d7a-96a8-647800691485" />

passing an incorrect PIN should trigger the following and clicking "login" should display the following
<img width="816" height="630" alt="image" src="https://github.com/user-attachments/assets/a81e04e2-4182-4a4f-af60-9375e404f249" />

finally, clicking the 👁️ reveals the PIN value
<img width="697" height="507" alt="image" src="https://github.com/user-attachments/assets/9960b019-72b7-423c-b668-1520c19bbdee" />


