### PR TITLE
Navigate by installation status, not browser URL; skip redundant client init

### DIFF
--- a/src/apis/boss.js
+++ b/src/apis/boss.js
@@ -11,6 +11,9 @@ import { error } from "../helpers/log.js";
 import { _callClient, _getProperty } from "./helpers.js";
 
 import { moduleClients } from "./index.js";
+import { LocalizationClient } from "./localization.js";
+import { NetworkClient } from "./network.js";
+import { RuntimeClient } from "./runtime.js";
 
 const OBJECT_PATH = "/org/fedoraproject/Anaconda/Boss";
 const INTERFACE_NAME = "org.fedoraproject.Anaconda.Boss";
@@ -44,13 +47,16 @@ export class BossClient {
         this.dispatch = dispatch;
     }
 
-    init (args = {}) {
+    async init (args = {}) {
         this.client.addEventListener("close", () => error("Boss client closed"));
 
+        const status = await getInstallationStatus();
+        const installationStarted = status !== INSTALLATION_STATUS.NOT_STARTED;
+        const clients = installationStarted ? [RuntimeClient, NetworkClient, LocalizationClient] : moduleClients;
         return Promise.all([
             this.dispatch(getInstallationStatusAction()),
             this.dispatch(getPendingErrorAction()),
-            ...moduleClients.map(Client => new Client(this.address, this.dispatch).init(args))
+            ...clients.map(Client => new Client(this.address, this.dispatch).init(args))
         ]).then(() => {
             this.startEventMonitor();
         });

--- a/src/apis/boss.js
+++ b/src/apis/boss.js
@@ -61,13 +61,17 @@ export class BossClient {
             { },
             (path, iface, signal, args) => {
                 if (signal === "PropertiesChanged" &&
-                    args[0] === INTERFACE_NAME &&
-                    Object.hasOwn(args[1], "ActiveInstallationTask") &&
-                    args[1].ActiveInstallationTask.v) {
-                    for (const Client of moduleClients) {
-                        Client.instance?.stopEventMonitor();
+                    args[0] === INTERFACE_NAME) {
+                    if (Object.hasOwn(args[1], "InstallationStatus")) {
+                        this.dispatch(getInstallationStatusAction());
                     }
-                    this.stopEventMonitor();
+                    if (Object.hasOwn(args[1], "ActiveInstallationTask") &&
+                        args[1].ActiveInstallationTask.v) {
+                        for (const Client of moduleClients) {
+                            Client.instance?.stopEventMonitor();
+                        }
+                        this.stopEventMonitor();
+                    }
                 }
             }
         );

--- a/src/components/AnacondaWizard.jsx
+++ b/src/components/AnacondaWizard.jsx
@@ -4,15 +4,13 @@
  */
 import cockpit from "cockpit";
 
-import { usePageLocation } from "hooks";
-
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { PageSection, PageSectionTypes } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Wizard, WizardStep } from "@patternfly/react-core/dist/esm/components/Wizard/index.js";
 
-import { getActiveInstallationTask } from "../apis/boss.js";
+import { INSTALLATION_STATUS } from "../apis/boss.js";
 
-import { PageContext, PayloadContext, StorageContext, SystemTypeContext, UserInterfaceContext } from "../contexts/Common.jsx";
+import { BossContext, PageContext, PayloadContext, StorageContext, SystemTypeContext, UserInterfaceContext } from "../contexts/Common.jsx";
 
 import { AnacondaPage } from "./AnacondaPage.jsx";
 import { AnacondaWizardFooter } from "./AnacondaWizardFooter.jsx";
@@ -33,14 +31,23 @@ export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFe
     const isBootIso = useContext(SystemTypeContext).systemType === "BOOT_ISO";
     const payloadType = useContext(PayloadContext).type;
     const userInterfaceConfig = useContext(UserInterfaceContext);
-    const { path } = usePageLocation();
+    const { installationStatus } = useContext(BossContext);
 
     const autoProceedBlockedRef = useRef(false);
+
+    const stepsOrder = getSteps(automatedInstall, userInterfaceConfig, { isBootIso, payloadType, storageScenarioId });
+    const firstStepId = stepsOrder.find(s => s.isFirstScreen)?.id;
+    const finalStepId = stepsOrder[stepsOrder.length - 1]?.id;
+
+    const goToProgressPage = useCallback(() => {
+        setCurrentStepId(finalStepId);
+    }, [finalStepId, setCurrentStepId]);
 
     const componentProps = {
         autoProceedBlockedRef,
         automatedInstall,
         dispatch,
+        goToProgressPage,
         onCritFail,
         pauseAtSummary,
         setShowStorage,
@@ -55,28 +62,28 @@ export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFe
         stepNotification,
     };
 
-    const stepsOrder = getSteps(automatedInstall, userInterfaceConfig, { isBootIso, payloadType, storageScenarioId });
-    const firstStepId = stepsOrder.find(s => s.isFirstScreen)?.id;
-
     useEffect(() => {
-        if (path[0] && path[0] !== currentStepId) {
-            // If path is set respect it
-            setCurrentStepId(path[0]);
-        } else if (!currentStepId) {
-            // Otherwise set the first step as the current step
+        if (installationStatus === null) {
+            return;
+        }
+
+        if (installationStatus !== INSTALLATION_STATUS.NOT_STARTED) {
+            if (currentStepId !== finalStepId) {
+                setCurrentStepId(finalStepId);
+            }
+            return;
+        }
+
+        if (!currentStepId) {
             setCurrentStepId(firstStepId);
         }
-    }, [currentStepId, firstStepId, path, setCurrentStepId]);
+    }, [currentStepId, finalStepId, firstStepId, installationStatus, setCurrentStepId]);
 
-    const finalStepId = stepsOrder[stepsOrder.length - 1]?.id;
     useEffect(() => {
-        getActiveInstallationTask()
-                .then(activeTask => {
-                    if (activeTask) {
-                        cockpit.location.go([finalStepId]);
-                    }
-                });
-    }, [finalStepId]);
+        if (currentStepId) {
+            cockpit.location.go([currentStepId]);
+        }
+    }, [currentStepId]);
 
     const createSteps = (stepsOrder, componentProps) => {
         return stepsOrder.map(s => {
@@ -129,11 +136,11 @@ export const AnacondaWizard = ({ automatedInstall, currentStepId, dispatch, isFe
             setStepNotification(null);
         }
 
-        cockpit.location.go([newStep.id]);
+        setCurrentStepId(newStep.id);
     };
 
     const finalStep = stepsOrder[stepsOrder.length - 1];
-    if (path[0] === finalStep.id) {
+    if (currentStepId === finalStep.id) {
         return (
             <PageSection hasBodyWrapper={false} type={PageSectionTypes.wizard}>
                 <finalStep.component {...componentProps} />

--- a/src/components/review/ReviewConfiguration.jsx
+++ b/src/components/review/ReviewConfiguration.jsx
@@ -76,7 +76,7 @@ const ReviewDescriptionList = ({ children }) => {
     );
 };
 
-export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, pauseAtSummary }) => {
+export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, goToProgressPage, pauseAtSummary }) => {
     const osRelease = useContext(OsReleaseContext);
     const userInterfaceConfig = useContext(UserInterfaceContext);
     const hiddenScreens = userInterfaceConfig.hidden_webui_pages || [];
@@ -113,7 +113,6 @@ export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, p
         if (!firstIncompleteStepId) {
             return;
         }
-        cockpit.location.go([firstIncompleteStepId]);
         goToStepById(firstIncompleteStepId);
     };
 
@@ -131,17 +130,17 @@ export const ReviewConfiguration = ({ autoProceedBlockedRef, automatedInstall, p
             return;
         }
         if (allValidatedReviewPagesComplete) {
-            cockpit.location.go(["anaconda-screen-progress"]);
+            goToProgressPage();
         } else {
             autoProceedBlockedRef.current = true;
         }
-    }, [automatedInstall, pauseAtSummary, allValidatedReviewPagesComplete, storageValidationPending,
+    }, [automatedInstall, goToProgressPage, pauseAtSummary, allValidatedReviewPagesComplete, storageValidationPending,
         autoProceedBlockedRef, reviewValidationPending]);
 
     // Display custom footer
     const getFooter = useMemo(() => (
-        <CustomFooter pageValidationOk={allValidatedReviewPagesComplete && !reviewValidationPending} />
-    ), [allValidatedReviewPagesComplete, reviewValidationPending]);
+        <CustomFooter goToProgressPage={goToProgressPage} pageValidationOk={allValidatedReviewPagesComplete && !reviewValidationPending} />
+    ), [allValidatedReviewPagesComplete, goToProgressPage, reviewValidationPending]);
     useWizardFooter(getFooter);
 
     const languageDescription = localizationComplete
@@ -327,7 +326,7 @@ const useConfirmationCheckboxLabel = () => {
     return scenarioConfirmationLabel;
 };
 
-const CustomFooter = ({ pageValidationOk }) => {
+const CustomFooter = ({ goToProgressPage, pageValidationOk }) => {
     const { setIsFormValid } = useContext(PageContext) ?? {};
     const { getButtonLabel } = useScenario();
     const buttonLabel = getButtonLabel?.();
@@ -355,7 +354,7 @@ const CustomFooter = ({ pageValidationOk }) => {
           footerHelperText={confirmationCheckbox}
           nextButtonText={buttonLabel}
           nextButtonVariant={!installationIsClean ? "warning" : "primary"}
-          onNext={() => cockpit.location.go(["anaconda-screen-progress"])}
+          onNext={() => goToProgressPage()}
         />
     );
 };

--- a/test/check-progress
+++ b/test/check-progress
@@ -49,6 +49,11 @@ class TestInstallationProgress(VirtInstallMachineCase):
         b.wait_in_text("h2", "Successfully installed")
         b.wait_in_text(".pf-v6-c-empty-state", f"To begin using {get_pretty_name(m)}, reboot your system")
 
+        # Reload the page on success to make sure reconnect also works here
+        b.reload()
+        b.wait_in_text("h2", "Successfully installed")
+        b.wait_in_text(".pf-v6-c-empty-state", f"To begin using {get_pretty_name(m)}, reboot your system")
+
         # Pixel test the complete progress step
         b.assert_pixels(
             "#app",


### PR DESCRIPTION
Revised version of: https://github.com/rhinstaller/anaconda-webui/pull/1412 