### PR TITLE
fix: return after onFail for bootloader on MDRAID detection

### DIFF
--- a/src/components/storage/cockpit-storage-integration/CheckStorageDialog.jsx
+++ b/src/components/storage/cockpit-storage-integration/CheckStorageDialog.jsx
@@ -274,6 +274,7 @@ const handleMDRAID = ({ devices, onFail, refDevices, setNextCheckStep }) => {
                     devices[bootloaderDriveMDRAID].name.v
                 )
             });
+            return;
         }
     }
 


### PR DESCRIPTION
Without the return, handleMDRAID continued to setNewSelectedDisks() which called setNextCheckStep(), overriding the failed state and letting the pipeline proceed to backend validation. The backend error then replaced the MDRAID-specific error message.