### PR TITLE
test-compose: fix failure detection for updated tests-status output

### DIFF
--- a/.github/workflows/test-compose.yml
+++ b/.github/workflows/test-compose.yml
@@ -49,8 +49,6 @@ jobs:
 
           bots/tests-status - --wait 2>&1 | tee tests-status.log
 
-          if grep -q '^  not ok ' tests-status.log; then
-            echo "Failed test cases:"
-            grep '^  not ok ' tests-status.log
+          if grep -q '^Failed tests' tests-status.log; then
             exit 1
           fi


### PR DESCRIPTION
The tests-status script outputs a "Failed tests" header when tests fail.

See https://github.com/rhinstaller/anaconda-webui/actions/runs/32323987922/job/96291428038