### PR TITLE
feat: use InstallationStatus as source of truth for page navigation

### DIFF
--- a/src/apis/boss.js
+++ b/src/apis/boss.js
@@ -112,6 +112,23 @@ export const installWithTasks = () => {
 };
 
 /**
+ * @returns {Promise}           Resolves when the first installation task has been started
+ */
+export const startInstallation = () => {
+    return installWithTasks().then(tasks => {
+        const taskProxy = new BossClient().client.proxy(
+            "org.fedoraproject.Anaconda.Task",
+            tasks[0]
+        );
+        return new Promise((resolve, reject) => {
+            taskProxy.wait(() => {
+                taskProxy.Start().then(resolve, reject);
+            });
+        });
+    });
+};
+
+/**
  * @param {string} locale       Locale id
  */
 export const setLocale = ({ locale }) => {

--- a/src/apis/boss.js
+++ b/src/apis/boss.js
@@ -11,6 +11,7 @@ import { error } from "../helpers/log.js";
 import { _callClient, _getProperty } from "./helpers.js";
 
 import { moduleClients } from "./index.js";
+import { PayloadsClient } from "./payloads.js";
 
 const OBJECT_PATH = "/org/fedoraproject/Anaconda/Boss";
 const INTERFACE_NAME = "org.fedoraproject.Anaconda.Boss";
@@ -44,13 +45,21 @@ export class BossClient {
         this.dispatch = dispatch;
     }
 
-    init (args = {}) {
+    async init (args = {}) {
         this.client.addEventListener("close", () => error("Boss client closed"));
+
+        const status = await getInstallationStatus();
+        // PayloadsClient is problematic outside NOT_STARTED state, potentially leading
+        // to UnknownCompsEnvironmentError.
+        const payloadsNotNeeded = status !== INSTALLATION_STATUS.NOT_STARTED;
+        const clients = payloadsNotNeeded
+            ? moduleClients.filter(C => C !== PayloadsClient)
+            : moduleClients;
 
         return Promise.all([
             this.dispatch(getInstallationStatusAction()),
             this.dispatch(getPendingErrorAction()),
-            ...moduleClients.map(Client => new Client(this.address, this.dispatch).init(args))
+            ...clients.map(Client => new Client(this.address, this.dispatch).init(args))
         ]).then(() => {
             this.startEventMonitor();
         });

--- a/src/apis/boss.js
+++ b/src/apis/boss.js
@@ -11,7 +11,9 @@ import { error } from "../helpers/log.js";
 import { _callClient, _getProperty } from "./helpers.js";
 
 import { moduleClients } from "./index.js";
-import { PayloadsClient } from "./payloads.js";
+import { LocalizationClient } from "./localization.js";
+import { NetworkClient } from "./network.js";
+import { RuntimeClient } from "./runtime.js";
 
 const OBJECT_PATH = "/org/fedoraproject/Anaconda/Boss";
 const INTERFACE_NAME = "org.fedoraproject.Anaconda.Boss";
@@ -49,13 +51,12 @@ export class BossClient {
         this.client.addEventListener("close", () => error("Boss client closed"));
 
         const status = await getInstallationStatus();
-        // PayloadsClient is problematic outside NOT_STARTED state, potentially leading
-        // to UnknownCompsEnvironmentError.
-        const payloadsNotNeeded = status !== INSTALLATION_STATUS.NOT_STARTED;
-        const clients = payloadsNotNeeded
-            ? moduleClients.filter(C => C !== PayloadsClient)
-            : moduleClients;
-
+        const installationCompleted = status === INSTALLATION_STATUS.SUCCEEDED ||
+            status === INSTALLATION_STATUS.FAILED;
+        // If the installation is completed, only init strictly required modules. Loading others can be
+        // problematic. PayloadClient, for instance, consistently leads to an error on reconnection
+        // if the installation is completed.
+        const clients = installationCompleted ? [RuntimeClient, NetworkClient, LocalizationClient] : moduleClients;
         return Promise.all([
             this.dispatch(getInstallationStatusAction()),
             this.dispatch(getPendingErrorAction()),

--- a/src/apis/boss.js
+++ b/src/apis/boss.js
@@ -61,13 +61,17 @@ export class BossClient {
             { },
             (path, iface, signal, args) => {
                 if (signal === "PropertiesChanged" &&
-                    args[0] === INTERFACE_NAME &&
-                    Object.hasOwn(args[1], "ActiveInstallationTask") &&
-                    args[1].ActiveInstallationTask.v) {
-                    for (const Client of moduleClients) {
-                        Client.instance?.stopEventMonitor();
+                    args[0] === INTERFACE_NAME) {
+                    if (Object.hasOwn(args[1], "InstallationStatus")) {
+                        this.dispatch(getInstallationStatusAction());
                     }
-                    this.stopEventMonitor();
+                    if (Object.hasOwn(args[1], "ActiveInstallationTask") &&
+                        args[1].ActiveInstallationTask.v) {
+                        for (const Client of moduleClients) {
+                            Client.instance?.stopEventMonitor();
+                        }
+                        this.stopEventMonitor();
+                    }
                 }
             }
         );

--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -6,11 +6,11 @@ import cockpit from "cockpit";
 
 import { usePageLocation } from "hooks";
 
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { PageSection, PageSectionTypes } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Wizard, WizardStep } from "@patternfly/react-core/dist/esm/components/Wizard/index.js";
 
-import { getActiveInstallationTask } from "../apis/boss.js";
+import { getActiveInstallationTask, startInstallation } from "../apis/boss.js";
 
 import { PageContext, PayloadContext, StorageContext, SystemTypeContext, UserInterfaceContext } from "../contexts/Common.jsx";
 
@@ -37,9 +37,16 @@ export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFe
 
     const autoProceedBlockedRef = useRef(false);
 
+    const beginInstallation = useCallback(() => {
+        setIsStartingInstallation(true);
+        startInstallation()
+                .catch(onCritFail({ context: "Installation of the system failed" }));
+    }, [onCritFail]);
+
     const componentProps = {
         autoProceedBlockedRef,
         automatedInstall,
+        beginInstallation,
         dispatch,
         onCritFail,
         pauseAtSummary,

--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -10,9 +10,9 @@ import React, { useCallback, useContext, useEffect, useRef, useState } from "rea
 import { PageSection, PageSectionTypes } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Wizard, WizardStep } from "@patternfly/react-core/dist/esm/components/Wizard/index.js";
 
-import { getActiveInstallationTask, startInstallation } from "../apis/boss.js";
+import { INSTALLATION_STATUS, startInstallation } from "../apis/boss.js";
 
-import { PageContext, PayloadContext, StorageContext, SystemTypeContext, UserInterfaceContext } from "../contexts/Common.jsx";
+import { BossContext, PageContext, PayloadContext, StorageContext, SystemTypeContext, UserInterfaceContext } from "../contexts/Common.jsx";
 
 import { AnacondaPage } from "./AnacondaPage.jsx";
 import { AnacondaWizardFooter } from "./AnacondaWizardFooter.jsx";
@@ -27,6 +27,7 @@ export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFe
      */
     const [isFormDisabled, setIsFormDisabled] = useState(false);
     const [isFormValid, setIsFormValid] = useState(false);
+    const [isStartingInstallation, setIsStartingInstallation] = useState(false);
     const [stepNotification, setStepNotification] = useState(null);
 
     const { storageScenarioId } = useContext(StorageContext);
@@ -34,6 +35,7 @@ export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFe
     const payloadType = useContext(PayloadContext).type;
     const userInterfaceConfig = useContext(UserInterfaceContext);
     const { path } = usePageLocation();
+    const { installationStatus } = useContext(BossContext);
 
     const autoProceedBlockedRef = useRef(false);
 
@@ -65,25 +67,21 @@ export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFe
     const stepsOrder = getSteps(automatedInstall, userInterfaceConfig, { isBootIso, payloadType, storageScenarioId });
     const firstStepId = stepsOrder.find(s => s.isFirstScreen)?.id;
 
+    const finalStepId = stepsOrder[stepsOrder.length - 1]?.id;
+
     useEffect(() => {
-        if (path[0] && path[0] !== currentStepId) {
+        if (installationStatus && installationStatus !== INSTALLATION_STATUS.NOT_STARTED) {
+            if (path[0] !== finalStepId) {
+                cockpit.location.go([finalStepId]);
+            }
+        } else if (path[0] && path[0] !== currentStepId) {
             // If path is set respect it
             setCurrentStepId(path[0]);
         } else if (!currentStepId) {
             // Otherwise set the first step as the current step
             setCurrentStepId(firstStepId);
         }
-    }, [currentStepId, firstStepId, path, setCurrentStepId]);
-
-    const finalStepId = stepsOrder[stepsOrder.length - 1]?.id;
-    useEffect(() => {
-        getActiveInstallationTask()
-                .then(activeTask => {
-                    if (activeTask) {
-                        cockpit.location.go([finalStepId]);
-                    }
-                });
-    }, [finalStepId]);
+    }, [currentStepId, finalStepId, firstStepId, installationStatus, path, setCurrentStepId]);
 
     const createSteps = (stepsOrder, componentProps) => {
         return stepsOrder.map(s => {
@@ -139,15 +137,18 @@ export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFe
         cockpit.location.go([newStep.id]);
     };
 
+    // Render the progress page only if the installation has started. Direct
+    // URL access with NOT_STARTED status would crash without installation context.
+    // While the installation is being triggered, render nothing to avoid flashing.
     const finalStep = stepsOrder[stepsOrder.length - 1];
-    if (path[0] === finalStep.id) {
+    if (path[0] === finalStep.id && installationStatus !== INSTALLATION_STATUS.NOT_STARTED) {
         return (
             <PageSection hasBodyWrapper={false} type={PageSectionTypes.wizard}>
                 <finalStep.component {...componentProps} />
             </PageSection>
         );
     }
-    if (currentStepId === undefined) {
+    if (currentStepId === undefined || isStartingInstallation) {
         return null;
     }
 

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -7,7 +7,7 @@ import cockpit from "cockpit";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Page, PageGroup, PageSection, PageSectionTypes } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 
-import { BossClient, INSTALLATION_STATUS } from "../apis/boss.js";
+import { BossClient } from "../apis/boss.js";
 
 import { initialState, reducer, useReducerWithThunk } from "../reducer.js";
 
@@ -73,22 +73,6 @@ export const Application = ({ conf, dispatch, installationStatus, isFetching, on
                     setStoreInitialized(true);
                 }, onCritFail({ context: N_("Reading information about the computer failed.") }));
     }, [address, automatedInstall, conf, dispatch, onCritFail]);
-
-    // Redirect to the correct page based on installation status
-    useEffect(() => {
-        if (!installationStatus) {
-            return;
-        }
-        const PROGRESS_PAGE = "anaconda-screen-progress";
-        const currentPath = cockpit.location.path[0];
-        const shouldBeOnProgress = installationStatus !== INSTALLATION_STATUS.NOT_STARTED;
-
-        if (shouldBeOnProgress && currentPath !== PROGRESS_PAGE) {
-            cockpit.location.replace([PROGRESS_PAGE]);
-        } else if (!shouldBeOnProgress && currentPath === PROGRESS_PAGE) {
-            cockpit.location.replace([]);
-        }
-    }, [installationStatus]);
 
     // Postpone rendering anything until we read the dbus address and the default configuration
     if (!address || !storeInitialized || !installationStatus) {

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -7,7 +7,7 @@ import cockpit from "cockpit";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Page, PageGroup, PageSection, PageSectionTypes } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 
-import { BossClient } from "../apis/boss.js";
+import { BossClient, INSTALLATION_STATUS } from "../apis/boss.js";
 
 import { initialState, reducer, useReducerWithThunk } from "../reducer.js";
 
@@ -73,6 +73,22 @@ export const Application = ({ conf, dispatch, installationStatus, isFetching, on
                     setStoreInitialized(true);
                 }, onCritFail({ context: N_("Reading information about the computer failed.") }));
     }, [address, automatedInstall, conf, dispatch, onCritFail]);
+
+    // Redirect to the correct page based on installation status
+    useEffect(() => {
+        if (!installationStatus) {
+            return;
+        }
+        const PROGRESS_PAGE = "anaconda-screen-progress";
+        const currentPath = cockpit.location.path[0];
+        const shouldBeOnProgress = installationStatus !== INSTALLATION_STATUS.NOT_STARTED;
+
+        if (shouldBeOnProgress && currentPath !== PROGRESS_PAGE) {
+            cockpit.location.replace([PROGRESS_PAGE]);
+        } else if (!shouldBeOnProgress && currentPath === PROGRESS_PAGE) {
+            cockpit.location.replace([]);
+        }
+    }, [installationStatus]);
 
     // Postpone rendering anything until we read the dbus address and the default configuration
     if (!address || !storeInitialized || !installationStatus) {

--- a/src/components/installation/InstallationProgress.jsx
+++ b/src/components/installation/InstallationProgress.jsx
@@ -14,7 +14,7 @@ import { ExclamationCircleIcon } from "@patternfly/react-icons/dist/esm/icons/ex
 import { InProgressIcon } from "@patternfly/react-icons/dist/esm/icons/in-progress-icon";
 import { PendingIcon } from "@patternfly/react-icons/dist/esm/icons/pending-icon";
 
-import { BossClient, getActiveInstallationTask, getSteps, INSTALLATION_STATUS, installWithTasks } from "../../apis/boss.js";
+import { BossClient, getActiveInstallationTask, getSteps, INSTALLATION_STATUS } from "../../apis/boss.js";
 
 import { exitGui, rebootSystem } from "../../helpers/exit.js";
 import { debug } from "../../helpers/log.js";
@@ -123,12 +123,6 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
             });
         };
 
-        const startNewInstallation = () =>
-            installWithTasks().then(
-                tasks => connectToTask(tasks[0], true),
-                onCritFail(failureCtx)
-            );
-
         const handleError = (message, detailType, categoryProxy) => {
             if (!message) return;
 
@@ -170,8 +164,11 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
                 }
                 break;
 
-            default:
-                startNewInstallation();
+            default: {
+                const errMsg = "Progress page reached but installation has not started";
+                debug(errMsg);
+                onCritFail(failureCtx)({ message: errMsg });
+            }
             }
         };
         syncInstallState();

--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -76,7 +76,7 @@ const ReviewDescriptionList = ({ children }) => {
     );
 };
 
-export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, pauseAtSummary }) => {
+export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, beginInstallation, pauseAtSummary }) => {
     const osRelease = useContext(OsReleaseContext);
     const userInterfaceConfig = useContext(UserInterfaceContext);
     const hiddenScreens = userInterfaceConfig.hidden_webui_pages || [];
@@ -131,17 +131,17 @@ export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, p
             return;
         }
         if (allValidatedReviewPagesComplete) {
-            cockpit.location.go(["anaconda-screen-progress"]);
+            beginInstallation();
         } else {
             autoProceedBlockedRef.current = true;
         }
-    }, [automatedInstall, pauseAtSummary, allValidatedReviewPagesComplete, storageValidationPending,
+    }, [automatedInstall, beginInstallation, pauseAtSummary, allValidatedReviewPagesComplete, storageValidationPending,
         autoProceedBlockedRef, reviewValidationPending]);
 
     // Display custom footer
     const getFooter = useMemo(() => (
-        <CustomFooter pageValidationOk={allValidatedReviewPagesComplete && !reviewValidationPending} />
-    ), [allValidatedReviewPagesComplete, reviewValidationPending]);
+        <CustomFooter beginInstallation={beginInstallation} pageValidationOk={allValidatedReviewPagesComplete && !reviewValidationPending} />
+    ), [allValidatedReviewPagesComplete, beginInstallation, reviewValidationPending]);
     useWizardFooter(getFooter);
 
     const languageDescription = localizationComplete
@@ -327,7 +327,7 @@ const useConfirmationCheckboxLabel = () => {
     return scenarioConfirmationLabel;
 };
 
-const CustomFooter = ({ pageValidationOk }) => {
+const CustomFooter = ({ beginInstallation, pageValidationOk }) => {
     const { setIsFormValid } = useContext(PageContext) ?? {};
     const { getButtonLabel } = useScenario();
     const buttonLabel = getButtonLabel?.();
@@ -355,7 +355,7 @@ const CustomFooter = ({ pageValidationOk }) => {
           footerHelperText={confirmationCheckbox}
           nextButtonText={buttonLabel}
           nextButtonVariant={!installationIsClean ? "warning" : "primary"}
-          onNext={() => cockpit.location.go(["anaconda-screen-progress"])}
+          onNext={() => beginInstallation()}
         />
     );
 };

--- a/test/check-progress
+++ b/test/check-progress
@@ -49,6 +49,11 @@ class TestInstallationProgress(VirtInstallMachineCase):
         b.wait_in_text("h2", "Successfully installed")
         b.wait_in_text(".pf-v6-c-empty-state", f"To begin using {get_pretty_name(m)}, reboot your system")
 
+        # Reload the page on success to make sure reconnect also works here
+        b.reload()
+        b.wait_in_text("h2", "Successfully installed")
+        b.wait_in_text(".pf-v6-c-empty-state", f"To begin using {get_pretty_name(m)}, reboot your system")
+
         # Pixel test the complete progress step
         b.assert_pixels(
             "#app",


### PR DESCRIPTION
The remote access gives users the opportunity to access any url, which might lead to errors if anaconda is not at the proper state to show that screen. One bug resulting from this, for instance, is forcibly going to screen-progress page while the installation has not started yet: it will trigger a nasty error reported on INSTALLER-4825.

This opens an avenue of bugs that we likely need to fix anyway, but instead of patching them one by one now, this proposal is to fix them all by relying on the the installation status now reported by the backend.

**Maybe we could even rely on INSTALLATION_STATUS to reactively change to certain pages in the future instead of making individual calls to cockpit.location.go("somepage").**

Also fix a bug related to remote installation: when reloading/reconnecting after an installation already started, the Payloads module often errors with "UnknownCompsEnvironmentError". This error is 100% reproducible for dnf payload type and the installation is completed with success.

Resolves: INSTALLER-4825