### PR TITLE
network: remove Configure Network item from kebab menu

### DIFF
--- a/src/components/HeaderKebab.jsx
+++ b/src/components/HeaderKebab.jsx
@@ -20,7 +20,6 @@ import { convertToExtlinkIfNeeded } from "../helpers/extlink.js";
 import { AppVersionContext, OsReleaseContext, SystemTypeContext } from "../contexts/Common.jsx";
 
 import { UserIssue } from "./Error.jsx";
-import { CockpitNetworkConfiguration } from "./network/CockpitNetworkConfiguration.jsx";
 import { CockpitStorageIntegration } from "./storage/cockpit-storage-integration/CockpitStorageIntegration.jsx";
 
 import "./HeaderKebab.scss";
@@ -86,9 +85,6 @@ export const HeaderKebab = ({ dispatch, isConnected, onCritFail, reportLinkURL, 
     const [isOpen, setIsOpen] = useState(false);
     const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
     const [isReportIssueOpen, setIsReportIssueOpen] = useState(false);
-    const [isNetworkOpen, setIsNetworkOpen] = useState(false);
-    const isBootIso = useContext(SystemTypeContext).systemType === "BOOT_ISO";
-
     const onToggle = () => {
         setIsOpen(!isOpen);
     };
@@ -104,19 +100,7 @@ export const HeaderKebab = ({ dispatch, isConnected, onCritFail, reportLinkURL, 
         setIsReportIssueOpen(true);
     };
 
-    const handleNetwork = () => {
-        setIsNetworkOpen(true);
-    };
-
     const dropdownItems = [
-        ...(isBootIso
-            ? [
-                <DropdownItem id="about-modal-dropdown-item-network" key="network" onClick={handleNetwork}>
-                    {_("Configure network")}
-                </DropdownItem>
-            ]
-            : []
-        ),
         <DropdownItem id="about-modal-dropdown-item-about" key="about" onClick={handleAboutModal}>
             {_("About")}
         </DropdownItem>,
@@ -146,11 +130,6 @@ export const HeaderKebab = ({ dispatch, isConnected, onCritFail, reportLinkURL, 
                     {dropdownItems}
                 </DropdownList>
             </Dropdown>
-            {isNetworkOpen &&
-            <CockpitNetworkConfiguration
-              setIsNetworkOpen={setIsNetworkOpen}
-              onCritFail={onCritFail}
-            />}
             {isAboutModalOpen &&
                 <AnacondaAboutModal
                   isModalOpen={isAboutModalOpen}

--- a/test/check-network
+++ b/test/check-network
@@ -76,60 +76,6 @@ class TestNetworkDestructive(VirtInstallMachineCase):
     # https://github.com/cockpit-project/cockpit/issues/22926 is fixed
     #@run_on_vm_setups("", "bootopts-net1")
     @run_on_vm_setups("bootopts-net1")
-    def testCockpitConfigurationPreInstall(self):
-        """
-        Description:
-            Test configuration of settings of a device.
-
-        Expected results:
-            - Change breaking connection raises expected confirmation dialog
-            - The configured values are correctly applied to connection profile and device.
-        """
-        b = self.browser
-        m = self.machine
-        i = Installer(b, m)
-        n = Network(b, m)
-
-        i.open()
-
-        iface = n.get_the_iface()
-
-        n.disable_ipv4_on_iface(iface)
-
-        # After editing, therefore persisting, the automatic default connection
-        # is updated by Cockpit (COCKPIT-1750)
-        con_name = iface
-
-        mtu_value = "1600"
-        n.set_mtu_on_iface(iface, mtu_value)
-
-        n.check_con_settings([
-            [con_name, "802-3-ethernet.mtu", mtu_value, None],
-        ])
-
-        dns_server = "8.8.8.8"
-        n.add_dns_server_to_iface(iface, dns_server)
-
-        n.check_con_settings([
-            [con_name, "ipv4.dns", dns_server, None],
-        ])
-
-        # Check that the checkpoint does not fail silently, ie check after
-        # checkpoint timeout (INSTALLER-4594)
-        time.sleep(COCKPIT_CHECKPOINT_ROLLBACK_TIME+2)
-
-        n.check_con_settings([
-            [con_name, "802-3-ethernet.mtu", mtu_value, None],
-        ])
-
-        n.check_con_settings([
-            [con_name, "ipv4.dns", dns_server, None],
-        ])
-
-    # FIXME add "" vm_setup back when
-    # https://github.com/cockpit-project/cockpit/issues/22926 is fixed
-    #@run_on_vm_setups("", "bootopts-net1")
-    @run_on_vm_setups("bootopts-net1")
     def testWizardCockpitConfigurationPreInstall(self):
         """
         Description:
@@ -210,7 +156,7 @@ class TestNetwork(VirtInstallMachineCase):
         n = Network(b, m)
 
         i.open()
-        i.reach(i.steps.INSTALLATION_METHOD)
+        i.reach(i.steps.NETWORK)
         n.enter_network()
 
         check_cockpit_module_js_error(b, "Network")

--- a/test/check-network-e2e
+++ b/test/check-network-e2e
@@ -36,12 +36,14 @@ class TestNetwork_E2E(VirtInstallMachineCase):
         con_name = iface
 
         mtu_value = "1600"
-        n.set_mtu_on_iface(iface, mtu_value)
+        i.reach_on_sidebar(i.steps.NETWORK)
+        n.set_mtu_on_iface_wizard(iface, mtu_value)
 
         n.check_con_settings([
             [con_name, "802-3-ethernet.mtu", mtu_value, None],
         ])
 
+        i.reach(i.steps.REVIEW)
         i.begin_installation(needs_confirmation=False)
         p = Progress(b)
         p.wait_done()

--- a/test/check-review
+++ b/test/check-review
@@ -5,7 +5,6 @@
 
 from anacondalib import VirtInstallMachineCase, pixel_tests_ignore
 from installer import Installer
-from network import Network
 from password import Password
 from review import Review
 from storage import BOOT_PARTITION_DEFAULT_SIZE_GB, Storage
@@ -27,7 +26,6 @@ class TestReview(VirtInstallMachineCase):
             - The review step shows the correct information after setting encryption
             - The hostname is shown for Live ISO
             - The timezone is not shown for Live ISO
-            - The UI elements for accessing network configuration are not present
         """
 
         b = self.browser
@@ -36,16 +34,11 @@ class TestReview(VirtInstallMachineCase):
         s = Storage(b, m)
         p = Password(b, s.encryption_id_prefix)
         r = Review(b, m)
-        n = Network(b, m)
-
         pretend_live_workstation_iso(self, i, m)
         i.open()
         # After clicking 'Next' on the storage step, partitioning is done, thus changing the available space on the disk
         # Since this is a non-destructive test we need to make sure the we reset partitioning to how it was before the test started
         i.reach(i.steps.REVIEW)
-
-        # check network configuration is not accessible on Live ISO
-        n.check_no_network_ui()
 
         # check language is shown
         r.check_language("English (United States)")

--- a/test/helpers/network.py
+++ b/test/helpers/network.py
@@ -132,30 +132,13 @@ class Network():
             n_files_found = len(files_found)
         assert n_files_found == count
 
-    def configure_network(self):
-        b = self.browser
-        b.click("#toggle-kebab")
-        b.click("#about-modal-dropdown-item-network")
-
-    def check_no_network_ui(self):
-        b = self.browser
-        b.click("#toggle-kebab")
-        # Wait for the dropdown menu to be visible before checking for the specific item
-        b.wait_visible("#toggle-kebab[aria-expanded='true'], .pf-c-dropdown__menu")
-        b.wait_not_present("#about-modal-dropdown-item-network")
-        b.click("#toggle-kebab")
-
     def enter_network(self):
         b = self.browser
-        self.configure_network()
-        self._switch_to_frame("cockpit-network")
+        self._switch_to_frame()
         b.wait_visible("#networking-interfaces")
 
     def exit_network(self):
-        b = self.browser
-        b.switch_to_top()
-        b.click("#cockpit-network-configuration-modal button:contains('Close')")
-        b.wait_not_present("#cockpit-network-configuration-modal")
+        self.browser.switch_to_top()
 
     def select_iface(self, iface):
         b = self.browser
@@ -197,6 +180,7 @@ class Network():
             [con_name, "connection.autoconnect", "yes", None]
         ])
 
+        i.reach(i.steps.NETWORK)
         n.enter_network()
         n.select_iface(iface)
         # Edit the connection
@@ -220,6 +204,7 @@ class Network():
 
         i.reach(i.steps.REVIEW)
 
+        i.reach_on_sidebar(i.steps.NETWORK)
         n.enter_network()
         n.select_iface(iface)
         n.set_autoreconnect(True)
@@ -228,6 +213,8 @@ class Network():
             [con_name, "connection.autoconnect", "yes", None]
         ])
 
+        i.reach(i.steps.REVIEW)
+
     def configure_iface_setting(self, setting_title):
         shim = SimpleNamespace(browser=self.browser)
         NetworkCase.configure_iface_setting(shim, setting_title)
@@ -235,14 +222,6 @@ class Network():
     def wait_for_iface_setting(self, setting_title, setting_value):
         shim = SimpleNamespace(browser=self.browser)
         NetworkCase.wait_for_iface_setting(shim, setting_title, setting_value)
-
-    def set_mtu_on_iface(self, iface, mtu):
-        n = self
-        n.enter_network()
-        n.select_iface(iface)
-        n.set_mtu(mtu)
-        n.wait_for_iface_setting("MTU", mtu)
-        n.exit_network()
 
     def set_mtu_on_iface_wizard(self, iface, mtu):
         self._switch_to_frame()
@@ -269,13 +248,6 @@ class Network():
     def toggle_onoff(self, sel: str) -> None:
         self.browser.click(sel + " input[type=checkbox]")
 
-    def add_dns_server_to_iface(self, iface, ip):
-        n = self
-        n.enter_network()
-        n.select_iface(iface)
-        n.add_dns_server(ip)
-        n.exit_network()
-
     def add_dns_server_to_iface_wizard(self, iface, ip):
         self._switch_to_frame()
         self.select_iface(iface)
@@ -300,14 +272,6 @@ class Network():
         with b.wait_timeout(60):
             b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
         b.wait_not_present("#confirm-breaking-change-popup")
-
-    def disable_ipv4_on_iface(self, iface):
-        n = self
-        n.enter_network()
-        n.select_iface(iface)
-        self.disable_ipv4()
-        n.keep_connection()
-        n.exit_network()
 
     def _switch_to_frame(self, name="network-configuration"):
         b = self.browser


### PR DESCRIPTION
Network configuration is now accessible only via the dedicated wizard network screen.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Resolves: INSTALLER-4868