### PR TITLE
[DO NOT MERGE] PoC: Add cockpit-tls support for remote installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,13 @@ install: $(DIST_TEST) po/LINGUAS
 	cp src/systemd/webui-cockpit-ws.service $(DESTDIR)/usr/lib/systemd/system/
 	cp src/systemd/cockpit-pin-auth@.service $(DESTDIR)/usr/lib/systemd/system/
 	cp src/systemd/cockpit-pin-auth.socket $(DESTDIR)/usr/lib/systemd/system/
+	cp src/systemd/webui-cockpit-tls.service $(DESTDIR)/usr/lib/systemd/system/
+	cp src/systemd/webui-cockpit-tls.socket $(DESTDIR)/usr/lib/systemd/system/
+	cp src/systemd/webui-wsinstance-https-factory.socket $(DESTDIR)/usr/lib/systemd/system/
+	cp src/systemd/webui-wsinstance-https-factory@.service $(DESTDIR)/usr/lib/systemd/system/
+	mkdir -p $(DESTDIR)/usr/share/anaconda/systemd/
+	cp src/systemd/cockpit-wsinstance-https@.socket $(DESTDIR)/usr/share/anaconda/systemd/
+	cp src/systemd/cockpit-wsinstance-https@.service $(DESTDIR)/usr/share/anaconda/systemd/
 	mkdir -p $(DESTDIR)/etc/anaconda/cockpit/conf.d/
 	cp src/config/cockpit/cockpit.conf $(DESTDIR)/etc/anaconda/cockpit/cockpit.conf
 	# Staged config, not active by default — webui-desktop copies it to conf.d/ at runtime

--- a/packaging/anaconda-webui.spec.in
+++ b/packaging/anaconda-webui.spec.in
@@ -110,6 +110,13 @@ exit 0
 %{_unitdir}/webui-cockpit-ws.service
 %{_unitdir}/cockpit-pin-auth.socket
 %{_unitdir}/cockpit-pin-auth@.service
+%{_unitdir}/webui-cockpit-tls.service
+%{_unitdir}/webui-cockpit-tls.socket
+%{_unitdir}/webui-wsinstance-https-factory.socket
+%{_unitdir}/webui-wsinstance-https-factory@.service
+%dir %{_datadir}/anaconda/systemd
+%{_datadir}/anaconda/systemd/cockpit-wsinstance-https@.socket
+%{_datadir}/anaconda/systemd/cockpit-wsinstance-https@.service
 
 
 # The changelog is automatically generated and merged

--- a/src/config/cockpit/conf.d/50-remote-auth.conf
+++ b/src/config/cockpit/conf.d/50-remote-auth.conf
@@ -10,6 +10,7 @@
 
 [WebService]
 CustomLoginPage = /usr/share/cockpit/anaconda-webui/
+AllowUnencrypted = false
 
 [Basic]
 Command = /usr/libexec/anaconda/cockpit-pin-auth

--- a/src/systemd/cockpit-wsinstance-https@.service
+++ b/src/systemd/cockpit-wsinstance-https@.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Anaconda Cockpit WS https instance %I
+Requires=cockpit-session.socket
+After=cockpit-session.socket
+
+[Service]
+Environment="XDG_CONFIG_DIRS=/run/anaconda"
+ExecStart=/usr/libexec/cockpit-ws --for-tls-proxy --port=0

--- a/src/systemd/cockpit-wsinstance-https@.socket
+++ b/src/systemd/cockpit-wsinstance-https@.socket
@@ -1,0 +1,8 @@
+[Unit]
+Description=Socket for Anaconda Cockpit WS https instance %I
+BindsTo=webui-cockpit-tls.service
+BindsTo=cockpit-wsinstance-https@%i.service
+
+[Socket]
+ListenStream=/run/cockpit/wsinstance/https@%i.sock
+RemoveOnStop=yes

--- a/src/systemd/webui-cockpit-tls.service
+++ b/src/systemd/webui-cockpit-tls.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Cockpit TLS Service for Anaconda Remote Installation
+Documentation=man:cockpit-tls(8)
+Requires=webui-cockpit-tls.socket
+Requires=webui-wsinstance-https-factory.socket
+After=webui-wsinstance-https-factory.socket
+
+[Service]
+RuntimeDirectory=cockpit/tls
+ExecStartPre=+/usr/libexec/anaconda/anaconda-cockpit-conf-merge
+ExecStartPre=+/usr/libexec/cockpit-certificate-ensure --for-cockpit-tls
+ExecStart=/usr/libexec/cockpit-tls --idle-timeout=0
+
+[Install]
+WantedBy=multi-user.target

--- a/src/systemd/webui-cockpit-tls.socket
+++ b/src/systemd/webui-cockpit-tls.socket
@@ -1,0 +1,11 @@
+[Unit]
+Description=Cockpit TLS Socket for Anaconda Remote Installation
+Documentation=man:cockpit-tls(8)
+
+[Socket]
+ListenStream=443
+ExecStartPost=-/bin/ln -snf active.issue /run/cockpit/issue
+ExecStopPost=-/bin/ln -snf inactive.issue /run/cockpit/issue
+
+[Install]
+WantedBy=sockets.target

--- a/src/systemd/webui-wsinstance-https-factory.socket
+++ b/src/systemd/webui-wsinstance-https-factory.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=Socket for Anaconda Cockpit WS https instance factory
+Documentation=man:cockpit-ws(8)
+BindsTo=webui-cockpit-tls.service
+
+[Socket]
+ListenStream=/run/cockpit/wsinstance/https-factory.sock
+Accept=yes
+RemoveOnStop=yes

--- a/src/systemd/webui-wsinstance-https-factory@.service
+++ b/src/systemd/webui-wsinstance-https-factory@.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Anaconda Cockpit WS https instance factory
+Documentation=man:cockpit-ws(8)
+
+[Service]
+ExecStart=/usr/libexec/cockpit-wsinstance-factory
+User=root

--- a/test/check-remote-auth
+++ b/test/check-remote-auth
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 from anacondalib import INSTALLER_VM_MEMORY_MB, VirtInstallMachineCase
-from installer import Installer
-from testlib import test_main  # pylint: disable=import-error
+from machine_install import VirtInstallMachine
+from testlib import Error, test_main  # pylint: disable=import-error
 
 
 class TestRemoteAuth(VirtInstallMachineCase):
@@ -15,23 +15,35 @@ class TestRemoteAuth(VirtInstallMachineCase):
             "memory_mb": INSTALLER_VM_MEMORY_MB,
         },
     }
+    machine: VirtInstallMachine
 
     def testBasic(self):
         """
         Description:
             Boot with ``inst.webui.remote inst.webui.remote.password=test1234``
-            and verify that PIN authentication is required.
+            and verify that PIN authentication is required over HTTPS.
 
         Expected results:
-            - The login page is shown
+            - Plain HTTP on port 80 is not reachable
+            - The login page is shown over HTTPS
             - Wrong PIN is rejected with an error
             - Correct PIN grants access to the installer
         """
         b = self.browser
         m = self.machine
-        _i = Installer(b, m)
+        webui_path = "/cockpit/@localhost/anaconda-webui/index.html"
 
-        b.open("/cockpit/@localhost/anaconda-webui/index.html")
+        # HTTP should not be reachable — cockpit-ws is bound to localhost
+        # TODO: better to redirect from http to https
+        for url_path in [webui_path, "/"]:
+            with self.assertRaises(Error) as err:
+                b.open(url_path)
+            self.assertIn("net::ERR_", str(err.exception))
+        # Switch to HTTPS port
+        b.port = m.web_port_https
+        # Opening at "/" should work (using webui_path should work too, but that's given)
+        b.open("/", tls=True)
+
 
         # Login page should be visible
         b.wait_visible("#pin-input")
@@ -39,14 +51,14 @@ class TestRemoteAuth(VirtInstallMachineCase):
         # Wrong password should be rejected
         b.set_input_text("#pin-input", "wrongpin")
         b.click("button[type=submit]")
-        b.wait_in_text(".pf-v6-c-alert", "Invalid PIN")
+        b.wait_in_text(".pf-v6-c-helper-text__item.pf-m-error", "Invalid PIN")
 
         # Correct password should grant access
         b.set_input_text("#pin-input", "test1234")
         b.click("button[type=submit]")
 
         # After login redirect, the installer loads at the root path
-        b.wait_js_cond('window.location.pathname === "/cockpit/@localhost/anaconda-webui/index.html"')
+        b.wait_js_cond(f'window.location.pathname === "{webui_path}"')
 
 
 if __name__ == "__main__":

--- a/test/machine_install.py
+++ b/test/machine_install.py
@@ -39,6 +39,7 @@ INSTALLER_VM_MEMORY_MB = 4096
 class VirtInstallMachine(VirtMachine):
     http_install_server = None
     http_install_port = None
+    web_port_https: int | str
 
     def __init__(self, image, **kwargs):
         # From test ``provision`` / ``new_machine``; must not reach Machine.__init__.
@@ -50,6 +51,7 @@ class VirtInstallMachine(VirtMachine):
         # test/run (CI), local test/check-*, and GlobalMachine.reset() which omits memory_mb.
         kwargs["memory_mb"] = max(kwargs.get("memory_mb") or 0, INSTALLER_VM_MEMORY_MB)
         super().__init__(image, **kwargs)
+        self.web_port_https = self._get_free_port(start_port=int(self.web_port) + 1)
 
     def _attach_libvirt_domain(self, timeout_sec=120):
         conn = self.virt_connection
@@ -217,7 +219,8 @@ class VirtInstallMachine(VirtMachine):
                 f"--qemu-commandline="
                 "'-netdev user,id=hostnet0,"
                 f"hostfwd=tcp:{self.ssh_address}:{self.ssh_port}-:22,"
-                f"hostfwd=tcp:{self.web_address}:{self.web_port}-:80 "
+                f"hostfwd=tcp:{self.web_address}:{self.web_port}-:80,"
+                f"hostfwd=tcp:{self.web_address}:{self.web_port_https}-:443 "
                 "-device virtio-net-pci,netdev=hostnet0,id=net0,addr=0x16' "
                 f"--extra-args '{extra_args}' "
                 f"{extra_boot_args_option}"

--- a/test/webui_testvm.py
+++ b/test/webui_testvm.py
@@ -45,6 +45,10 @@ def cmd_cli():
             print(
                 f"http://{machine.web_address}:{machine.web_port}/cockpit/@localhost/anaconda-webui/index.html"
             )
+            print("...or try https if a remote_pin was provided")
+            print(
+                f"https://{machine.web_address}:{machine.web_port_https}/cockpit/@localhost/anaconda-webui/index.html"
+            )
 
             # rsync development files over so /usr/local/share/cockpit is created with a development version
             if args.rsync:

--- a/webui-desktop
+++ b/webui-desktop
@@ -67,10 +67,20 @@ else
     rm -f "$REMOTE_AUTH_DROPIN"
 fi
 
-echo "WEBUI_ADDRESS=$WEBUI_ADDRESS" > /tmp/webui-cockpit-ws.env
-echo "WEBUI_AUTH=$WEBUI_AUTH" >> /tmp/webui-cockpit-ws.env
-
-systemctl start webui-cockpit-ws
+if [[ "$WEBUI_AUTH" == "1" ]]; then
+    # Remote with PIN auth: use cockpit-tls for TLS termination.
+    # The factory binary creates cockpit-wsinstance-https@ instances
+    # (hardcoded name). Override stock units with our versions that
+    # remove BindsTo=cockpit.service and DynamicUser sandboxing.
+    ln -sf /usr/share/anaconda/systemd/cockpit-wsinstance-https@.socket /run/systemd/system/
+    ln -sf /usr/share/anaconda/systemd/cockpit-wsinstance-https@.service /run/systemd/system/
+    systemctl daemon-reload
+    systemctl start webui-cockpit-tls.socket
+else
+    echo "WEBUI_ADDRESS=$WEBUI_ADDRESS" > /tmp/webui-cockpit-ws.env
+    echo "WEBUI_AUTH=$WEBUI_AUTH" >> /tmp/webui-cockpit-ws.env
+    systemctl start webui-cockpit-ws
+fi
 
 # Function to setup user-related environment
 setup_user_environment() {


### PR DESCRIPTION
This PR demonstrates a horrendous hack. Do not merge it, I'm only opening to be compared against #1413.

Enable TLS termination via cockpit-tls when WEBUI_AUTH=1 (remote
installation with PIN authentication). The plain HTTP path via
webui-cockpit-ws remains unchanged for local installation (WEBUI_AUTH=0).

New custom systemd units:
- webui-cockpit-tls.socket: listens on port 443
- webui-cockpit-tls.service: runs cockpit-tls with auto-generated
  self-signed certs (cockpit-certificate-ensure) and merged cockpit
  config (anaconda-cockpit-conf-merge)
- webui-wsinstance-https-factory.socket: factory socket bound to our
  TLS service instead of the stock cockpit.service
- webui-wsinstance-https-factory@.service: runs cockpit-wsinstance-factory
  as root (no DynamicUser sandboxing needed in the installer)

Override units for stock cockpit:
- cockpit-wsinstance-https@.socket: removes BindsTo=cockpit.service
- cockpit-wsinstance-https@.service: removes DynamicUser=yes sandboxing,
  sets XDG_CONFIG_DIRS=/run/anaconda for anaconda cockpit config

At runtime, webui-desktop symlinks the override units into
/run/systemd/system/ because cockpit-wsinstance-factory is a compiled
binary with the unit name cockpit-wsinstance-https@<fingerprint>
hardcoded — we cannot change what it instantiates.

Known limitations:
- Requires 4 custom units + 2 override units + runtime symlinks
- Stock cockpit-wsinstance-https@.service uses DynamicUser=yes +
  ProtectSystem=strict which prevents cockpit-pin-auth from reading
  /run/anaconda/remote-pin (PermissionError) — hence the overrides