### PR TITLE
fix: preserve installation progress step across page reloads

### DIFF
--- a/src/components/installation/InstallationProgress.jsx
+++ b/src/components/installation/InstallationProgress.jsx
@@ -94,15 +94,17 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
                         context: cockpit.format(N_("Installation of the system failed: $0"), refStatusMessage.current),
                     }));
                 });
-                categoryProxy.addEventListener("CategoryChanged", (_, category) => {
-                    debug("CategoryChanged:", category);
-                    const step = progressStepsMap[category];
-                    setCurrentProgressStep(current => {
-                        if (step !== undefined && step >= current) {
-                            return step;
-                        }
-                        return current;
-                    });
+                categoryProxy.addEventListener("changed", (_, data) => {
+                    if ("CurrentCategory" in data) {
+                        debug("CategoryChanged:", data.CurrentCategory);
+                        const step = progressStepsMap[data.CurrentCategory];
+                        setCurrentProgressStep(current => {
+                            if (step !== undefined && step >= current) {
+                                return step;
+                            }
+                            return current;
+                        });
+                    }
                 });
                 categoryProxy.addEventListener("ErrorRaised", (_, message, detailType) => {
                     handleError(message, detailType, categoryProxy);
@@ -113,11 +115,15 @@ export const InstallationProgress = ({ automatedInstall, onCritFail }) => {
                     setCurrentProgressStep(PROGRESS_STEPS_DONE);
                 });
             };
-            taskProxy.wait(() => {
+            Promise.all([taskProxy.wait(), categoryProxy.wait()]).then(() => {
                 addEventListeners();
                 if (shouldStart) {
                     taskProxy.Start().catch(onCritFail(failureCtx));
                 } else {
+                    const step = progressStepsMap[categoryProxy.CurrentCategory];
+                    if (step !== undefined) {
+                        setCurrentProgressStep(step);
+                    }
                     getSteps({ task: taskPath })
                             .then(
                                 ret => setSteps(ret.v),


### PR DESCRIPTION
The progress stepper reset to "Storage configuration" on page reload or when opening the installer in a different browser, because the current category is only pushed through D-Bus signals and can't be queried after the fact.

Persist the current progress step to /run/anaconda/webui-progress-step via cockpit.file() so any connecting browser can restore it.

Assisted-by: Claude Opus 4.6
Resolves: INSTALLER-4872