### PR TITLE
Add option to attach disk to testvm

### DIFF
--- a/test/machine_install.py
+++ b/test/machine_install.py
@@ -8,6 +8,7 @@ import shlex
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 from tempfile import TemporaryDirectory
 
@@ -46,6 +47,7 @@ class VirtInstallMachine(VirtMachine):
         self.pause_at_summary = kwargs.pop("pause_at_summary", False)
         self.payload_type = kwargs.pop("payload_type", "liveimg".lower())
         self.remote_pin = kwargs.pop("remote_pin", "")
+        self.extra_disks = kwargs.pop("extra_disks", [])
         # Always enforce the minimum RAM the installer requires. Covers every entry point the same way:
         # test/run (CI), local test/check-*, and GlobalMachine.reset() which omits memory_mb.
         kwargs["memory_mb"] = max(kwargs.get("memory_mb") or 0, INSTALLER_VM_MEMORY_MB)
@@ -196,7 +198,18 @@ class VirtInstallMachine(VirtMachine):
             else ""
         )
         auth_method = f"inst.webui.remote.pin={self.remote_pin}" if self.remote_pin else "inst.webui.remote.noauth"
+
         try:
+            disk_args = "--disk=none "
+            if self.extra_disks:
+                disk_parts = []
+                for size_gb in self.extra_disks:
+                    fd, path = tempfile.mkstemp(suffix='.qcow2', prefix=f"disk-anaconda-{self.label}-")
+                    os.close(fd)
+                    os.unlink(path)
+                    disk_parts.append(f"--disk path={path},size={size_gb},bus=virtio ")
+                disk_args = "".join(disk_parts)
+
             self._execute(
                 "virt-install "
                 "--wait "
@@ -221,7 +234,7 @@ class VirtInstallMachine(VirtMachine):
                 "-device virtio-net-pci,netdev=hostnet0,id=net0,addr=0x16' "
                 f"--extra-args '{extra_args}' "
                 f"{extra_boot_args_option}"
-                f"--disk=none "
+                f"{disk_args}"
                 f"--location {location} &"
             )
 

--- a/test/webui_testvm.py
+++ b/test/webui_testvm.py
@@ -23,13 +23,23 @@ def cmd_cli():
                         action='store_true', dest="pause_at_summary")
     parser.add_argument("--remote-pin", help="PIN for accessing the webui. Blank value defaults to inst.webui.remote.noauth",
                         dest="remote_pin")
+    def positive_int(value):
+        value = int(value)
+        if value <= 0:
+            raise argparse.ArgumentTypeError("must be a positive integer")
+        return value
+
+    parser.add_argument("--add-disk", help="Attach a virtual disk with the given size in GiB (e.g., --add-disk 15)",
+                        type=positive_int, metavar="SIZE", dest="add_disk")
     args = parser.parse_args()
 
     if args.bios:
         os.environ["TEST_FIRMWARE"] = "bios"
+    extra_disks = [args.add_disk] if args.add_disk is not None else []
     machine = VirtInstallMachine(image=args.image, memory_mb=INSTALLER_VM_MEMORY_MB,
                                  kickstart_file_name=args.kickstart_file_name,
-                                 pause_at_summary=args.pause_at_summary, remote_pin=args.remote_pin)
+                                 pause_at_summary=args.pause_at_summary, remote_pin=args.remote_pin,
+                                 extra_disks=extra_disks)
     try:
         machine.start()
 
@@ -62,7 +72,16 @@ def cmd_cli():
         signal.signal(signal.SIGTERM, lambda _, frame: machine.stop())
         signal.pause()
     except KeyboardInterrupt:
-        machine.stop()
+        pass
+    finally:
+        # Ignore additional Ctrl+C while cleaning up to avoid leaving disks behind.
+        previous_sigint = signal.getsignal(signal.SIGINT)
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        try:
+            machine.stop()
+        finally:
+            # Restore previous SIGINT handler.
+            signal.signal(signal.SIGINT, previous_sigint)
 
 
 # This can be used as helper program for tests not written in Python: Run given


### PR DESCRIPTION
Pass --disk args to virt-install so disks are part of the domain definition from the start. Anaconda discovers them during its initial storage scan. Extra disks are created as temporary qcow2 images and cleaned up when the VM is destroyed.

This feature can be used with --add-disk <size in GiB> while using webui_testvm.py

Example:
`./test/webui_testvm.py fedora-rawhide-boot --add-disk 15`

This change is useful for testing purposes

This is not part of any ticket