### PR TITLE
DEBUG: fix: remove XLayouts reset workaround from setXKeyboardDefaults

### DIFF
--- a/src/apis/localization.js
+++ b/src/apis/localization.js
@@ -231,10 +231,6 @@ const applyKickstartLanguage = (language) => {
     setLocale({ locale: language });
 };
 
-export const setXKeyboardDefaults = async () => {
-    // FIXME: Reset XLayouts before calling SetXKeyboardDefaults. Without this reset, the
-    // backend would see existing layouts and think they came from
-    // kickstart, preventing new defaults from being applied.
-    await setXLayouts({ layouts: [] });
-    await callClient("SetXKeyboardDefaults");
+export const setXKeyboardDefaults = () => {
+    return callClient("SetXKeyboardDefaults");
 };


### PR DESCRIPTION
The frontend previously cleared XLayouts to [] before calling SetXKeyboardDefaults to work around the backend inferring kickstart layouts from existing layouts. This temporary empty state caused a race condition: concurrent GetKeyboardConfigurationWithTask calls would see empty layouts and return an empty VConsole keymap, flashing the error "No valid VConsole keymap can be obtained for the selected keyboard layout(s)".

The backend now uses the keyboard_seen flag to detect kickstart layouts, so the clear workaround is no longer needed.