### PR TITLE
storage: only fetch free/total space for disk devices (gh1715)

### DIFF
--- a/src/actions/storage-actions.js
+++ b/src/actions/storage-actions.js
@@ -42,12 +42,17 @@ export const getDevicesAction = () => {
             try {
                 const devData = await getDeviceData({ disk: device });
 
-                const free = await getDiskFreeSpace({ diskNames: [device] });
-                // extend it with variants to keep the format consistent
-                devData.free = cockpit.variant(String, free);
+                if (devData["is-disk"].v) {
+                    const free = await getDiskFreeSpace({ diskNames: [device] });
+                    // extend it with variants to keep the format consistent
+                    devData.free = cockpit.variant(String, free);
 
-                const total = await getDiskTotalSpace({ diskNames: [device] });
-                devData.total = cockpit.variant(String, total);
+                    const total = await getDiskTotalSpace({ diskNames: [device] });
+                    devData.total = cockpit.variant(String, total);
+                } else {
+                    devData.free = cockpit.variant(String, 0);
+                    devData.total = cockpit.variant(String, devData.size.v);
+                }
 
                 const formatData = await getFormatData({ diskName: device });
                 devData.formatData = formatData;


### PR DESCRIPTION
GetDiskFreeSpace and GetDiskTotalSpace are only valid for disk devices. Calling them for LUKS or other non-disk devices causes an UnknownDeviceError traceback in anaconda, which kstest detects as a test failure.

Guard the calls with devData["is-disk"].v to skip non-disk devices.