### PR TITLE
fix: update eslint scripts to include build.js for linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "watch": "ESBUILD_WATCH=true ./build.js",
     "build": "./build.js",
-    "eslint": "eslint --ext .js --ext .jsx src/",
-    "eslint:fix": "eslint --fix --ext .js --ext .jsx src/",
+    "eslint": "eslint --ext .js --ext .jsx src/ build.js",
+    "eslint:fix": "eslint --fix --ext .js --ext .jsx src/ build.js",
     "stylelint": "stylelint 'src/**/*{.css,scss}'",
     "stylelint:fix": "stylelint --fix 'src/**/*{.css,scss}'"
   },


### PR DESCRIPTION
for some reason build.js wasn't included on eslint checks 😅 

EDIT: wow, everything is breaking now. maybe that's why it wasn't included. Funily enough if I run `npm run eslint` it works as expected...